### PR TITLE
chore: zero dependencies check

### DIFF
--- a/packages/contracts-bedrock/snapshots/abi/SuperchainConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SuperchainConfig.json
@@ -278,6 +278,11 @@
   },
   {
     "inputs": [],
+    "name": "ChainAlreadyHasDependencies",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "Unauthorized",
     "type": "error"
   }

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -44,8 +44,8 @@
     "sourceCodeHash": "0x26b7450f991fe197a94861cf618df04feb695dbbba884ffe93f96defa63e5bd7"
   },
   "src/L1/SuperchainConfig.sol": {
-    "initCodeHash": "0x14e3ce78307d6709b29199de4380620003cbfe311a56b201ab2767c17e9e2091",
-    "sourceCodeHash": "0xff091439483e0669cf39c27d16ad0ef6c624d28829d079fe2c5c2c836a2db748"
+    "initCodeHash": "0x5cd6b119f03beea59e2ba29ea92694e6e5cbcbb1a83a02557ffbe332ce687ab6",
+    "sourceCodeHash": "0x1e191c7746b936427b8391c68a42b542eab0821c005a4a6a517bbe855278cced"
   },
   "src/L1/SystemConfig.sol": {
     "initCodeHash": "0x0eda38e2fb2687a324289f04ec8ad0d2afe51f45219d074740fb4a0e24ea6569",

--- a/packages/contracts-bedrock/src/L1/interfaces/ISuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/interfaces/ISuperchainConfig.sol
@@ -15,8 +15,9 @@ interface ISuperchainConfig is IDependencySet {
     event Unpaused();
     event ChainAdded(uint256 indexed chainId, address indexed systemConfig, address indexed portal);
 
-    error ChainAlreadyAdded();
     error Unauthorized();
+    error ChainAlreadyHasDependencies();
+    error ChainAlreadyAdded();
 
     function GUARDIAN_SLOT() external view returns (bytes32);
     function PAUSED_SLOT() external view returns (bytes32);

--- a/packages/contracts-bedrock/test/L1/LiquidityMigrator.t.sol
+++ b/packages/contracts-bedrock/test/L1/LiquidityMigrator.t.sol
@@ -10,6 +10,7 @@ contract LiquidityMigratorTest is CommonTest {
     LiquidityMigrator public migrator;
 
     function setUp() public virtual override {
+        super.enableInterop();
         super.setUp();
         migrator = new LiquidityMigrator(address(sharedLockbox));
     }

--- a/packages/contracts-bedrock/test/L1/SharedLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/SharedLockbox.t.sol
@@ -18,6 +18,11 @@ contract SharedLockboxTest is CommonTest {
 
     event PortalAuthorized(address indexed portal);
 
+    function setUp() public virtual override {
+        super.enableInterop();
+        super.setUp();
+    }
+
     /// @notice Tests it reverts when the caller is not an authorized portal.
     function test_lockETH_unauthorizedPortal_reverts(address _caller) public {
         vm.assume(!sharedLockbox.authorizedPortals(_caller));

--- a/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
@@ -242,12 +242,16 @@ contract SuperchainConfig_AddChain_Test is CommonTest {
         superchainConfigForTest.forTest_addChainAndSystemConfig(chainIdTwo, systemConfigTwo);
         superchainConfigForTest.forTest_addChainAndSystemConfig(chainIdThree, systemConfigThree);
 
+        // Mock and expect the call to `dependencyCounter` to return 0 for the new chain
+        _mockAndExpect(
+            address(systemConfig),
+            abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector),
+            abi.encode(0)
+        );
+
         // Mock and expect the calls when looping through the first chain of the dependency set
         _mockAndExpect(
             systemConfigOne, abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, _chainId), ""
-        );
-        _mockAndExpect(
-            systemConfigOne, abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector), abi.encode(0)
         );
         _mockAndExpect(
             address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, chainIdOne), ""
@@ -258,18 +262,12 @@ contract SuperchainConfig_AddChain_Test is CommonTest {
             systemConfigTwo, abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, _chainId), ""
         );
         _mockAndExpect(
-            systemConfigTwo, abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector), abi.encode(0)
-        );
-        _mockAndExpect(
             address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, chainIdTwo), ""
         );
 
         // Mock and expect the calls when looping through the third chain of the dependency set
         _mockAndExpect(
             systemConfigThree, abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, _chainId), ""
-        );
-        _mockAndExpect(
-            systemConfigThree, abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector), abi.encode(0)
         );
         _mockAndExpect(
             address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, chainIdThree), ""

--- a/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
@@ -154,11 +154,11 @@ contract SuperchainConfig_AddChain_Test is CommonTest {
     /// @notice Tests that `addChain` reverts when the input chain already contains dependencies on its set.
     function test_addChain_alreadyHasDependencies_reverts(uint256 _chainId, address _systemConfig) external {
         // Mock the number of dependencies to be greater than 0.
-        uint256 _numberOfDependencies = 1;
+        uint256 numberOfDependencies = 1;
         _mockAndExpect(
             _systemConfig,
             abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector),
-            abi.encode(_numberOfDependencies)
+            abi.encode(numberOfDependencies)
         );
 
         vm.startPrank(superchainConfig.guardian());

--- a/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
@@ -151,6 +151,21 @@ contract SuperchainConfig_AddChain_Test is CommonTest {
         superchainConfig.addChain(_chainId, _systemConfig);
     }
 
+    /// @notice Tests that `addChain` reverts when the input chain already contains dependencies on its set.
+    function test_addChain_alreadyHasDependencies_reverts(uint256 _chainId, address _systemConfig) external {
+        // Mock the number of dependencies to be greater than 0.
+        uint256 _numberOfDependencies = 1;
+        _mockAndExpect(
+            _systemConfig,
+            abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector),
+            abi.encode(_numberOfDependencies)
+        );
+
+        vm.startPrank(superchainConfig.guardian());
+        vm.expectRevert(ISuperchainConfig.ChainAlreadyHasDependencies.selector);
+        superchainConfig.addChain(_chainId, _systemConfig);
+    }
+
     /// @notice Tests that `addChain` reverts when the chain is already in the dependency set.
     function test_addChain_chainAlreadyExists_reverts(uint256 _chainId, address _systemConfig) external {
         SuperchainConfigForTest superchainConfig = new SuperchainConfigForTest(address(sharedLockbox));

--- a/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
@@ -137,6 +137,11 @@ contract SuperchainConfig_Unpause_Test is CommonTest {
 contract SuperchainConfig_AddChain_Test is CommonTest {
     event ChainAdded(uint256 indexed chainId, address indexed systemConfig, address indexed portal);
 
+    function setUp() public virtual override {
+        super.enableInterop();
+        super.setUp();
+    }
+
     function _mockAndExpect(address _target, bytes memory _calldata, bytes memory _returnData) internal {
         vm.mockCall(_target, _calldata, _returnData);
         vm.expectCall(_target, _calldata);
@@ -171,6 +176,11 @@ contract SuperchainConfig_AddChain_Test is CommonTest {
         SuperchainConfigForTest superchainConfig = new SuperchainConfigForTest(address(sharedLockbox));
         superchainConfig.forTest_addChainOnDependencySet(_chainId);
 
+        // Mock the call over `dependencyCounter` to return 0 and avoid a previous revert
+        _mockAndExpect(
+            _systemConfig, abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector), abi.encode(0)
+        );
+
         vm.startPrank(superchainConfig.guardian());
         vm.expectRevert(SuperchainConfig.ChainAlreadyAdded.selector);
         superchainConfig.addChain(_chainId, _systemConfig);
@@ -190,9 +200,7 @@ contract SuperchainConfig_AddChain_Test is CommonTest {
         vm.expectCall(address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.optimismPortal.selector));
 
         // Mock and expect the call to authorize the portal on the SharedLockbox with the `_portal` address
-        _mockAndExpect(
-            address(sharedLockbox), abi.encodeWithSelector(ISharedLockbox.authorizePortal.selector, _portal), ""
-        );
+        vm.expectCall(address(sharedLockbox), abi.encodeWithSelector(ISharedLockbox.authorizePortal.selector, _portal));
 
         // Expect the `addDependency` function call to not be called since the dependency set is empty
         uint64 zeroCalls = 0;
@@ -239,6 +247,9 @@ contract SuperchainConfig_AddChain_Test is CommonTest {
             systemConfigOne, abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, _chainId), ""
         );
         _mockAndExpect(
+            systemConfigOne, abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector), abi.encode(0)
+        );
+        _mockAndExpect(
             address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, chainIdOne), ""
         );
 
@@ -247,12 +258,18 @@ contract SuperchainConfig_AddChain_Test is CommonTest {
             systemConfigTwo, abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, _chainId), ""
         );
         _mockAndExpect(
+            systemConfigTwo, abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector), abi.encode(0)
+        );
+        _mockAndExpect(
             address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, chainIdTwo), ""
         );
 
         // Mock and expect the calls when looping through the third chain of the dependency set
         _mockAndExpect(
             systemConfigThree, abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, _chainId), ""
+        );
+        _mockAndExpect(
+            systemConfigThree, abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector), abi.encode(0)
         );
         _mockAndExpect(
             address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, chainIdThree), ""


### PR DESCRIPTION
* Added check
* Enabled interop on tests and removed unnecessary mocks over contracts deployed on the testing suite setup.

CLOSES OPT-559