### PR TITLE
feat: adding permit2 support to SuperWETH and SuperchainERC20

### DIFF
--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -116,7 +116,7 @@
     "sourceCodeHash": "0x4b806cc85cead74c8df34ab08f4b6c6a95a1a387a335ec8a7cb2de4ea4e1cf41"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
-    "initCodeHash": "0x362f5ee610df9ba99bf2ae5e6a96abace8ac8eb62d7a3433037525818cf13de0",
+    "initCodeHash": "0xa812d6c13a02e560864a023f0bc9696065f426aa95b8558e01925b164400d11c",
     "sourceCodeHash": "0xad3934ea533544b3c130c80be26201354af85f9166cb2ce54d96e5e383ebb5c1"
   },
   "src/L2/OptimismSuperchainERC20Beacon.sol": {

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -116,7 +116,7 @@
     "sourceCodeHash": "0x4b806cc85cead74c8df34ab08f4b6c6a95a1a387a335ec8a7cb2de4ea4e1cf41"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
-    "initCodeHash": "0x4fd71b5352b78d51d39625b6defa77a75be53067b32f3cba86bd17a46917adf9",
+    "initCodeHash": "0x362f5ee610df9ba99bf2ae5e6a96abace8ac8eb62d7a3433037525818cf13de0",
     "sourceCodeHash": "0xad3934ea533544b3c130c80be26201354af85f9166cb2ce54d96e5e383ebb5c1"
   },
   "src/L2/OptimismSuperchainERC20Beacon.sol": {
@@ -132,8 +132,8 @@
     "sourceCodeHash": "0xd56922cb04597dea469c65e5a49d4b3c50c171e603601e6f41da9517cae0b11a"
   },
   "src/L2/SuperchainWETH.sol": {
-    "initCodeHash": "0xaa136fc27006d722867bcd017742cd119e58658d9860826551095775f70739ce",
-    "sourceCodeHash": "0x2b627b6492c4ca3cc6a457fe48b7d0b1d335125d9c6288f7373b6525542532e8"
+    "initCodeHash": "0x7635fa9c6dfa42aaafc0eccbc3a36fa4166e80b0ab398fd7d24f01c3ded06b29",
+    "sourceCodeHash": "0x47c6191169c823bfd1013de877952791a22d5587bc1a97b40c8001418f5317ff"
   },
   "src/L2/WETH.sol": {
     "initCodeHash": "0x8ccf5227a09f3ee8e450df1f9dc72a538c03226f0182c23976635c2b49859147",

--- a/packages/contracts-bedrock/snapshots/abi/OptimismSuperchainERC20.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismSuperchainERC20.json
@@ -18,6 +18,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "PERMIT2",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",

--- a/packages/contracts-bedrock/snapshots/abi/SuperchainWETH.json
+++ b/packages/contracts-bedrock/snapshots/abi/SuperchainWETH.json
@@ -8,6 +8,19 @@
     "type": "receive"
   },
   {
+    "inputs": [],
+    "name": "PERMIT2",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",

--- a/packages/contracts-bedrock/src/L2/SuperchainERC20.sol
+++ b/packages/contracts-bedrock/src/L2/SuperchainERC20.sol
@@ -5,6 +5,7 @@ import { ISuperchainERC20Extensions, ISuperchainERC20Errors } from "src/L2/inter
 import { ERC20 } from "@solady/tokens/ERC20.sol";
 import { IL2ToL2CrossDomainMessenger } from "src/L2/interfaces/IL2ToL2CrossDomainMessenger.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Preinstalls } from "src/libraries/Preinstalls.sol";
 
 /// @title SuperchainERC20
 /// @notice SuperchainERC20 is a standard extension of the base ERC20 token contract that unifies ERC20 token
@@ -14,10 +15,12 @@ abstract contract SuperchainERC20 is ISuperchainERC20Extensions, ISuperchainERC2
     /// @notice Address of the L2ToL2CrossDomainMessenger Predeploy.
     address internal constant MESSENGER = Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER;
 
-    /// @notice Sends tokens to some target address on another chain.
-    /// @param _to      Address to send tokens to.
-    /// @param _amount  Amount of tokens to send.
-    /// @param _chainId Chain ID of the destination chain.
+    /// @inheritdoc ISuperchainERC20Extensions
+    function PERMIT2() public pure returns (address) {
+        return Preinstalls.Permit2;
+    }
+
+    /// @inheritdoc ISuperchainERC20Extensions
     function sendERC20(address _to, uint256 _amount, uint256 _chainId) external virtual {
         if (_to == address(0)) revert ZeroAddress();
 
@@ -29,10 +32,7 @@ abstract contract SuperchainERC20 is ISuperchainERC20Extensions, ISuperchainERC2
         emit SendERC20(msg.sender, _to, _amount, _chainId);
     }
 
-    /// @notice Relays tokens received from another chain.
-    /// @param _from   Address of the msg.sender of sendERC20 on the source chain.
-    /// @param _to     Address to relay tokens to.
-    /// @param _amount Amount of tokens to relay.
+    /// @inheritdoc ISuperchainERC20Extensions
     function relayERC20(address _from, address _to, uint256 _amount) external virtual {
         if (msg.sender != MESSENGER) revert CallerNotL2ToL2CrossDomainMessenger();
 
@@ -45,5 +45,60 @@ abstract contract SuperchainERC20 is ISuperchainERC20Extensions, ISuperchainERC2
         _mint(_to, _amount);
 
         emit RelayERC20(_from, _to, _amount, source);
+    }
+
+    /// @notice Transfers `amount` tokens from `from` to `to`.
+    ///         If the spender is the permit2 address, returns the maximum uint256 value.
+    /// @param  from   The address of the owner of the tokens.
+    /// @param  to     The address that will receive the tokens.
+    /// @param  amount The amount of tokens to transfer.
+    /// @return Whether the transfer was successful or not.
+    function transferFrom(address from, address to, uint256 amount) public virtual override returns (bool) {
+        if (msg.sender == PERMIT2()) {
+            uint256 _BALANCE_SLOT_SEED = 0x87a211a2;
+            uint256 _TRANSFER_EVENT_SIGNATURE = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef;
+
+            _beforeTokenTransfer(from, to, amount);
+
+            assembly {
+                let from_ := shl(96, from)
+                // Compute the balance slot and load its value.
+                mstore(0x0c, or(from_, _BALANCE_SLOT_SEED))
+                let fromBalanceSlot := keccak256(0x0c, 0x20)
+                let fromBalance := sload(fromBalanceSlot)
+                // Revert if insufficient balance.
+                if gt(amount, fromBalance) {
+                    mstore(0x00, 0xf4d678b8) // `InsufficientBalance()`.
+                    revert(0x1c, 0x04)
+                }
+                // Subtract and store the updated balance.
+                sstore(fromBalanceSlot, sub(fromBalance, amount))
+                // Compute the balance slot of `to`.
+                mstore(0x00, to)
+                let toBalanceSlot := keccak256(0x0c, 0x20)
+                // Add and store the updated balance of `to`.
+                // Will not overflow because the sum of all user balances
+                // cannot exceed the maximum uint256 value.
+                sstore(toBalanceSlot, add(sload(toBalanceSlot), amount))
+                // Emit the {Transfer} event.
+                mstore(0x20, amount)
+                log3(0x20, 0x20, _TRANSFER_EVENT_SIGNATURE, shr(96, from_), shr(96, mload(0x0c)))
+            }
+            _afterTokenTransfer(from, to, amount);
+            return true;
+        }
+        return super.transferFrom(from, to, amount);
+    }
+
+    /// @notice Returns the allowance for a spender on the owner's tokens.
+    ///         If the spender is the permit2 address, returns the maximum uint256 value.
+    /// @param  owner   Owner of the tokens.
+    /// @param  spender Spender of the tokens.
+    /// @return result Allowance for the spender.
+    function allowance(address owner, address spender) public view virtual override returns (uint256 result) {
+        if (spender == PERMIT2()) {
+            result = type(uint256).max;
+        }
+        result = super.allowance(owner, spender);
     }
 }

--- a/packages/contracts-bedrock/src/L2/SuperchainERC20.sol
+++ b/packages/contracts-bedrock/src/L2/SuperchainERC20.sol
@@ -97,7 +97,7 @@ abstract contract SuperchainERC20 is ISuperchainERC20Extensions, ISuperchainERC2
     /// @return result Allowance for the spender.
     function allowance(address owner, address spender) public view virtual override returns (uint256 result) {
         if (spender == PERMIT2()) {
-            result = type(uint256).max;
+            return type(uint256).max;
         }
         result = super.allowance(owner, spender);
     }

--- a/packages/contracts-bedrock/src/L2/interfaces/ISuperchainERC20.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/ISuperchainERC20.sol
@@ -23,6 +23,12 @@ interface ISuperchainERC20Extensions {
     /// @param source   Chain ID of the source chain.
     event RelayERC20(address indexed from, address indexed to, uint256 amount, uint256 source);
 
+    /// @notice Getter function for the permit2 address. It deterministically deployed
+    ///         so it will always be at the same address. It is also included as a preinstall,
+    ///         so it exists in the genesis state of chains.
+    /// @return Address of permit2 on this network.
+    function PERMIT2() external pure returns (address);
+
     /// @notice Sends tokens to some target address on another chain.
     /// @param _to      Address to send tokens to.
     /// @param _amount  Amount of tokens to send.

--- a/packages/contracts-bedrock/src/universal/WETH98.sol
+++ b/packages/contracts-bedrock/src/universal/WETH98.sol
@@ -81,7 +81,7 @@ contract WETH98 is IWETH {
     }
 
     /// @inheritdoc IWETH
-    function transferFrom(address src, address dst, uint256 wad) public returns (bool) {
+    function transferFrom(address src, address dst, uint256 wad) public virtual returns (bool) {
         require(balanceOf[src] >= wad);
 
         if (src != msg.sender && allowance[src][msg.sender] != type(uint256).max) {

--- a/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20.t.sol
@@ -351,6 +351,22 @@ contract OptimismSuperchainERC20Test is Test {
         assertEq(superchainERC20.balanceOf(_to), _toBalanceBefore + _amount);
     }
 
+    function testFuzz_allowance_permit2_max(address _owner) external view {
+        assertEq(superchainERC20.allowance(_owner, superchainERC20.PERMIT2()), type(uint256).max);
+    }
+
+    function testFuzz_permit2_transferFrom(address _owner, address _receiver, uint256 _amount) external {
+        vm.assume(_owner != _receiver);
+        vm.assume(_owner != ZERO_ADDRESS);
+        vm.prank(BRIDGE);
+        superchainERC20.mint(_owner, _amount);
+
+        assertEq(superchainERC20.balanceOf(_receiver), 0);
+        vm.prank(superchainERC20.PERMIT2());
+        superchainERC20.transferFrom(_owner, _receiver, _amount);
+        assertEq(superchainERC20.balanceOf(_receiver), _amount);
+    }
+
     /// @notice Tests the `decimals` function always returns the correct value.
     function testFuzz_decimals_succeeds(uint8 _decimals) public {
         OptimismSuperchainERC20 _newSuperchainERC20 = _deploySuperchainERC20Proxy(REMOTE_TOKEN, NAME, SYMBOL, _decimals);

--- a/packages/contracts-bedrock/test/L2/SuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainERC20.t.sol
@@ -203,6 +203,20 @@ contract SuperchainERC20Test is Test {
         assertEq(superchainERC20.balanceOf(_to), _toBalanceBefore + _amount);
     }
 
+    function testFuzz_allowance_permit2_max(address _owner) external view {
+        assertEq(superchainERC20.allowance(_owner, superchainERC20.PERMIT2()), type(uint256).max);
+    }
+
+    function testFuzz_permit2_transferFrom(address _owner, address _receiver, uint256 _amount) external {
+        vm.assume(_owner != _receiver);
+        superchainERC20.mint(_owner, _amount);
+
+        assertEq(superchainERC20.balanceOf(_receiver), 0);
+        vm.prank(superchainERC20.PERMIT2());
+        superchainERC20.transferFrom(_owner, _receiver, _amount);
+        assertEq(superchainERC20.balanceOf(_receiver), _amount);
+    }
+
     /// @notice Tests the `name` function always returns the correct value.
     function testFuzz_name_succeeds(string memory _name) public {
         SuperchainERC20 _newSuperchainERC20 = new SuperchainERC20Mock(_name, SYMBOL, DECIMALS);

--- a/packages/contracts-bedrock/test/L2/SuperchainWETH.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainWETH.t.sol
@@ -351,4 +351,28 @@ contract SuperchainWETH_Test is CommonTest {
         assertEq(address(superchainWeth).balance, 0);
         assertEq(superchainWeth.balanceOf(bob), 0);
     }
+
+    /// @notice Tests that the Permit2 contract succesfully transfers tokens from
+    ///         a user without requiring a previous approval transaction/
+    /// @param _owner    The owner of the WETH.
+    /// @param _receiver The address that will receive the WETH.
+    /// @param _amount   The amount of WETH to transfer.
+    function testFuzz_permit2_transferFrom(address _owner, address _receiver, uint256 _amount) external {
+        // Assume
+        _amount = bound(_amount, 0, type(uint248).max - 1);
+        vm.assume(_owner != _receiver);
+
+        // Arrange
+        vm.deal(_owner, _amount);
+        vm.prank(_owner);
+        superchainWeth.deposit{ value: _amount }();
+
+        // Sanity-check Assert
+        assertEq(superchainWeth.balanceOf(_receiver), 0);
+
+        // Act
+        vm.prank(superchainWeth.PERMIT2());
+        superchainWeth.transferFrom(_owner, _receiver, _amount);
+        assertEq(superchainWeth.balanceOf(_receiver), _amount);
+    }
 }


### PR DESCRIPTION
**Description**

Adds Permit2 support to `SuperchainWETH` and `SuperchainERC20` contracts.

**Information and Questions**


Solady doesn't make use of its `allowance` function in `transferFrom`, instead it computes and reads from the slot directly. This means that overriding the `allowance` function doesn't affect the `transferFrom` function. For this reason I had to override `transferFrom` and add a special case for when PERMIT2 is the `msg.sender`. The logic within that if block is the same `transferFrom` performs when updating the balances of `from` and `to`. 

Despite `allowance` not being used in `transferFrom` I still overrode it in case integrators fetch it to perform further logic. If I hadn't it would return `0` and that may mess up some of their logic.

When it came to `SuperchainWETH` I noticed it inherited from `WETH98` which has `allowance` as a public mapping. This means it can't be overriden. I came up with two potential approaches:
1. Following OZ's pattern of renaming `allowance` to `_allowances` and making it a private state variable. This allowed me to add an `allowance` getter and to make it virtual so I could override it easily. This also meant modifying a bit of logic from this contract and from `DelayedWETH`.
2. Making `transferFrom` virtual and adding the case when `PERMIT2` is the caller at the beginning.

I went for approach 2. However this approach doesn't reflect the virtual allowance of PERMIT2, so I'm not 100% sold this is the best approach. The main reason why I chose it was because it didn't affect the logic (other than adding a virtual keyword) of WETH98 nor any contract that inherited from it, and because I was not certain whether there were certain design guidelines that `WETH98` had to follow.

I can implement the first approach quickly if needed. Also any other potential approached that I may have missed are welcomed.

One more doubt I had was whether to add this logic to the `SuperchainERC20` or not. By adding it here we are forcing all contracts extending from it to support `Permit2`. Extension can then opt-out. Another approach would be to not add it to the `SuperchainERC20` and have the extensions opt-in instead.

Lastly, these implementations and the current one on `OptimismMintableERC20` doesn't have a way to revoke the infinite allowance. Are we sure we don't want to add this?