### PR TITLE
feat: add crosschain properties

### DIFF
--- a/packages/contracts-bedrock/test/properties/halmos/MockL2ToL2Messenger.sol
+++ b/packages/contracts-bedrock/test/properties/halmos/MockL2ToL2Messenger.sol
@@ -1,25 +1,65 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+import "src/L2/L2ToL2CrossDomainMessenger.sol";
+import { SafeCall } from "src/libraries/SafeCall.sol";
 
 // TODO: Try to merge to a single mocked contract used by fuzzing and symbolic invariant tests - only if possible
-// and low priorty
-contract MockL2ToL2Messenger {
-    // Setting the current cross domain sender for the check of sender address equals the supertoken address
-    address internal immutable CROSS_DOMAIN_SENDER;
+// and is a low priorty
+contract MockL2ToL2Messenger is IL2ToL2CrossDomainMessenger {
+    /// NOTE: Setting everything as immutable bc the storage layour is ignored when etching.
+    address internal immutable SOURCE_TOKEN;
+    address internal immutable DESTINATION_TOKEN;
+    uint256 public immutable DESTINATION_CHAIN_ID;
+    // Custom cross domain sender to be used when neither the source nor destination token are the callers
+    address internal immutable CUSTOM_CROSS_DOMAIN_SENDER;
 
-    constructor(address _xDomainSender) {
-        CROSS_DOMAIN_SENDER = _xDomainSender;
+    constructor(
+        address _sourceToken,
+        address _destinationToken,
+        uint256 _destinationChainId,
+        address _customCrossDomainSender
+    ) {
+        SOURCE_TOKEN = _sourceToken;
+        DESTINATION_TOKEN = _destinationToken;
+        DESTINATION_CHAIN_ID = _destinationChainId;
+        CUSTOM_CROSS_DOMAIN_SENDER = _customCrossDomainSender;
     }
 
-    function sendMessage(uint256 , address , bytes calldata) external payable {
+    function sendMessage(uint256 _destination, address, bytes calldata _message) external payable {
+        // Mocking the environment to allow atomicity by executing the message call
+        if (_destination == DESTINATION_CHAIN_ID) {
+            (bool _success) = SafeCall.call(DESTINATION_TOKEN, 0, _message);
+            if (!_success) revert("MockL2ToL2Messenger: sendMessage failed");
+        }
+    }
+
+    function relayMessage(
+        uint256,
+        uint256,
+        uint256,
+        address,
+        address _target,
+        bytes calldata _message
+    )
+        external
+        payable
+    {
+        (bool succ, bytes memory ret) = _target.call{ value: msg.value }(_message);
+        if (!succ) revert(string(ret));
+
+        // TODO: Add more logic? Like replacing the (unsupported) `TSTORE` updates with `SSTORE` - or add the checks
     }
 
     function crossDomainMessageSource() external view returns (uint256 _source) {
         _source = block.chainid + 1;
     }
 
+    // Mock this function so it just always returns the expected if called by the supertoken, or otherwise defaults to
+    // the custom cross domain sender
     function crossDomainMessageSender() external view returns (address _sender) {
-        _sender = CROSS_DOMAIN_SENDER;
+        if (msg.sender == SOURCE_TOKEN) _sender = SOURCE_TOKEN;
+        else if (msg.sender == DESTINATION_TOKEN) _sender = DESTINATION_TOKEN;
+        else _sender = CUSTOM_CROSS_DOMAIN_SENDER;
     }
 }

--- a/packages/contracts-bedrock/test/properties/halmos/OptimismSuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/properties/halmos/OptimismSuperchainERC20.t.sol
@@ -12,12 +12,23 @@ contract SymTest_OptimismSuperchainERC20 is SymTest, HalmosBase {
     MockL2ToL2Messenger internal constant MESSENGER = MockL2ToL2Messenger(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
 
     OptimismSuperchainERC20 public superchainERC20Impl;
-    OptimismSuperchainERC20 internal optimismSuperchainERC20;
+    OptimismSuperchainERC20 internal sourceToken;
+    OptimismSuperchainERC20 internal destToken;
 
     function setUp() public {
         // Deploy the OptimismSuperchainERC20 contract implementation and the proxy to be used
         superchainERC20Impl = new OptimismSuperchainERC20();
-        optimismSuperchainERC20 = OptimismSuperchainERC20(
+        sourceToken = OptimismSuperchainERC20(
+            address(
+                // TODO: Update to beacon proxy
+                new ERC1967Proxy(
+                    address(superchainERC20Impl),
+                    abi.encodeCall(OptimismSuperchainERC20.initialize, (remoteToken, name, symbol, decimals))
+                )
+            )
+        );
+
+        destToken = OptimismSuperchainERC20(
             address(
                 // TODO: Update to beacon proxy
                 new ERC1967Proxy(
@@ -29,19 +40,34 @@ contract SymTest_OptimismSuperchainERC20 is SymTest, HalmosBase {
 
         // Etch the mocked L2 to L2 Messenger since the messenger logic is out of scope for these test suite. Also, we
         // avoid issues such as `TSTORE` opcode not being supported, or issues with `encodeVersionedNonce()`
-        address _mockL2ToL2CrossDomainMessenger = address(new MockL2ToL2Messenger(address(optimismSuperchainERC20)));
+        address _mockL2ToL2CrossDomainMessenger =
+            address(new MockL2ToL2Messenger(address(sourceToken), address(destToken), DESTINATION_CHAIN_ID, address(0)));
         vm.etch(address(MESSENGER), _mockL2ToL2CrossDomainMessenger.code);
         // NOTE: We need to set the crossDomainMessageSender as an immutable or otherwise storage vars and not taken
         // into account when etching on halmos. Setting a constant slot with setters and getters didn't work neither.
     }
 
     /// @notice Check setup works as expected
-    function check_setup() public view {
-        assert(optimismSuperchainERC20.remoteToken() == remoteToken);
-        assert(eqStrings(optimismSuperchainERC20.name(), name));
-        assert(eqStrings(optimismSuperchainERC20.symbol(), symbol));
-        assert(optimismSuperchainERC20.decimals() == decimals);
-        assert(MESSENGER.crossDomainMessageSender() == address(optimismSuperchainERC20));
+    function check_setup() public {
+        // Source token
+        assert(sourceToken.remoteToken() == remoteToken);
+        assert(eqStrings(sourceToken.name(), name));
+        assert(eqStrings(sourceToken.symbol(), symbol));
+        assert(sourceToken.decimals() == decimals);
+        vm.prank(address(sourceToken));
+        assert(MESSENGER.crossDomainMessageSender() == address(sourceToken));
+
+        // Destination token
+        assert(destToken.remoteToken() == remoteToken);
+        assert(eqStrings(destToken.name(), name));
+        assert(eqStrings(destToken.symbol(), symbol));
+        assert(destToken.decimals() == decimals);
+        assert(MESSENGER.DESTINATION_CHAIN_ID() == DESTINATION_CHAIN_ID);
+        vm.prank(address(destToken));
+        assert(MESSENGER.crossDomainMessageSender() == address(destToken));
+
+        // Custom cross domain sender
+        assert(MESSENGER.crossDomainMessageSender() == address(0));
     }
 
     /// @custom:property-id 6
@@ -56,17 +82,16 @@ contract SymTest_OptimismSuperchainERC20 is SymTest, HalmosBase {
         public
     {
         /* Preconditions */
-        vm.assume(_chainId != CURRENT_CHAIN_ID);
         vm.assume(_to != address(0));
         vm.assume(_from != address(0));
 
         // Can't deal to unsupported cheatcode
         vm.prank(Predeploys.L2_STANDARD_BRIDGE);
-        optimismSuperchainERC20.mint(_from, _initialBalance);
+        sourceToken.mint(_from, _initialBalance);
 
         vm.prank(_from);
         /* Action */
-        try optimismSuperchainERC20.sendERC20(_to, _amount, _chainId) {
+        try sourceToken.sendERC20(_to, _amount, _chainId) {
             /* Postcondition */
             assert(_initialBalance >= _amount);
         } catch {
@@ -89,21 +114,18 @@ contract SymTest_OptimismSuperchainERC20 is SymTest, HalmosBase {
         vm.assume(_to != address(0));
         // Deploying a new messenger because of an issue of not being able to etch the storage layout of the mock
         // contract. So needed to a new one setting the symbolic immutable variable for the crossDomainSender.
-        vm.etch(address(MESSENGER), address(new MockL2ToL2Messenger(_crossDomainSender)).code);
+        // Used 0 address on source token so when the `soureToken` calls it if returns the symbolic `_crossDomainSender`
+        vm.etch(
+            address(MESSENGER), address(new MockL2ToL2Messenger(address(0), address(0), 0, _crossDomainSender)).code
+        );
 
         vm.prank(_sender);
         /* Action */
-        try optimismSuperchainERC20.relayERC20(_from, _to, _amount) {
+        try sourceToken.relayERC20(_from, _to, _amount) {
             /* Postconditions */
-            assert(
-                _sender == address(MESSENGER)
-                    && MESSENGER.crossDomainMessageSender() == address(optimismSuperchainERC20)
-            );
+            assert(_sender == address(MESSENGER) && MESSENGER.crossDomainMessageSender() == address(sourceToken));
         } catch {
-            assert(
-                _sender != address(MESSENGER)
-                    || MESSENGER.crossDomainMessageSender() != address(optimismSuperchainERC20)
-            );
+            assert(_sender != address(MESSENGER) || MESSENGER.crossDomainMessageSender() != address(sourceToken));
         }
     }
 
@@ -112,37 +134,38 @@ contract SymTest_OptimismSuperchainERC20 is SymTest, HalmosBase {
     function check_sendERC20ZeroCall(address _from, address _to, uint256 _chainId) public {
         /* Preconditions */
         vm.assume(_to != address(0));
-        vm.assume(_chainId != CURRENT_CHAIN_ID);
         vm.assume(_to != address(Predeploys.CROSS_L2_INBOX) && _to != address(MESSENGER));
 
-        uint256 _totalSupplyBefore = optimismSuperchainERC20.totalSupply();
-        uint256 _fromBalanceBefore = optimismSuperchainERC20.balanceOf(_from);
+        uint256 _totalSupplyBefore = sourceToken.totalSupply();
+        uint256 _fromBalanceBefore = sourceToken.balanceOf(_from);
+        uint256 _toBalanceBefore = sourceToken.balanceOf(_to);
 
         vm.startPrank(_from);
         /* Action */
-        optimismSuperchainERC20.sendERC20(_to, ZERO_AMOUNT, _chainId);
+        sourceToken.sendERC20(_to, ZERO_AMOUNT, _chainId);
 
         /* Postcondition */
-        assert(optimismSuperchainERC20.totalSupply() == _totalSupplyBefore);
-        assert(optimismSuperchainERC20.balanceOf(_from) == _fromBalanceBefore);
+        assert(sourceToken.totalSupply() == _totalSupplyBefore);
+        assert(sourceToken.balanceOf(_from) == _fromBalanceBefore);
+        assert(sourceToken.balanceOf(_to) == _toBalanceBefore);
     }
 
     /// @custom:property-id 9
     /// @custom:property `relayERC20` with a value of zero does not modify accounting
     function check_relayERC20ZeroCall(address _from, address _to) public {
-        uint256 _totalSupplyBefore = optimismSuperchainERC20.totalSupply();
+        uint256 _totalSupplyBefore = sourceToken.totalSupply();
         /* Preconditions */
-        uint256 _fromBalanceBefore = optimismSuperchainERC20.balanceOf(_from);
-        uint256 _toBalanceBefore = optimismSuperchainERC20.balanceOf(_to);
+        uint256 _fromBalanceBefore = sourceToken.balanceOf(_from);
+        uint256 _toBalanceBefore = sourceToken.balanceOf(_to);
         vm.prank(address(MESSENGER));
 
         /* Action */
-        optimismSuperchainERC20.relayERC20(_from, _to, ZERO_AMOUNT);
+        sourceToken.relayERC20(_from, _to, ZERO_AMOUNT);
 
         /* Postconditions */
-        assert(optimismSuperchainERC20.totalSupply() == _totalSupplyBefore);
-        assert(optimismSuperchainERC20.balanceOf(_from) == _fromBalanceBefore);
-        assert(optimismSuperchainERC20.balanceOf(_to) == _toBalanceBefore);
+        assert(sourceToken.totalSupply() == _totalSupplyBefore);
+        assert(sourceToken.balanceOf(_from) == _fromBalanceBefore);
+        assert(sourceToken.balanceOf(_to) == _toBalanceBefore);
     }
 
     /// @custom:property-id 10
@@ -157,21 +180,20 @@ contract SymTest_OptimismSuperchainERC20 is SymTest, HalmosBase {
     {
         /* Preconditions */
         vm.assume(_to != address(0));
-        vm.assume(_chainId != CURRENT_CHAIN_ID);
 
         vm.prank(Predeploys.L2_STANDARD_BRIDGE);
-        optimismSuperchainERC20.mint(_sender, _amount);
+        sourceToken.mint(_sender, _amount);
 
-        uint256 _totalSupplyBefore = optimismSuperchainERC20.totalSupply();
-        uint256 _balanceBefore = optimismSuperchainERC20.balanceOf(_sender);
+        uint256 _totalSupplyBefore = sourceToken.totalSupply();
+        uint256 _balanceBefore = sourceToken.balanceOf(_sender);
 
         vm.prank(_sender);
         /* Action */
-        optimismSuperchainERC20.sendERC20(_to, _amount, _chainId);
+        sourceToken.sendERC20(Predeploys.CROSS_L2_INBOX, _amount, _chainId);
 
         /* Postconditions */
-        assert(optimismSuperchainERC20.totalSupply() == _totalSupplyBefore - _amount);
-        assert(optimismSuperchainERC20.balanceOf(_sender) == _balanceBefore - _amount);
+        assert(sourceToken.totalSupply() == _totalSupplyBefore - _amount);
+        assert(sourceToken.balanceOf(_sender) == _balanceBefore - _amount);
     }
 
     /// @custom:property-id 11
@@ -181,32 +203,32 @@ contract SymTest_OptimismSuperchainERC20 is SymTest, HalmosBase {
         vm.assume(_to != address(0));
 
         /* Preconditions */
-        uint256 _totalSupplyBefore = optimismSuperchainERC20.totalSupply();
-        uint256 _toBalanceBefore = optimismSuperchainERC20.balanceOf(_to);
+        uint256 _totalSupplyBefore = sourceToken.totalSupply();
+        uint256 _toBalanceBefore = sourceToken.balanceOf(_to);
 
         vm.prank(address(MESSENGER));
         /* Action */
-        optimismSuperchainERC20.relayERC20(_from, _to, _amount);
+        sourceToken.relayERC20(_from, _to, _amount);
 
         /* Postconditions */
-        assert(optimismSuperchainERC20.totalSupply() == _totalSupplyBefore + _amount);
-        assert(optimismSuperchainERC20.balanceOf(_to) == _toBalanceBefore + _amount);
+        assert(sourceToken.totalSupply() == _totalSupplyBefore + _amount);
+        assert(sourceToken.balanceOf(_to) == _toBalanceBefore + _amount);
     }
 
     /// @custom:property-id 12
     /// @custom:property Increases the total supply on the amount minted by the bridge
     function check_mint(address _from, uint256 _amount) public {
         /* Preconditions */
-        uint256 _totalSupplyBefore = optimismSuperchainERC20.totalSupply();
-        uint256 _balanceBefore = optimismSuperchainERC20.balanceOf(_from);
+        uint256 _totalSupplyBefore = sourceToken.totalSupply();
+        uint256 _balanceBefore = sourceToken.balanceOf(_from);
 
         vm.startPrank(Predeploys.L2_STANDARD_BRIDGE);
         /* Action */
-        optimismSuperchainERC20.mint(_from, _amount);
+        sourceToken.mint(_from, _amount);
 
         /* Postconditions */
-        assert(optimismSuperchainERC20.totalSupply() == _totalSupplyBefore + _amount);
-        assert(optimismSuperchainERC20.balanceOf(_from) == _balanceBefore + _amount);
+        assert(sourceToken.totalSupply() == _totalSupplyBefore + _amount);
+        assert(sourceToken.balanceOf(_from) == _balanceBefore + _amount);
     }
 
     /// @custom:property-id 13
@@ -214,24 +236,68 @@ contract SymTest_OptimismSuperchainERC20 is SymTest, HalmosBase {
     function check_burn(address _from, uint256 _amount) public {
         /* Preconditions */
         vm.prank(Predeploys.L2_STANDARD_BRIDGE);
-        optimismSuperchainERC20.mint(_from, _amount);
+        sourceToken.mint(_from, _amount);
 
-        uint256 _totalSupplyBefore = optimismSuperchainERC20.totalSupply();
-        uint256 _balanceBefore = optimismSuperchainERC20.balanceOf(_from);
+        uint256 _totalSupplyBefore = sourceToken.totalSupply();
+        uint256 _balanceBefore = sourceToken.balanceOf(_from);
 
         vm.prank(Predeploys.L2_STANDARD_BRIDGE);
         /* Action */
-        optimismSuperchainERC20.burn(_from, _amount);
+        sourceToken.burn(_from, _amount);
 
         /* Postconditions */
-        assert(optimismSuperchainERC20.totalSupply() == _totalSupplyBefore - _amount);
-        assert(optimismSuperchainERC20.balanceOf(_from) == _balanceBefore - _amount);
+        assert(sourceToken.totalSupply() == _totalSupplyBefore - _amount);
+        assert(sourceToken.balanceOf(_from) == _balanceBefore - _amount);
     }
 
     /// @custom:property-id 14
     /// @custom:property Supertoken total supply starts at zero
     function check_totalSupplyStartsAtZero() public view {
         /* Postconditions */
-        assert(optimismSuperchainERC20.totalSupply() == 0);
+        assert(sourceToken.totalSupply() == 0);
+    }
+
+    /// @custom:property-id 22
+    /// @custom:property `sendERC20` decreases sender balance in source chain and increases receiver balance in
+    /// destination chain exactly by the input amount
+    /// @custom:property-id 23
+    /// @custom:property `sendERC20` decreases total supply in source chain and increases it in destination chain
+    /// exactly by the input amount
+    function check_crossChainMintAndBurn(address _from, address _to, uint256 _amount, uint256 _chainId) public {
+        /* Preconditions */
+        vm.assume(_to != address(0));
+        vm.assume(_from != address(0));
+
+        // Mint the amount to send
+        vm.prank(Predeploys.L2_STANDARD_BRIDGE);
+        sourceToken.mint(_from, _amount);
+
+        uint256 fromBalanceBefore = sourceToken.balanceOf(_from);
+        uint256 toBalanceBefore = destToken.balanceOf(_to);
+        uint256 sourceTotalSupplyBefore = sourceToken.totalSupply();
+        uint256 destTotalSupplyBefore = destToken.totalSupply();
+
+        vm.prank(_from);
+        /* Action */
+        try sourceToken.sendERC20(_to, _amount, _chainId) {
+            /* Postconditions */
+            // Source
+            assert(sourceToken.balanceOf(_from) == fromBalanceBefore - _amount);
+            assert(sourceToken.totalSupply() == sourceTotalSupplyBefore - _amount);
+
+            // Destination
+            if (_chainId == DESTINATION_CHAIN_ID) {
+                // If the destination chain matches the one of the dest token, check that the amount was minted
+                assert(destToken.balanceOf(_to) == toBalanceBefore + _amount);
+                assert(destToken.totalSupply() == destTotalSupplyBefore + _amount);
+            } else {
+                // Otherwise the balances should remain the same
+                assert(destToken.balanceOf(_to) == toBalanceBefore);
+                assert(destToken.totalSupply() == destTotalSupplyBefore);
+            }
+        } catch {
+            // Shouldn't fail
+            assert(false);
+        }
     }
 }

--- a/packages/contracts-bedrock/test/properties/helpers/HalmosBase.sol
+++ b/packages/contracts-bedrock/test/properties/helpers/HalmosBase.sol
@@ -5,6 +5,7 @@ import { Test } from "forge-std/Test.sol";
 
 contract HalmosBase is Test {
     uint256 internal constant CURRENT_CHAIN_ID = 1;
+    uint256 internal constant DESTINATION_CHAIN_ID = 2;
     uint256 internal constant ZERO_AMOUNT = 0;
 
     address internal remoteToken = address(bytes20(keccak256("remoteToken")));


### PR DESCRIPTION
* refactor: allow for atomicity on mock messenger

* refactor: cross domain sender logic on mock messenger

* refactor: l2 to l2 caller and messenge sender logic

* chore: remove assumes for removed checks on mock messenger
----------------

On the mock messenger, I had to return immutable vars on cross domain sender function due to the same problem with the storage layout. The same happens with the destination chain value on `sendMessage`.


To run the files: `just test-halmos-all`


CLOSES FUZZ-32