### PR TITLE
chore: use ierc20 alias for ierc20 solady interface

### DIFF
--- a/packages/contracts-bedrock/src/L2/interfaces/ISuperchainERC20.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/ISuperchainERC20.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.0;
 
 // Interfaces
 import { ICrosschainERC20 } from "src/L2/interfaces/ICrosschainERC20.sol";
-import { IERC20Solady } from "src/vendor/interfaces/IERC20Solady.sol";
+import { IERC20Solady as IERC20 } from "src/vendor/interfaces/IERC20Solady.sol";
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title ISuperchainERC20
 /// @notice This interface is available on the SuperchainERC20 contract.
 /// @dev This interface is needed for the abstract SuperchainERC20 implementation but is not part of the standard
-interface ISuperchainERC20 is ICrosschainERC20, IERC20Solady, ISemver {
+interface ISuperchainERC20 is ICrosschainERC20, IERC20, ISemver {
     error Unauthorized();
 
     function __constructor__() external;

--- a/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20.t.sol
@@ -7,7 +7,7 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
-import { IERC20Solady } from "src/vendor/interfaces/IERC20Solady.sol";
+import { IERC20Solady as IERC20 } from "src/vendor/interfaces/IERC20Solady.sol";
 
 import { Initializable } from "@openzeppelin/contracts-v5/proxy/utils/Initializable.sol";
 import { IERC165 } from "@openzeppelin/contracts-v5/utils/introspection/IERC165.sol";
@@ -144,12 +144,12 @@ contract OptimismSuperchainERC20Test is Test {
         vm.assume(_to != ZERO_ADDRESS);
 
         // Get the total supply and balance of `_to` before the mint to compare later on the assertions
-        uint256 _totalSupplyBefore = IERC20Solady(address(optimismSuperchainERC20)).totalSupply();
-        uint256 _toBalanceBefore = IERC20Solady(address(optimismSuperchainERC20)).balanceOf(_to);
+        uint256 _totalSupplyBefore = IERC20(address(optimismSuperchainERC20)).totalSupply();
+        uint256 _toBalanceBefore = IERC20(address(optimismSuperchainERC20)).balanceOf(_to);
 
         // Look for the emit of the `Transfer` event
         vm.expectEmit(address(optimismSuperchainERC20));
-        emit IERC20Solady.Transfer(ZERO_ADDRESS, _to, _amount);
+        emit IERC20.Transfer(ZERO_ADDRESS, _to, _amount);
 
         // Look for the emit of the `Mint` event
         vm.expectEmit(address(optimismSuperchainERC20));
@@ -202,7 +202,7 @@ contract OptimismSuperchainERC20Test is Test {
 
         // Look for the emit of the `Transfer` event
         vm.expectEmit(address(optimismSuperchainERC20));
-        emit IERC20Solady.Transfer(_from, ZERO_ADDRESS, _amount);
+        emit IERC20.Transfer(_from, ZERO_ADDRESS, _amount);
 
         // Look for the emit of the `Burn` event
         vm.expectEmit(address(optimismSuperchainERC20));
@@ -302,7 +302,7 @@ contract OptimismSuperchainERC20Test is Test {
         deal(address(optimismSuperchainERC20), _owner, _amount);
 
         vm.expectEmit(address(optimismSuperchainERC20));
-        emit IERC20Solady.Transfer(_owner, _recipient, _amount);
+        emit IERC20.Transfer(_owner, _recipient, _amount);
 
         // Act
         vm.prank(Preinstalls.Permit2);

--- a/packages/contracts-bedrock/test/L2/SuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainERC20.t.sol
@@ -6,7 +6,7 @@ import { Test } from "forge-std/Test.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
-import { IERC20Solady } from "src/vendor/interfaces/IERC20Solady.sol";
+import { IERC20Solady as IERC20 } from "src/vendor/interfaces/IERC20Solady.sol";
 
 // Target contract
 import { SuperchainERC20 } from "src/L2/SuperchainERC20.sol";
@@ -58,7 +58,7 @@ contract SuperchainERC20Test is Test {
 
         // Look for the emit of the `Transfer` event
         vm.expectEmit(address(superchainERC20));
-        emit IERC20Solady.Transfer(ZERO_ADDRESS, _to, _amount);
+        emit IERC20.Transfer(ZERO_ADDRESS, _to, _amount);
 
         // Look for the emit of the `CrosschainMinted` event
         vm.expectEmit(address(superchainERC20));
@@ -101,7 +101,7 @@ contract SuperchainERC20Test is Test {
 
         // Look for the emit of the `Transfer` event
         vm.expectEmit(address(superchainERC20));
-        emit IERC20Solady.Transfer(_from, ZERO_ADDRESS, _amount);
+        emit IERC20.Transfer(_from, ZERO_ADDRESS, _amount);
 
         // Look for the emit of the `CrosschainBurnt` event
         vm.expectEmit(address(superchainERC20));


### PR DESCRIPTION
Addressing https://github.com/ethereum-optimism/optimism/pull/12476#discussion_r1805670385

`just test` and `just pre-pr` have already been executed and passed