### PR TITLE
chore: update line length

### DIFF
--- a/packages/contracts-bedrock/STYLE_GUIDE.md
+++ b/packages/contracts-bedrock/STYLE_GUIDE.md
@@ -42,7 +42,7 @@ with additional rules. These are:
 - Always use `@notice` since it has the same general effect as `@dev` but avoids confusion about when to use one over the other.
 - Include a newline between `@notice` and the first `@param`.
 - Include a newline between `@param` and the first `@return`.
-- Use a line-length of 100 characters.
+- Use a line-length of 120 characters.
 
 We also have the following custom tags:
 


### PR DESCRIPTION
**Description**

Line length is outdated, current [`foundry.toml`](https://github.com/ethereum-optimism/optimism/blob/13d116acfa528f57082976ee1be0ed1ba98c9823/packages/contracts-bedrock/foundry.toml#L61) file sets it up to 120.