### PR TITLE
test: superc20 tob properties

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,6 @@
 [submodule "packages/contracts-bedrock/lib/halmos-cheatcodes"]
 	path = packages/contracts-bedrock/lib/halmos-cheatcodes
 	url = https://github.com/a16z/halmos-cheatcodes
+[submodule "packages/contracts-bedrock/lib/properties"]
+	path = packages/contracts-bedrock/lib/properties
+	url = https://github.com/crytic/properties

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -17,6 +17,7 @@ remappings = [
   '@rari-capital/solmate/=lib/solmate',
   '@lib-keccak/=lib/lib-keccak/contracts/lib',
   '@solady/=lib/solady/src',
+  '@crytic/properties/=lib/properties/',
   'forge-std/=lib/forge-std/src',
   'ds-test/=lib/forge-std/lib/ds-test/src',
   'safe-contracts/=lib/safe-contracts/contracts',

--- a/packages/contracts-bedrock/medusa.json
+++ b/packages/contracts-bedrock/medusa.json
@@ -56,6 +56,7 @@
 			},
 			"targetFunctionSignatures": [],
 			"excludeFunctionSignatures": [
+        "ProtocolProperties.test_ERC20external_zeroAddressBalance()",
         "ProtocolProperties.test_ERC20external_transferToZeroAddress()",
         "ProtocolProperties.test_ERC20external_transferFromToZeroAddress(uint256)"
       ]

--- a/packages/contracts-bedrock/medusa.json
+++ b/packages/contracts-bedrock/medusa.json
@@ -55,7 +55,10 @@
 				]
 			},
 			"targetFunctionSignatures": [],
-			"excludeFunctionSignatures": []
+			"excludeFunctionSignatures": [
+        "ProtocolProperties.test_ERC20external_transferToZeroAddress()",
+        "ProtocolProperties.test_ERC20external_transferFromToZeroAddress(uint256)"
+      ]
 		},
 		"chainConfig": {
 			"codeSizeCheckDisabled": true,

--- a/packages/contracts-bedrock/test/properties/PROPERTIES.md
+++ b/packages/contracts-bedrock/test/properties/PROPERTIES.md
@@ -117,7 +117,7 @@ It’s worth noting that these properties will not hold for a live system
 
 # Expected external interactions
 
-- regular ERC20 operations between any accounts on the same chain, provided by [crytic ERC20 properties](https://github.com/crytic/properties?tab=readme-ov-file#erc20-tests)
+- [x] regular ERC20 operations between any accounts on the same chain, provided by [crytic ERC20 properties](https://github.com/crytic/properties?tab=readme-ov-file#erc20-tests)
 
 # Invariant-breaking candidates (brain dump)
 

--- a/packages/contracts-bedrock/test/properties/helpers/Actors.t.sol
+++ b/packages/contracts-bedrock/test/properties/helpers/Actors.t.sol
@@ -22,7 +22,7 @@ contract Actors is StdUtils {
     }
 
     /// @notice get the currently configured actor, should equal msg.sender
-    function currentActor() internal view returns(address){
+    function currentActor() internal view returns (address) {
         return _currentActor;
     }
 

--- a/packages/contracts-bedrock/test/properties/helpers/Actors.t.sol
+++ b/packages/contracts-bedrock/test/properties/helpers/Actors.t.sol
@@ -13,12 +13,16 @@ contract Actors is StdUtils {
     /// usually called with msg.sender as a parameter, to track the actors
     /// already provided by the fuzzer
     modifier withActor(address who) {
+        addActor(who);
+        _currentActor = who;
+        _;
+    }
+
+    function addActor(address who) internal {
         if (!_isActor[who]) {
             _isActor[who] = true;
             _actors.push(who);
         }
-        _currentActor = who;
-        _;
     }
 
     /// @notice get the currently configured actor, should equal msg.sender

--- a/packages/contracts-bedrock/test/properties/helpers/OptimismSuperchainERC20ForToBProperties.t.sol
+++ b/packages/contracts-bedrock/test/properties/helpers/OptimismSuperchainERC20ForToBProperties.t.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3
+pragma solidity ^0.8.25;
+
+import { OptimismSuperchainERC20 } from "src/L2/OptimismSuperchainERC20.sol";
+
+contract OptimismSuperchainERC20ForToBProperties is OptimismSuperchainERC20 {
+    bool public constant isMintableOrBurnable = true;
+    uint256 public initialSupply = 0;
+}

--- a/packages/contracts-bedrock/test/properties/medusa/Protocol.properties.t.sol
+++ b/packages/contracts-bedrock/test/properties/medusa/Protocol.properties.t.sol
@@ -3,12 +3,29 @@ pragma solidity ^0.8.25;
 
 import { TestBase } from "forge-std/Base.sol";
 
+import { ITokenMock } from "@crytic/properties/contracts/ERC20/external/util/ITokenMock.sol";
 import { EnumerableMap } from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
+import { CryticERC20ExternalBasicProperties } from
+    "@crytic/properties/contracts/ERC20/external/properties/ERC20ExternalBasicProperties.sol";
 import { ProtocolHandler } from "./handlers/Protocol.handler.t.sol";
 import { OptimismSuperchainERC20 } from "src/L2/OptimismSuperchainERC20.sol";
 
-contract ProtocolProperties is ProtocolHandler {
+contract ProtocolProperties is ProtocolHandler, CryticERC20ExternalBasicProperties {
     using EnumerableMap for EnumerableMap.Bytes32ToUintMap;
+
+    /// @dev `token` is the token under test for the ToB properties. This is coupled
+    /// to the ProtocolHandler constructor initializing at least one supertoken
+    constructor() {
+        token = ITokenMock(allSuperTokens[0]);
+    }
+
+    /// @dev not that much of a handler, since this only changes which
+    /// supertoken the ToB assertions are performed against. Thankfully, they are
+    /// implemented in a way that don't require tracking ghost variables or can
+    /// break properties defined by us
+    function handler_ToBTestOtherToken(uint256 index) external {
+        token = ITokenMock(allSuperTokens[bound(index, 0, allSuperTokens.length - 1)]);
+    }
 
     // TODO: will need rework after
     //   - non-atomic bridge

--- a/packages/contracts-bedrock/test/properties/medusa/handlers/Protocol.handler.t.sol
+++ b/packages/contracts-bedrock/test/properties/medusa/handlers/Protocol.handler.t.sol
@@ -7,6 +7,7 @@ import { StdUtils } from "forge-std/StdUtils.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts-v5/proxy/ERC1967/ERC1967Proxy.sol";
 import { EnumerableMap } from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 import { OptimismSuperchainERC20 } from "src/L2/OptimismSuperchainERC20.sol";
+import { OptimismSuperchainERC20ForToBProperties } from "../../helpers/OptimismSuperchainERC20ForToBProperties.t.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { MockL2ToL2CrossDomainMessenger } from "../../helpers/MockL2ToL2CrossDomainMessenger.t.sol";
 import { Actors } from "../../helpers/Actors.t.sol";
@@ -42,7 +43,7 @@ contract ProtocolHandler is TestBase, StdUtils, Actors {
 
     constructor() {
         vm.etch(address(MESSENGER), address(new MockL2ToL2CrossDomainMessenger()).code);
-        superchainERC20Impl = new OptimismSuperchainERC20();
+        superchainERC20Impl = new OptimismSuperchainERC20ForToBProperties();
         for (uint256 remoteTokenIndex = 0; remoteTokenIndex < INITIAL_TOKENS; remoteTokenIndex++) {
             _deployRemoteToken();
             for (uint256 supertokenChainId = 0; supertokenChainId < INITIAL_SUPERTOKENS; supertokenChainId++) {

--- a/packages/contracts-bedrock/test/properties/medusa/handlers/Protocol.handler.t.sol
+++ b/packages/contracts-bedrock/test/properties/medusa/handlers/Protocol.handler.t.sol
@@ -82,6 +82,45 @@ contract ProtocolHandler is TestBase, StdUtils, Actors {
         ghost_totalSupplyAcrossChains.set(MESSENGER.superTokenInitDeploySalts(addr), currentValue + amount);
     }
 
+    function handler_SupERC20Transfer(
+        uint256 tokenIndex,
+        address recipient,
+        uint256 amount
+    )
+        external
+        withActor(msg.sender)
+    {
+        vm.prank(currentActor());
+        OptimismSuperchainERC20(allSuperTokens[bound(tokenIndex, 0, allSuperTokens.length)]).transfer(recipient, amount);
+    }
+
+    function handler_SupERC20TransferFrom(
+        uint256 tokenIndex,
+        address from,
+        address to,
+        uint256 amount
+    )
+        external
+        withActor(msg.sender)
+    {
+        vm.prank(currentActor());
+        OptimismSuperchainERC20(allSuperTokens[bound(tokenIndex, 0, allSuperTokens.length)]).transferFrom(
+            from, to, amount
+        );
+    }
+
+    function handler_SupERC20Approve(
+        uint256 tokenIndex,
+        address spender,
+        uint256 amount
+    )
+        external
+        withActor(msg.sender)
+    {
+        vm.prank(currentActor());
+        OptimismSuperchainERC20(allSuperTokens[bound(tokenIndex, 0, allSuperTokens.length)]).transfer(spender, amount);
+    }
+
     /// @notice deploy a remote token, that supertokens will be a representation of. They are  never called, so there
     /// is no need to actually deploy a contract for them
     function _deployRemoteToken() internal {

--- a/packages/contracts-bedrock/test/properties/medusa/handlers/Protocol.handler.t.sol
+++ b/packages/contracts-bedrock/test/properties/medusa/handlers/Protocol.handler.t.sol
@@ -38,7 +38,7 @@ contract ProtocolHandler is TestBase, StdUtils, Actors {
     address[] internal remoteTokens;
     address[] internal allSuperTokens;
 
-    //@notice  'real' deploy salt => total supply sum across chains
+    /// @notice  'real' deploy salt => total supply sum across chains
     EnumerableMap.Bytes32ToUintMap internal ghost_totalSupplyAcrossChains;
 
     constructor() {


### PR DESCRIPTION
Preferred this approach to

- test a supertoken in isolation -> would amount to testing the solady erc20 implementation, + I would like to get the ToB invariants checked against contracts that had 'real' state transitions from the core test suite
- modifying/extending the ToB contracts so they assert against *every* supertoken: if there's an issue with one token, the fuzzer is going to find it eventually by testing one token at a time (I hope)

ToB properties, however, don't only check the invariants but also cause valid ERC20 state transitions, so we got that for free :sparkles: 

edit: had to guide the fuzzer a bit more to actually cover most ToB properties (making the paragraph above a bit less true), and discovered two that solady's erc20 implementation doesn't comply with