### PR TITLE
docs: properties for invariant testing

### DIFF
--- a/packages/contracts-bedrock/test/invariants/echidna/superc20/PROPERTIES.md
+++ b/packages/contracts-bedrock/test/invariants/echidna/superc20/PROPERTIES.md
@@ -1,0 +1,41 @@
+supERC20 properties
+===================
+
+Valid state
+-----------
+
+| id    | description                                                           | halmos | echidna |
+| ----- | -----                                                                 | -----  | -----   |
+|   0   | calls to sendERC20 succeed as long as caller has enough balance       |        |         |
+
+Variable transition
+-------------------
+
+| id    | description                                                           | halmos | echidna |
+| ----- | -----                                                                 | -----  | -----   |
+|   1   | sendERC20 decreases the token's totalSupply in the source chain       |        |         |
+|   2   | relayERC20 increases the token's totalSupply in the destination chain |        |         |
+|   3   | only calls to `convert()` can increase the total supply across chains |        |         |
+
+High level
+----------
+
+| id    | description                                                                                                  | halmos | echidna |
+| ----- | -----                                                                                                        | -----  | -----   |
+|   4   | sum of total supply across all chains is always `<=` to `convert()`ed amount                                 |        |         |
+|   5   | tokens `sendERC20`-ed to a chain can be `relayERC20`-ed as long as the source chain is in the dependency set |        |         |
+
+Unit test
+---------
+
+| id    | description                                                                | halmos | echidna |
+| ----- | -----                                                                      | -----  | -----   |
+|   6   | supERC20 token address does not depend on chainID                          |        |         |
+|   7   | supERC20 token address depends on name, remote token, address and decimals |        |         |
+
+Expected external interactions
+==============================
+- regular ERC20 transfers between any accounts on the same chain
+
+
+

--- a/packages/contracts-bedrock/test/invariants/echidna/superc20/SUMMARY.md
+++ b/packages/contracts-bedrock/test/invariants/echidna/superc20/SUMMARY.md
@@ -1,0 +1,24 @@
+supERC20 advanced testing campaign
+==================================
+
+Contracts in scope
+------------------
+- [ ] [OptimismSuperchainERC20](src/L2/OptimismSuperchainERC20.sol)
+- [ ] [OptimismMintableERC20](src/universal/OptimismMintableERC20.sol)
+- [ ] SuperchainERC20 (not yet implemented)
+- [ ] SuperchainERC20Factory (not yet implemented, in PR #8)
+- [ ] L2StandardBridgeInterop (not yet implemented, in PR #10)
+
+Behavior assumed correct
+-------------------------
+- [ ] inclusion of relay transactions
+- [ ] sequencer implementation
+- [ ] [L2ToL2CrossDomainMessenger](src/L2/L2CrossDomainMessenger.sol)
+- [ ] [CrossL2Inbox](src/L2/CrossL2Inbox.sol)
+
+
+Pain points
+-----------
+- extensive use of transient storage by `L2ToL2CrossDomainMessenger` combined with lack of support for it in `hevm`
+- a given supertoken should be guaranteed to have the same address across all chains, however we won't be able to replicate that in the fuzzing campaign since they have to all run in the same EVM
+


### PR DESCRIPTION
I'm not quite sure how to go about specifying the invariants for supERC20, since:

- the ethereum-optimism/optimism repo in packages/contracts-bedrock already has invariant tests, but written in foundry
- invariants are programatically generated from the @custom:invariant tags in code, and we're gonna write invariant defs before their test code

any feedback is welcome :sparkles: