### PR TITLE
refactor: change params order

### DIFF
--- a/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
@@ -53,15 +53,15 @@ interface IL2ToL2CrossDomainMessenger {
     /// @param target       Target contract or wallet address.
     /// @param messageNonce Nonce associated with the message sent
     /// @param sender       Address initiating this message call
-    /// @param message      Message payload to call target with.
     /// @param entrypoint   Address of the entrypoint on the destination chain.
+    /// @param message      Message payload to call target with.
     event SentMessage(
         uint256 indexed destination,
         address indexed target,
         uint256 indexed messageNonce,
         address sender,
-        bytes message,
-        address entrypoint
+        address entrypoint,
+        bytes message
     );
 
     /// @notice Emitted whenever a message is successfully relayed on this chain.
@@ -104,15 +104,15 @@ interface IL2ToL2CrossDomainMessenger {
     ///         `relayMessage` for successful relaying.
     /// @param _destination Chain ID of the destination chain.
     /// @param _target      Target contract or wallet address.
-    /// @param _message     Message payload to call target with.
     /// @param _entrypoint  Address of the entrypoint on the destination chain. If it is address(0) then the
     ///                     message can be relayed by any address on the destination chain.
+    /// @param _message     Message payload to call target with.
     /// @return The hash of the message being sent, used to track whether the message has successfully been relayed.
     function sendMessage(
         uint256 _destination,
         address _target,
-        bytes calldata _message,
-        address _entrypoint
+        address _entrypoint,
+        bytes calldata _message
     )
         external
         returns (bytes32);

--- a/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
+++ b/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
@@ -130,11 +130,6 @@
         "internalType": "bytes",
         "name": "_message",
         "type": "bytes"
-      },
-      {
-        "internalType": "address",
-        "name": "_entrypoint",
-        "type": "address"
       }
     ],
     "name": "sendMessage",
@@ -158,6 +153,11 @@
       {
         "internalType": "address",
         "name": "_target",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_entrypoint",
         "type": "address"
       },
       {
@@ -263,15 +263,15 @@
       },
       {
         "indexed": false,
-        "internalType": "bytes",
-        "name": "message",
-        "type": "bytes"
-      },
-      {
-        "indexed": false,
         "internalType": "address",
         "name": "entrypoint",
         "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "message",
+        "type": "bytes"
       }
     ],
     "name": "SentMessage",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -100,8 +100,8 @@
     "sourceCodeHash": "0xaef8ea36c5b78cd12e0e62811d51db627ccf0dfd2cc5479fb707a10ef0d42048"
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol": {
-    "initCodeHash": "0xeae09cf9c04e4edfa7bcb1282d1f2d0ed753fc24f122ab51b4ca9fd6c5230d2f",
-    "sourceCodeHash": "0x5f1452f6c299e4589fbb4ad7a2d96e7497724630888d7f17dfdc6297af5e8b64"
+    "initCodeHash": "0xce538694aa7471738330a247e09e6b36a2702bc36b4b58c01dbf819cd3ab393c",
+    "sourceCodeHash": "0xfabbf852a0886e59595435c5d6b7e8b09ad5c743cc6bdf7fbac9ffe2d08e17ec"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
     "initCodeHash": "0xdac32a1057a6bc8a8d2ffdce1db8f34950cd0ffd1454d2133865736d21869192",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -100,8 +100,8 @@
     "sourceCodeHash": "0xaef8ea36c5b78cd12e0e62811d51db627ccf0dfd2cc5479fb707a10ef0d42048"
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol": {
-    "initCodeHash": "0xce538694aa7471738330a247e09e6b36a2702bc36b4b58c01dbf819cd3ab393c",
-    "sourceCodeHash": "0xfabbf852a0886e59595435c5d6b7e8b09ad5c743cc6bdf7fbac9ffe2d08e17ec"
+    "initCodeHash": "0x18c5491bf03bff26d6166fbae7305f46bdf723db13faa46e7cb59b43d523357d",
+    "sourceCodeHash": "0xae2bfa1fc28912d40d87f3ce3be772c56c987372d0a2f8d17780d96ff26fc6f5"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
     "initCodeHash": "0xdac32a1057a6bc8a8d2ffdce1db8f34950cd0ffd1454d2133865736d21869192",

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -75,8 +75,8 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     uint16 public constant messageVersion = uint16(0);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.15
-    string public constant version = "1.0.0-beta.15";
+    /// @custom:semver 1.0.0-beta.14
+    string public constant version = "1.0.0-beta.14";
 
     /// @notice Mapping of message hashes to boolean receipt values. Note that a message will only be present in this
     ///         mapping if it has successfully been relayed on this chain, and can therefore not be relayed again.

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -75,8 +75,8 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     uint16 public constant messageVersion = uint16(0);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.14
-    string public constant version = "1.0.0-beta.14";
+    /// @custom:semver 1.0.0-beta.15
+    string public constant version = "1.0.0-beta.15";
 
     /// @notice Mapping of message hashes to boolean receipt values. Note that a message will only be present in this
     ///         mapping if it has successfully been relayed on this chain, and can therefore not be relayed again.

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -206,6 +206,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
 
         // Call the sendMessage function with value to provoke revert
         // NOTE: using encodeWithSignature to target the correct overloaded function signature
+        // nosemgrep: sol-style-use-abi-encodecall
         (bool success,) = address(l2ToL2CrossDomainMessenger).call{ value: _value }(
             abi.encodeWithSignature("sendMessage(uint256, address, bytes)", _destination, _target, _message)
         );
@@ -291,6 +292,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         );
 
         // Ensure the CrossL2Inbox validates this message
+        // nosemgrep: sol-style-use-abi-encodecall
         vm.mockCall({
             callee: Predeploys.CROSS_L2_INBOX,
             data: abi.encodeCall(ICrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -123,7 +123,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         assertEq(logs[0].topics[3], bytes32(messageNonce));
 
         // data
-        assertEq(logs[0].data, abi.encode(address(this), _message, address(0)));
+        assertEq(logs[0].data, abi.encode(address(this), address(0), _message));
 
         // Check that the message nonce has been incremented
         assertEq(l2ToL2CrossDomainMessenger.messageNonce(), messageNonce + 1);
@@ -158,7 +158,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         vm.recordLogs();
 
         // Call the sendMessage function
-        bytes32 msgHash = l2ToL2CrossDomainMessenger.sendMessage(_destination, _target, _message, _entrypoint);
+        bytes32 msgHash = l2ToL2CrossDomainMessenger.sendMessage(_destination, _target, _entrypoint, _message);
         assertEq(
             msgHash,
             Hashing.hashL2toL2CrossDomainMessage(
@@ -177,7 +177,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         assertEq(logs[0].topics[3], bytes32(messageNonce));
 
         // data
-        assertEq(logs[0].data, abi.encode(address(this), _message, _entrypoint));
+        assertEq(logs[0].data, abi.encode(address(this), _entrypoint, _message));
 
         // Check that the message nonce has been incremented
         assertEq(l2ToL2CrossDomainMessenger.messageNonce(), messageNonce + 1);
@@ -287,7 +287,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
             Identifier(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, _blockNum, _logIndex, _time, _source);
         bytes memory sentMessage = abi.encodePacked(
             abi.encode(L2ToL2CrossDomainMessenger.SentMessage.selector, block.chainid, _target, _nonce), // topics
-            abi.encode(_sender, _message, address(_entrypoint)) // data
+            abi.encode(_sender, address(_entrypoint), _message) // data
         );
 
         // Ensure the CrossL2Inbox validates this message
@@ -361,7 +361,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
             Identifier(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, _blockNum, _logIndex, _time, _source);
         bytes memory sentMessage = abi.encodePacked(
             abi.encode(L2ToL2CrossDomainMessenger.SentMessage.selector, block.chainid, _target, _nonce), // topics
-            abi.encode(_sender, _message, address(0)) // data
+            abi.encode(_sender, address(0), _message) // data
         );
 
         // Ensure the CrossL2Inbox validates this message
@@ -414,7 +414,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
             Identifier(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, _blockNum, _logIndex, _time, _source);
         bytes memory sentMessage = abi.encodePacked(
             abi.encode(L2ToL2CrossDomainMessenger.SentMessage.selector, block.chainid, _target, _nonce), // topics
-            abi.encode(_sender, _message, _entrypoint) // data
+            abi.encode(_sender, _entrypoint, _message) // data
         );
 
         // Ensure the CrossL2Inbox validates this message
@@ -517,7 +517,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
             Identifier(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, _blockNum, _logIndex, _time, _source);
         bytes memory sentMessage = abi.encodePacked(
             abi.encode(L2ToL2CrossDomainMessenger.SentMessage.selector, block.chainid, target, _nonce), // topics
-            abi.encode(_sender, message, address(0)) // data
+            abi.encode(_sender, address(0), message) // data
         );
 
         // Ensure the CrossL2Inbox validates this message
@@ -559,7 +559,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         Identifier memory id = Identifier(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, 1, 1, 1, _source);
         bytes memory sentMessage = abi.encodePacked(
             abi.encode(L2ToL2CrossDomainMessenger.SentMessage.selector, block.chainid, address(0), _nonce), // topics
-            abi.encode(_sender, "") // data
+            abi.encode(_sender, address(0), "") // data
         );
 
         l2ToL2CrossDomainMessenger.relayMessage(id, sentMessage);
@@ -598,7 +598,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
             Identifier(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, _blockNum, _logIndex, _time, _source1);
         bytes memory sentMessage = abi.encodePacked(
             abi.encode(L2ToL2CrossDomainMessenger.SentMessage.selector, block.chainid, target, _nonce), // topics
-            abi.encode(_sender1, message, address(0)) // data
+            abi.encode(_sender1, address(0), message) // data
         );
 
         // Ensure the CrossL2Inbox validates this message
@@ -647,7 +647,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         Identifier memory id = Identifier(_origin, _blockNum, _logIndex, _time, _source);
         bytes memory sentMessage = abi.encodePacked(
             abi.encode(L2ToL2CrossDomainMessenger.SentMessage.selector, block.chainid, _target, _nonce), // topics
-            abi.encode(_sender, _message) // data
+            abi.encode(_sender, address(0), _message) // data
         );
 
         // Call
@@ -680,7 +680,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
             Identifier(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, _blockNum, _logIndex, _time, _source);
         bytes memory sentMessage = abi.encodePacked(
             abi.encode(L2ToL2CrossDomainMessenger.SentMessage.selector, _destination, _target, _nonce), // topics
-            abi.encode(_sender, _message) // data
+            abi.encode(_sender, address(0), _message) // data
         );
 
         // Ensure the CrossL2Inbox validates this message
@@ -719,7 +719,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
             abi.encode(
                 L2ToL2CrossDomainMessenger.SentMessage.selector, block.chainid, Predeploys.CROSS_L2_INBOX, _nonce
             ), // topics
-            abi.encode(_sender, _message) // data
+            abi.encode(_sender, address(0), _message) // data
         );
 
         // Ensure the CrossL2Inbox validates this message
@@ -761,7 +761,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
                 Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER,
                 _nonce
             ), // topics
-            abi.encode(_sender, _message) // data
+            abi.encode(_sender, address(0), _message) // data
         );
 
         // Ensure the CrossL2Inbox validates this message
@@ -811,7 +811,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
             Identifier(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, _blockNum, _logIndex, _time, _source);
         bytes memory sentMessage = abi.encodePacked(
             abi.encode(L2ToL2CrossDomainMessenger.SentMessage.selector, block.chainid, _target, _nonce), // topics
-            abi.encode(_sender, _message, address(0)) // data
+            abi.encode(_sender, address(0), _message) // data
         );
 
         // Ensure the CrossL2Inbox validates this message
@@ -861,7 +861,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
             Identifier(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, _blockNum, _logIndex, _time, _source);
         bytes memory sentMessage = abi.encodePacked(
             abi.encode(L2ToL2CrossDomainMessenger.SentMessage.selector, block.chainid, _target, _nonce), // topics
-            abi.encode(_sender, _message, address(0)) // data
+            abi.encode(_sender, address(0), _message) // data
         );
 
         // Ensure the CrossL2Inbox validates this message

--- a/packages/contracts-bedrock/test/L2/SuperchainTokenBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainTokenBridge.t.sol
@@ -121,6 +121,7 @@ contract SuperchainTokenBridgeTest is CommonTest {
         // Mock the call over the `sendMessage` function and expect it to be called properly
         bytes memory _message =
             abi.encodeCall(superchainTokenBridge.relayERC20, (address(superchainERC20), _sender, _to, _amount));
+        // nosemgrep: sol-style-use-abi-encodecall
         _mockAndExpect(
             Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER,
             abi.encodeWithSignature(

--- a/packages/contracts-bedrock/test/L2/SuperchainWETH.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainWETH.t.sol
@@ -525,6 +525,7 @@ contract SuperchainWETH_Test is CommonTest {
 
         // Mock the call over the `sendMessage` function and expect it to be called properly
         bytes memory _message = abi.encodeCall(superchainWeth.relayETH, (_sender, _to, _amount));
+        // nosemgrep: sol-style-use-abi-encodecall
         _mockAndExpect(
             Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER,
             abi.encodeWithSignature("sendMessage(uint256,address,bytes)", _chainId, address(superchainWeth), _message),


### PR DESCRIPTION
Changes the params order for the `sendMessage` functions and event such that dynamic types are at the end. Also updates the `SentMessage` event and its corresponding selector.