### PR TITLE
feat: dependency set refactor

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/ISuperchainConfig.sol
+++ b/packages/contracts-bedrock/interfaces/L1/ISuperchainConfig.sol
@@ -13,26 +13,27 @@ interface ISuperchainConfig is IDependencySet {
     event Initialized(uint8 version);
     event Paused(string identifier);
     event Unpaused();
-    event ChainAdded(uint256 indexed chainId, address indexed systemConfig, address indexed portal);
+    event DependencyAdded(uint256 indexed chainId, address indexed systemConfig, address indexed portal);
 
     error Unauthorized();
-    error ChainAlreadyHasDependencies();
-    error ChainAlreadyAdded();
+    error DependencySetTooLarge();
+    error InvalidChainID();
+    error DependencyAlreadyAdded();
 
     function GUARDIAN_SLOT() external view returns (bytes32);
     function PAUSED_SLOT() external view returns (bytes32);
-    function UPGRADER_SLOT() external view returns (bytes32);
+    function DEPENDENCY_MANAGER_SLOT() external view returns (bytes32);
     function SHARED_LOCKBOX() external view returns (ISharedLockbox);
     function guardian() external view returns (address guardian_);
-    function systemConfigs(uint256) external view returns (address);
-    function upgrader() external view returns (address upgrader_);
-    function initialize(address _guardian, address _upgrader, bool _paused) external;
+    function dependencyManager() external view returns (address dependencyManager_);
+    function initialize(address _guardian, address _dependencyManager, bool _paused) external;
     function pause(string memory _identifier) external;
     function paused() external view returns (bool paused_);
     function unpause() external;
     function version() external view returns (string memory);
-    function addChain(uint256 _chainId, address _systemConfig) external;
+    function addDependency(uint256 _chainId, address _systemConfig) external;
     function dependencySet() external view returns (uint256[] memory);
+    function dependencySetSize() external view returns (uint8);
 
     function __constructor__(address _sharedLockbox) external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/ISystemConfigInterop.sol
+++ b/packages/contracts-bedrock/interfaces/L1/ISystemConfigInterop.sol
@@ -53,9 +53,6 @@ interface ISystemConfigInterop {
     function transferOwnership(address newOwner) external; // nosemgrep
     function unsafeBlockSigner() external view returns (address addr_);
 
-    function addDependency(uint256 _chainId) external;
-    function removeDependency(uint256 _chainId) external;
-    function dependencyCounter() external view returns (uint256);
     function initialize(
         address _owner,
         uint32 _basefeeScalar,
@@ -69,7 +66,6 @@ interface ISystemConfigInterop {
     )
         external;
     function version() external pure returns (string memory);
-    function SUPERCHAIN_CONFIG() external view returns (address);
 
-    function __constructor__(address _superchainConfig) external;
+    function __constructor__() external;
 }

--- a/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol
+++ b/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol
@@ -26,9 +26,6 @@ interface ICrossL2Inbox {
     /// @notice Thrown when trying to execute a cross chain message with an invalid Identifier timestamp.
     error InvalidTimestamp();
 
-    /// @notice Thrown when trying to execute a cross chain message with an invalid Identifier chain ID.
-    error InvalidChainId();
-
     /// @notice Thrown when trying to execute a cross chain message and the target call fails.
     error TargetCallFailed();
 

--- a/packages/contracts-bedrock/interfaces/L2/IL1BlockInterop.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL1BlockInterop.sol
@@ -2,21 +2,13 @@
 pragma solidity ^0.8.0;
 
 enum ConfigType {
-    SET_GAS_PAYING_TOKEN,
-    ADD_DEPENDENCY,
-    REMOVE_DEPENDENCY
+    SET_GAS_PAYING_TOKEN
 }
 
 interface IL1BlockInterop {
-    error AlreadyDependency();
-    error CantRemovedDependency();
-    error DependencySetSizeTooLarge();
     error NotCrossL2Inbox();
-    error NotDependency();
     error NotDepositor();
 
-    event DependencyAdded(uint256 indexed chainId);
-    event DependencyRemoved(uint256 indexed chainId);
     event GasPayingTokenSet(address indexed token, uint8 indexed decimals, bytes32 name, bytes32 symbol);
 
     function DEPOSITOR_ACCOUNT() external pure returns (address addr_);
@@ -25,7 +17,6 @@ interface IL1BlockInterop {
     function batcherHash() external view returns (bytes32);
     function blobBaseFee() external view returns (uint256);
     function blobBaseFeeScalar() external view returns (uint32);
-    function dependencySetSize() external view returns (uint8);
     function depositsComplete() external;
     function gasPayingToken() external view returns (address addr_, uint8 decimals_);
     function gasPayingTokenName() external view returns (string memory name_);
@@ -33,7 +24,6 @@ interface IL1BlockInterop {
     function hash() external view returns (bytes32);
     function isCustomGasToken() external view returns (bool);
     function isDeposit() external view returns (bool isDeposit_);
-    function isInDependencySet(uint256 _chainId) external view returns (bool);
     function l1FeeOverhead() external view returns (uint256);
     function l1FeeScalar() external view returns (uint256);
     function number() external view returns (uint64);

--- a/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
@@ -42,9 +42,6 @@ interface IL2ToL2CrossDomainMessenger {
     /// @notice Thrown when a call to the target contract during message relay fails.
     error TargetCallFailed();
 
-    /// @notice Thrown when attempting to use a chain ID that is not in the dependency set.
-    error InvalidChainId();
-
     /// @notice Emitted whenever a message is sent to a destination
     /// @param destination  Chain ID of the destination chain.
     /// @param target       Target contract or wallet address.

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -144,7 +144,6 @@ library ChainAssertions {
     /// @notice Asserts that the SystemConfigInterop is setup correctly
     function checkSystemConfigInterop(
         Types.ContractSet memory _contracts,
-        Types.ContractSet memory _proxies,
         DeployConfig _cfg,
         bool _isProxy
     )
@@ -152,7 +151,6 @@ library ChainAssertions {
         view
     {
         ISystemConfigInterop config = ISystemConfigInterop(_contracts.SystemConfig);
-        ISuperchainConfig superchainConfig = ISuperchainConfig(_proxies.SuperchainConfig);
 
         console.log(
             "Running chain assertions on the SystemConfigInterop %s at %s",
@@ -161,9 +159,6 @@ library ChainAssertions {
         );
 
         checkSystemConfig(_contracts, _cfg, _isProxy);
-
-        require(config.dependencyCounter() == 0, "CHECK-SCFGI-10");
-        require(config.SUPERCHAIN_CONFIG() == address(superchainConfig), "CHECK-SCFGI-20");
     }
 
     /// @notice Asserts that the L1CrossDomainMessenger is setup correctly

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -394,13 +394,7 @@ contract Deploy is Deployer {
             _oracle: IPreimageOracle(address(dio.preimageOracleSingleton()))
         });
         if (_isInterop) {
-            Types.ContractSet memory proxies = _proxies();
-            ChainAssertions.checkSystemConfigInterop({
-                _contracts: contracts,
-                _proxies: proxies,
-                _cfg: cfg,
-                _isProxy: false
-            });
+            ChainAssertions.checkSystemConfigInterop({ _contracts: contracts, _cfg: cfg, _isProxy: false });
         } else {
             ChainAssertions.checkSystemConfig({ _contracts: contracts, _cfg: cfg, _isProxy: false });
         }

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -990,14 +990,11 @@ contract DeployImplementationsInterop is DeployImplementations {
         if (existingImplementation != address(0)) {
             impl = ISystemConfigInterop(existingImplementation);
         } else {
-            address superchainConfig = address(_dii.superchainConfigProxy());
             vm.broadcast(msg.sender);
             impl = ISystemConfigInterop(
                 DeployUtils.create1({
                     _name: "SystemConfigInterop",
-                    _args: DeployUtils.encodeConstructor(
-                        abi.encodeCall(ISystemConfigInterop.__constructor__, (superchainConfig))
-                    )
+                    _args: DeployUtils.encodeConstructor(abi.encodeCall(ISystemConfigInterop.__constructor__, ()))
                 })
             );
         }

--- a/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
@@ -482,7 +482,7 @@ contract DeploySuperchain is Script {
         ISuperchainConfig superchainConfigProxy;
         {
             address guardian = _dsi.guardian();
-            address upgrader = _dsi.superchainProxyAdminOwner();
+            address dependencyManager = _dsi.superchainProxyAdminOwner();
             bool paused = _dsi.paused();
 
             vm.startBroadcast(msg.sender);
@@ -497,7 +497,7 @@ contract DeploySuperchain is Script {
             superchainProxyAdmin.upgradeAndCall(
                 payable(address(superchainConfigProxy)),
                 address(_dso.superchainConfigImpl()),
-                abi.encodeCall(ISuperchainConfig.initialize, (guardian, upgrader, paused))
+                abi.encodeCall(ISuperchainConfig.initialize, (guardian, dependencyManager, paused))
             );
             vm.stopBroadcast();
         }

--- a/packages/contracts-bedrock/scripts/deploy/ManageDependencies.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ManageDependencies.s.sol
@@ -47,17 +47,18 @@ contract ManageDependenciesInput is BaseDeployIO {
 }
 
 contract ManageDependencies is Script {
+    // TODO: Fix dependency management since SystemConfig does not handle them anymore
     function run(ManageDependenciesInput _input) public {
-        bool remove = _input.remove();
-        uint256 chainId = _input.chainId();
-        ISystemConfigInterop systemConfig = _input.systemConfig();
+        // bool remove = _input.remove();
+        // uint256 chainId = _input.chainId();
+        // ISystemConfigInterop systemConfig = _input.systemConfig();
 
-        // Call the appropriate function based on the remove flag
-        vm.broadcast(msg.sender);
-        if (remove) {
-            systemConfig.removeDependency(chainId);
-        } else {
-            systemConfig.addDependency(chainId);
-        }
+        // // Call the appropriate function based on the remove flag
+        // vm.broadcast(msg.sender);
+        // if (remove) {
+        //     systemConfig.removeDependency(chainId);
+        // } else {
+        //     systemConfig.addDependency(chainId);
+        // }
     }
 }

--- a/packages/contracts-bedrock/snapshots/.gas-snapshot
+++ b/packages/contracts-bedrock/snapshots/.gas-snapshot
@@ -1,6 +1,6 @@
 GasBenchMark_L1BlockInterop_DepositsComplete:test_depositsComplete_benchmark() (gas: 7589)
 GasBenchMark_L1BlockInterop_DepositsComplete_Warm:test_depositsComplete_benchmark() (gas: 5589)
-GasBenchMark_L1BlockInterop_SetValuesInterop:test_setL1BlockValuesInterop_benchmark() (gas: 175722)
+GasBenchMark_L1BlockInterop_SetValuesInterop:test_setL1BlockValuesInterop_benchmark() (gas: 175700)
 GasBenchMark_L1BlockInterop_SetValuesInterop_Warm:test_setL1BlockValuesInterop_benchmark() (gas: 5144)
 GasBenchMark_L1Block_SetValuesEcotone:test_setL1BlockValuesEcotone_benchmark() (gas: 158553)
 GasBenchMark_L1Block_SetValuesEcotone_Warm:test_setL1BlockValuesEcotone_benchmark() (gas: 7619)

--- a/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
+++ b/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
@@ -245,11 +245,6 @@
   },
   {
     "inputs": [],
-    "name": "InvalidChainId",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "InvalidTimestamp",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/abi/L1BlockInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/L1BlockInterop.json
@@ -79,19 +79,6 @@
   },
   {
     "inputs": [],
-    "name": "dependencySetSize",
-    "outputs": [
-      {
-        "internalType": "uint8",
-        "name": "",
-        "type": "uint8"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "depositsComplete",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -174,25 +161,6 @@
       {
         "internalType": "bool",
         "name": "isDeposit_",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_chainId",
-        "type": "uint256"
-      }
-    ],
-    "name": "isInDependencySet",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
         "type": "bool"
       }
     ],
@@ -390,32 +358,6 @@
     "inputs": [
       {
         "indexed": true,
-        "internalType": "uint256",
-        "name": "chainId",
-        "type": "uint256"
-      }
-    ],
-    "name": "DependencyAdded",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "chainId",
-        "type": "uint256"
-      }
-    ],
-    "name": "DependencyRemoved",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
         "internalType": "address",
         "name": "token",
         "type": "address"
@@ -444,27 +386,7 @@
   },
   {
     "inputs": [],
-    "name": "AlreadyDependency",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "CantRemovedDependency",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "DependencySetSizeTooLarge",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "NotCrossL2Inbox",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "NotDependency",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
+++ b/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
@@ -255,11 +255,6 @@
   },
   {
     "inputs": [],
-    "name": "InvalidChainId",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "MessageAlreadyRelayed",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/abi/SuperchainConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SuperchainConfig.json
@@ -12,6 +12,19 @@
   },
   {
     "inputs": [],
+    "name": "DEPENDENCY_MANAGER_SLOT",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "GUARDIAN_SLOT",
     "outputs": [
       {
@@ -50,19 +63,6 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "UPGRADER_SLOT",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -75,9 +75,22 @@
         "type": "address"
       }
     ],
-    "name": "addChain",
+    "name": "addDependency",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "dependencyManager",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "dependencyManager_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -88,6 +101,19 @@
         "internalType": "uint256[]",
         "name": "",
         "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "dependencySetSize",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
       }
     ],
     "stateMutability": "view",
@@ -115,7 +141,7 @@
       },
       {
         "internalType": "address",
-        "name": "_upgrader",
+        "name": "_dependencyManager",
         "type": "address"
       },
       {
@@ -175,42 +201,10 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "systemConfigs",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [],
     "name": "unpause",
     "outputs": [],
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "upgrader",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "upgrader_",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -225,6 +219,25 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "enum SuperchainConfig.UpdateType",
+        "name": "updateType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "ConfigUpdate",
+    "type": "event"
   },
   {
     "anonymous": false,
@@ -248,26 +261,7 @@
         "type": "address"
       }
     ],
-    "name": "ChainAdded",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "enum SuperchainConfig.UpdateType",
-        "name": "updateType",
-        "type": "uint8"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "data",
-        "type": "bytes"
-      }
-    ],
-    "name": "ConfigUpdate",
+    "name": "DependencyAdded",
     "type": "event"
   },
   {
@@ -304,12 +298,17 @@
   },
   {
     "inputs": [],
-    "name": "ChainAlreadyAdded",
+    "name": "DependencyAlreadyAdded",
     "type": "error"
   },
   {
     "inputs": [],
-    "name": "ChainAlreadyHasDependencies",
+    "name": "DependencySetTooLarge",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidChainID",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfigInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfigInterop.json
@@ -1,16 +1,5 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_superchainConfig",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
     "inputs": [],
     "name": "BATCH_INBOX_SLOT",
     "outputs": [
@@ -116,19 +105,6 @@
   },
   {
     "inputs": [],
-    "name": "SUPERCHAIN_CONFIG",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "UNSAFE_BLOCK_SIGNER_SLOT",
     "outputs": [
       {
@@ -151,19 +127,6 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_chainId",
-        "type": "uint256"
-      }
-    ],
-    "name": "addDependency",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -213,19 +176,6 @@
         "internalType": "uint32",
         "name": "",
         "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "dependencyCounter",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -577,19 +527,6 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_chainId",
-        "type": "uint256"
-      }
-    ],
-    "name": "removeDependency",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,7 +36,7 @@
     "sourceCodeHash": "0xa0f411c08b04df19153908c8d459af0a708adba5062d3efa74c0398998b68a07"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0xd122f99c1d0ae0377063169b15ad4755a675f9752d9039cae6862d356d7df3f8",
+    "initCodeHash": "0x2099718fceba959f621b2905fa27e67c2c9940da3d4c0c4b9996a57901e925ad",
     "sourceCodeHash": "0xae2fbe02c0f8685692babeed0252ae8a624dc6d3bfb082fc3807d7b84869004b"
   },
   "src/L1/ProtocolVersions.sol": {
@@ -48,24 +48,24 @@
     "sourceCodeHash": "0xbc1e6321e241f18175c2c3c0cf898490a31ebe0dbaced1213c59621cdafd63c2"
   },
   "src/L1/SuperchainConfig.sol": {
-    "initCodeHash": "0x291c5a1696d6eb2a7d53f59a547d642ed6b41a4977d1e995375dfcb758151055",
-    "sourceCodeHash": "0x60fef6bd049c7ec6527d87319a12790561924f7d4355c5e2c3f5b06227b63b8e"
+    "initCodeHash": "0x358d0b58ec3749fd7c61543548225bc7a946e8ddcac61d74ba8bf76337a28ed4",
+    "sourceCodeHash": "0x84fb331967603bf12c5c70c77b710fbef1764907a8a770157249b56ef8105bd8"
   },
   "src/L1/SystemConfig.sol": {
     "initCodeHash": "0x11707ca5ef2bfc0da82e945cb97e62226852d850e8bdecb8ec22fc1ab7967894",
     "sourceCodeHash": "0x71cedc36b538c3db2ac43d1d9554583a3f09eee9e9a5c5d39608418bd466ee0e"
   },
   "src/L1/SystemConfigInterop.sol": {
-    "initCodeHash": "0xd03b97cd34c51d95e246678303f6f870ef39495af39d888915cbd31bf58cc5e3",
-    "sourceCodeHash": "0x49636aeaaf48925cf6dcfce6f55f4949fc35a9c873faed1fbd30ded1841a4da1"
+    "initCodeHash": "0x5f38dcfe71010dd69f3079dacc28a9caa05b6d95d1ec37085cc0ae0d064c21b6",
+    "sourceCodeHash": "0x76df63273dfaf52595241904680db0e52b55f34cfbe17a658bbd453a701f4fc2"
   },
   "src/L2/BaseFeeVault.sol": {
     "initCodeHash": "0xc403d4c555d8e69a2699e01d192ae7327136701fa02da10a6d75a584b3c364c9",
     "sourceCodeHash": "0xfa56426153227e798150f6becc30a33fd20a3c6e0d73c797a3922dd631acbb57"
   },
   "src/L2/CrossL2Inbox.sol": {
-    "initCodeHash": "0x7a189f6dff6c19ec6f1e94d84a0d9d98a320a68812f957e50bf8b63224bb0dce",
-    "sourceCodeHash": "0x9bbfabb19b7f572dadae797786c2f87d892693650151bd8de6eadee3e03fc559"
+    "initCodeHash": "0x12c325f9898460dc42f54febcfe312a4a92d6b78b78586f54c7be9ae8d5b39be",
+    "sourceCodeHash": "0x205252627db9b225f61aae249293a7a20d90797e53a378ed8df7b1323cffbed4"
   },
   "src/L2/ETHLiquidity.sol": {
     "initCodeHash": "0xbb16de6a3f678db7301694a000f315154f25f9660c8dcec4b0bef20bc7cfdebd",
@@ -80,8 +80,8 @@
     "sourceCodeHash": "0xffb6cf768097b2d6cb6ecb2d6463c176af9acd70415aa0d2e4f017758f737eee"
   },
   "src/L2/L1BlockInterop.sol": {
-    "initCodeHash": "0x67e99306d9a09cac587f65cfa2c0de55da9eca184fd1fc3f4b885d2c47114483",
-    "sourceCodeHash": "0x9493f90136917fc95d2ac942f061c1b9cffeff6d327afb46fe4e69784e7f2100"
+    "initCodeHash": "0xacc0a2e9c11b1288bdf46b26c90845c832c2728890982b54faa8a9f1af1c2142",
+    "sourceCodeHash": "0x2baa99123043382a3c1e85e7c9109afbd84a4b16a5d2e0daf9c8cbbb7d8cf9c1"
   },
   "src/L2/L1FeeVault.sol": {
     "initCodeHash": "0x6745b7be3895a5e8d373df0066d931bae29c47672ac46c2f5829bd0052cc6d9e",
@@ -108,8 +108,8 @@
     "sourceCodeHash": "0xaef8ea36c5b78cd12e0e62811d51db627ccf0dfd2cc5479fb707a10ef0d42048"
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol": {
-    "initCodeHash": "0xc56db8cb569efa0467fd53ab3fa218af3051e54f5517d7fafb7b5831b4350618",
-    "sourceCodeHash": "0x72062343a044e9c56f4143dcfc71706286eb205902006c2afcf6a4cd90c3e9f8"
+    "initCodeHash": "0x115a00cfd2432d8b230302ec9a22f611ec23420aecd4b35d3d1d42041db820a9",
+    "sourceCodeHash": "0x9b653a71e0af65f86aa730cf889b881b2ceddcdf5c94df1064c92d4e13e3dd4a"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
     "initCodeHash": "0xdac32a1057a6bc8a8d2ffdce1db8f34950cd0ffd1454d2133865736d21869192",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -65,7 +65,7 @@
   },
   "src/L2/CrossL2Inbox.sol": {
     "initCodeHash": "0x12c325f9898460dc42f54febcfe312a4a92d6b78b78586f54c7be9ae8d5b39be",
-    "sourceCodeHash": "0x205252627db9b225f61aae249293a7a20d90797e53a378ed8df7b1323cffbed4"
+    "sourceCodeHash": "0xec115e27a78d76a47d8fbb6454d049a5f8314fe0283a4a9cbd44f286388cb0f0"
   },
   "src/L2/ETHLiquidity.sol": {
     "initCodeHash": "0xbb16de6a3f678db7301694a000f315154f25f9660c8dcec4b0bef20bc7cfdebd",
@@ -109,7 +109,7 @@
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol": {
     "initCodeHash": "0x115a00cfd2432d8b230302ec9a22f611ec23420aecd4b35d3d1d42041db820a9",
-    "sourceCodeHash": "0x9b653a71e0af65f86aa730cf889b881b2ceddcdf5c94df1064c92d4e13e3dd4a"
+    "sourceCodeHash": "0x067e879cd1acf2348e0729dd02395c064d24cf4571fdeade8bc2eefd8accec87"
   },
   "src/L2/OptimismSuperchainERC20.sol": {
     "initCodeHash": "0xdac32a1057a6bc8a8d2ffdce1db8f34950cd0ffd1454d2133865736d21869192",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -49,15 +49,15 @@
   },
   "src/L1/SuperchainConfig.sol": {
     "initCodeHash": "0x358d0b58ec3749fd7c61543548225bc7a946e8ddcac61d74ba8bf76337a28ed4",
-    "sourceCodeHash": "0x84fb331967603bf12c5c70c77b710fbef1764907a8a770157249b56ef8105bd8"
+    "sourceCodeHash": "0x53b5514e15c386abcd5209763e9454f257ab88972c59ac777eb7511beb2fa1bd"
   },
   "src/L1/SystemConfig.sol": {
     "initCodeHash": "0x11707ca5ef2bfc0da82e945cb97e62226852d850e8bdecb8ec22fc1ab7967894",
     "sourceCodeHash": "0x71cedc36b538c3db2ac43d1d9554583a3f09eee9e9a5c5d39608418bd466ee0e"
   },
   "src/L1/SystemConfigInterop.sol": {
-    "initCodeHash": "0x5f38dcfe71010dd69f3079dacc28a9caa05b6d95d1ec37085cc0ae0d064c21b6",
-    "sourceCodeHash": "0x76df63273dfaf52595241904680db0e52b55f34cfbe17a658bbd453a701f4fc2"
+    "initCodeHash": "0x62b10d18c8bc51f694a9705e62df1c4ec2260500b5cd159e613efe2f623ed38c",
+    "sourceCodeHash": "0x61d2430c8d8aa83c0b941ade9e13c59af74feb78152addb37452d1da8a332d1d"
   },
   "src/L2/BaseFeeVault.sol": {
     "initCodeHash": "0xc403d4c555d8e69a2699e01d192ae7327136701fa02da10a6d75a584b3c364c9",

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1BlockInterop.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1BlockInterop.json
@@ -75,12 +75,5 @@
     "offset": 0,
     "slot": "7",
     "type": "uint256"
-  },
-  {
-    "bytes": "64",
-    "label": "dependencySet",
-    "offset": 0,
-    "slot": "8",
-    "type": "struct EnumerableSet.UintSet"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/SuperchainConfig.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/SuperchainConfig.json
@@ -14,17 +14,10 @@
     "type": "bool"
   },
   {
-    "bytes": "32",
-    "label": "systemConfigs",
-    "offset": 0,
-    "slot": "1",
-    "type": "mapping(uint256 => address)"
-  },
-  {
     "bytes": "64",
     "label": "_dependencySet",
     "offset": 0,
-    "slot": "2",
+    "slot": "1",
     "type": "struct EnumerableSet.UintSet"
   }
 ]

--- a/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
@@ -8,7 +8,7 @@ import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable
 import { Storage } from "src/libraries/Storage.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { Unauthorized } from "src/libraries/errors/CommonErrors.sol";
-import { ISystemConfigInterop } from "interfaces/L1/ISystemConfigInterop.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { ISharedLockbox } from "interfaces/L1/ISharedLockbox.sol";
 
 // Interfaces
@@ -23,10 +23,10 @@ contract SuperchainConfig is Initializable, ISemver {
 
     /// @notice Enum representing different types of updates.
     /// @custom:value GUARDIAN            Represents an update to the guardian.
-    /// @custom:value UPGRADER            Represents an update to the upgrader.
+    /// @custom:value DEPENDENCY_MANAGER  Represents an update to the dependency manager.
     enum UpdateType {
         GUARDIAN,
-        UPGRADER
+        DEPENDENCY_MANAGER
     }
 
     /// @notice Whether or not the Superchain is paused.
@@ -36,9 +36,10 @@ contract SuperchainConfig is Initializable, ISemver {
     ///         It can only be modified by an upgrade.
     bytes32 public constant GUARDIAN_SLOT = bytes32(uint256(keccak256("superchainConfig.guardian")) - 1);
 
-    /// @notice The address of the upgrader, which can add a chain to the dependency set.
+    /// @notice The address of the dependency manager, which can add a chain to the dependency set.
     ///         It can only be modified by an upgrade.
-    bytes32 public constant UPGRADER_SLOT = bytes32(uint256(keccak256("superchainConfig.upgrader")) - 1);
+    bytes32 public constant DEPENDENCY_MANAGER_SLOT =
+        bytes32(uint256(keccak256("superchainConfig.dependencyManager")) - 1);
 
     // The Shared Lockbox contract
     ISharedLockbox public immutable SHARED_LOCKBOX;
@@ -55,24 +56,24 @@ contract SuperchainConfig is Initializable, ISemver {
     /// @param data       Encoded update data.
     event ConfigUpdate(UpdateType indexed updateType, bytes data);
 
-    /// @notice Emitted when a new chain is added as part of the dependency set.
+    /// @notice Emitted when a new dependency is added as part of the dependency set.
     /// @param chainId      The chain ID.
     /// @param systemConfig The address of the SystemConfig contract.
     /// @param portal       The address of the OptimismPortal contract.
-    event ChainAdded(uint256 indexed chainId, address indexed systemConfig, address indexed portal);
+    event DependencyAdded(uint256 indexed chainId, address indexed systemConfig, address indexed portal);
 
-    /// @notice Thrown when the input chain's system config already contains dependencies on its set.
-    error ChainAlreadyHasDependencies();
+    /// @notice Thrown when the dependency set is too large to add a new dependency.
+    error DependencySetTooLarge();
+
+    /// @notice Thrown when the input chain ID is the same as the current chain ID.
+    error InvalidChainID();
 
     /// @notice Thrown when the input chain is already added to the dependency set.
-    error ChainAlreadyAdded();
+    error DependencyAlreadyAdded();
 
     /// @notice Semantic version.
     /// @custom:semver 1.1.1-beta.5
     string public constant version = "1.1.1-beta.5";
-
-    // Mapping from chainId to SystemConfig address
-    mapping(uint256 => address) public systemConfigs;
 
     // Dependency set of chains that are part of the same cluster
     EnumerableSet.UintSet internal _dependencySet;
@@ -84,12 +85,12 @@ contract SuperchainConfig is Initializable, ISemver {
     }
 
     /// @notice Initializer.
-    /// @param _guardian    Address of the guardian, can pause the OptimismPortal.
-    /// @param _upgrader    Address of the upgrader, can add a chain to the dependency set.
-    /// @param _paused      Initial paused status.
-    function initialize(address _guardian, address _upgrader, bool _paused) external initializer {
+    /// @param _guardian             Address of the guardian, can pause the OptimismPortal.
+    /// @param _dependencyManager    Address of the dependencyManager, can add a chain to the dependency set.
+    /// @param _paused               Initial paused status.
+    function initialize(address _guardian, address _dependencyManager, bool _paused) external initializer {
         _setGuardian(_guardian);
-        _setUpgrader(_upgrader);
+        _setDependencyManager(_dependencyManager);
         if (_paused) {
             _pause("Initializer paused");
         }
@@ -100,9 +101,9 @@ contract SuperchainConfig is Initializable, ISemver {
         guardian_ = Storage.getAddress(GUARDIAN_SLOT);
     }
 
-    /// @notice Getter for the upgrader address.
-    function upgrader() public view returns (address upgrader_) {
-        upgrader_ = Storage.getAddress(UPGRADER_SLOT);
+    /// @notice Getter for the dependency manager address.
+    function dependencyManager() public view returns (address dependencyManager_) {
+        dependencyManager_ = Storage.getAddress(DEPENDENCY_MANAGER_SLOT);
     }
 
     /// @notice Getter for the current paused status.
@@ -139,45 +140,32 @@ contract SuperchainConfig is Initializable, ISemver {
         emit ConfigUpdate(UpdateType.GUARDIAN, abi.encode(_guardian));
     }
 
-    /// @notice Sets the upgrader address. This is only callable during initialization, so an upgrade
-    ///         will be required to change the upgrader.
-    /// @param _upgrader The new upgrader address.
-    function _setUpgrader(address _upgrader) internal {
-        Storage.setAddress(UPGRADER_SLOT, _upgrader);
-        emit ConfigUpdate(UpdateType.UPGRADER, abi.encode(_upgrader));
+    /// @notice Sets the dependency manager address. This is only callable during initialization, so an upgrade
+    ///         will be required to change the dependency manager.
+    /// @param _dependencyManager The new dependency manager address.
+    function _setDependencyManager(address _dependencyManager) internal {
+        Storage.setAddress(DEPENDENCY_MANAGER_SLOT, _dependencyManager);
+        emit ConfigUpdate(UpdateType.DEPENDENCY_MANAGER, abi.encode(_dependencyManager));
     }
 
-    /// @notice Adds a new chain to the dependency set.
-    ///         Adds the new chain as a dependency for all existing chains in the dependency set, and vice versa. It
-    ///         also stores the SystemConfig address of it, and authorizes the OptimismPortal on the SharedLockbox.
-    /// @param _chainId     The chain ID.
-    /// @param _systemConfig The SystemConfig contract address of the chain to add.
-    function addChain(uint256 _chainId, address _systemConfig) external {
-        if (msg.sender != upgrader()) revert Unauthorized();
-        if (ISystemConfigInterop(_systemConfig).dependencyCounter() != 0) revert ChainAlreadyHasDependencies();
+    /// @notice Adds a new dependency to the dependency set. It also authorizes it's OptimismPortal on the
+    ///         SharedLockbox. Can only be called by the dependency manager.
+    /// @param _chainId         The chain ID.
+    /// @param _systemConfig    The SystemConfig contract address of the chain to add.
+    function addDependency(uint256 _chainId, address _systemConfig) external {
+        if (msg.sender != dependencyManager()) revert Unauthorized();
+
+        if (_dependencySet.length() == type(uint8).max) revert DependencySetTooLarge();
+        if (_chainId == block.chainid) revert InvalidChainID();
 
         // Add to the dependency set and check it is not already added (`add()` returns false if it already exists)
-        if (!_dependencySet.add(_chainId)) revert ChainAlreadyAdded();
-
-        systemConfigs[_chainId] = _systemConfig;
-
-        // Loop through the dependency set and update the dependency for each chain. Using length - 1 to exclude the
-        // current chain from the loop.
-        for (uint256 i; i < _dependencySet.length() - 1; i++) {
-            uint256 currentId = _dependencySet.at(i);
-
-            // Add the new chain as dependency for the current chain on the loop
-            ISystemConfigInterop(systemConfigs[currentId]).addDependency(_chainId);
-
-            // Add the current chain on the loop as dependency for the new chain
-            ISystemConfigInterop(_systemConfig).addDependency(currentId);
-        }
+        if (!_dependencySet.add(_chainId)) revert DependencyAlreadyAdded();
 
         // Authorize the portal on the shared lockbox
-        address portal = ISystemConfigInterop(_systemConfig).optimismPortal();
+        address portal = ISystemConfig(_systemConfig).optimismPortal();
         SHARED_LOCKBOX.authorizePortal(portal);
 
-        emit ChainAdded(_chainId, _systemConfig, portal);
+        emit DependencyAdded(_chainId, _systemConfig, portal);
     }
 
     /// @notice Checks if a chain is part or not of the dependency set.
@@ -189,5 +177,11 @@ contract SuperchainConfig is Initializable, ISemver {
     /// @notice Getter for the chain ids list on the dependency set.
     function dependencySet() external view returns (uint256[] memory) {
         return _dependencySet.values();
+    }
+
+    /// @notice Returns the size of the dependency set.
+    /// @return The size of the dependency set.
+    function dependencySetSize() external view returns (uint8) {
+        return uint8(_dependencySet.length());
     }
 }

--- a/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
@@ -68,7 +68,7 @@ contract SuperchainConfig is Initializable, ISemver {
     /// @notice Thrown when the input chain ID is the same as the current chain ID.
     error InvalidChainID();
 
-    /// @notice Thrown when the input chain is already added to the dependency set.
+    /// @notice Thrown when the input dependency is already added to the set.
     error DependencyAlreadyAdded();
 
     /// @notice Semantic version.

--- a/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
@@ -20,9 +20,9 @@ import { ConfigType } from "interfaces/L2/IL1BlockInterop.sol";
 ///         All configuration is stored on L1 and picked up by L2 as part of the derviation of
 ///         the L2 chain.
 contract SystemConfigInterop is SystemConfig {
-    /// @custom:semver +interop-beta.8
+    /// @custom:semver +interop-beta.9
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.8");
+        return string.concat(super.version(), "+interop-beta.9");
     }
 
     /// @notice Internal setter for the gas paying token address, includes validation.

--- a/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfigInterop.sol
@@ -9,7 +9,6 @@ import { SystemConfig } from "src/L1/SystemConfig.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { GasPayingToken } from "src/libraries/GasPayingToken.sol";
 import { StaticConfig } from "src/libraries/StaticConfig.sol";
-import { Storage } from "src/libraries/Storage.sol";
 
 // Interfaces
 import { IOptimismPortalInterop as IOptimismPortal } from "interfaces/L1/IOptimismPortalInterop.sol";
@@ -21,23 +20,9 @@ import { ConfigType } from "interfaces/L2/IL1BlockInterop.sol";
 ///         All configuration is stored on L1 and picked up by L2 as part of the derviation of
 ///         the L2 chain.
 contract SystemConfigInterop is SystemConfig {
-    /// @notice Storage slot where the dependency counter is stored
-    /// @dev    Equal to bytes32(uint256(keccak256("systemconfig.dependencyCounter")) - 1)
-    bytes32 internal constant DEPENDENCY_COUNTER_SLOT =
-        0x4ae776ed628fe5cb57f351f2986b1f5aee6fda3f6ec83fa6166e8098945adb19;
-
-    /// @notice The address of the SuperchainConfig contract.
-    address public immutable SUPERCHAIN_CONFIG;
-
     /// @custom:semver +interop-beta.8
     function version() public pure override returns (string memory) {
         return string.concat(super.version(), "+interop-beta.8");
-    }
-
-    /// @notice Constructs the SystemConfig contract.
-    /// @param _superchainConfig The address of the SuperchainConfig contract.
-    constructor(address _superchainConfig) {
-        SUPERCHAIN_CONFIG = _superchainConfig;
     }
 
     /// @notice Internal setter for the gas paying token address, includes validation.
@@ -67,34 +52,5 @@ contract SystemConfigInterop is SystemConfig {
                 })
             );
         }
-    }
-
-    /// @notice Adds a chain to the interop dependency set. Can only be called by the SuperchainConfig.
-    /// @param _chainId Chain ID of chain to add.
-    function addDependency(uint256 _chainId) external {
-        require(msg.sender == SUPERCHAIN_CONFIG, "SystemConfig: caller is not the SuperchainConfig");
-
-        Storage.setUint(DEPENDENCY_COUNTER_SLOT, dependencyCounter() + 1);
-
-        IOptimismPortal(payable(optimismPortal())).setConfig(
-            ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(_chainId)
-        );
-    }
-
-    /// @notice Removes a chain from the interop dependency set. Can only be called by the SuperchainConfig
-    /// @param _chainId Chain ID of the chain to remove.
-    function removeDependency(uint256 _chainId) external {
-        require(msg.sender == SUPERCHAIN_CONFIG, "SystemConfig: caller is not the SuperchainConfig");
-
-        Storage.setUint(DEPENDENCY_COUNTER_SLOT, dependencyCounter() - 1);
-
-        IOptimismPortal(payable(optimismPortal())).setConfig(
-            ConfigType.REMOVE_DEPENDENCY, StaticConfig.encodeRemoveDependency(_chainId)
-        );
-    }
-
-    /// @notice getter for the dependency counter
-    function dependencyCounter() public view returns (uint256) {
-        return Storage.getUint(DEPENDENCY_COUNTER_SLOT);
     }
 }

--- a/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
@@ -8,7 +8,6 @@ import { SafeCall } from "src/libraries/SafeCall.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
-import { IDependencySet } from "interfaces/L2/IDependencySet.sol";
 import { IL1BlockInterop } from "interfaces/L2/IL1BlockInterop.sol";
 
 /// @notice Thrown when the caller is not DEPOSITOR_ACCOUNT when calling `setInteropStart()`
@@ -22,9 +21,6 @@ error NotEntered();
 
 /// @notice Thrown when trying to execute a cross chain message with an invalid Identifier timestamp.
 error InvalidTimestamp();
-
-/// @notice Thrown when trying to execute a cross chain message with an invalid Identifier chain ID.
-error InvalidChainId();
 
 /// @notice Thrown when trying to execute a cross chain message and the target call fails.
 error TargetCallFailed();
@@ -76,8 +72,8 @@ contract CrossL2Inbox is ISemver, TransientReentrancyAware {
     address internal constant DEPOSITOR_ACCOUNT = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.11
-    string public constant version = "1.0.0-beta.11";
+    /// @custom:semver 1.0.0-beta.12
+    string public constant version = "1.0.0-beta.12";
 
     /// @notice Emitted when a cross chain message is being executed.
     /// @param msgHash Hash of message payload being executed.
@@ -190,9 +186,6 @@ contract CrossL2Inbox is ISemver, TransientReentrancyAware {
     /// @param _id Identifier of the message.
     function _checkIdentifier(Identifier calldata _id) internal view {
         if (_id.timestamp > block.timestamp || _id.timestamp <= interopStart()) revert InvalidTimestamp();
-        if (!IDependencySet(Predeploys.L1_BLOCK_ATTRIBUTES).isInDependencySet(_id.chainId)) {
-            revert InvalidChainId();
-        }
     }
 
     /// @notice Stores the Identifier in transient storage.

--- a/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
@@ -180,9 +180,8 @@ contract CrossL2Inbox is ISemver, TransientReentrancyAware {
         emit ExecutingMessage(_msgHash, _id);
     }
 
-    /// @notice Validates that for a given cross chain message identifier,
-    ///         it's timestamp is not in the future and the source chainId
-    ///         is in the destination chain's dependency set.
+    /// @notice Validates that for a given cross chain message identifier
+    ///         it's timestamp is not in the future.
     /// @param _id Identifier of the message.
     function _checkIdentifier(Identifier calldata _id) internal view {
         if (_id.timestamp > block.timestamp || _id.timestamp <= interopStart()) revert InvalidTimestamp();

--- a/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
+++ b/packages/contracts-bedrock/src/L2/L1BlockInterop.sol
@@ -5,27 +5,15 @@ pragma solidity 0.8.15;
 import { L1Block } from "src/L2/L1Block.sol";
 
 // Libraries
-import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { GasPayingToken } from "src/libraries/GasPayingToken.sol";
 import { StaticConfig } from "src/libraries/StaticConfig.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
-import {
-    NotDepositor,
-    NotCrossL2Inbox,
-    NotDependency,
-    DependencySetSizeTooLarge,
-    AlreadyDependency,
-    CantRemovedDependency
-} from "src/libraries/L1BlockErrors.sol";
+import { NotDepositor, NotCrossL2Inbox } from "src/libraries/L1BlockErrors.sol";
 
 /// @notice Enum representing different types of configurations that can be set on L1BlockInterop.
 /// @custom:value SET_GAS_PAYING_TOKEN  Represents the config type for setting the gas paying token.
-/// @custom:value ADD_DEPENDENCY        Represents the config type for adding a chain to the interop dependency set.
-/// @custom:value REMOVE_DEPENDENCY     Represents the config type for removing a chain from the interop dependency set.
 enum ConfigType {
-    SET_GAS_PAYING_TOKEN,
-    ADD_DEPENDENCY,
-    REMOVE_DEPENDENCY
+    SET_GAS_PAYING_TOKEN
 }
 
 /// @custom:proxied true
@@ -33,25 +21,14 @@ enum ConfigType {
 /// @title L1BlockInterop
 /// @notice Interop extenstions of L1Block.
 contract L1BlockInterop is L1Block {
-    using EnumerableSet for EnumerableSet.UintSet;
-
-    /// @notice Event emitted when a new dependency is added to the interop dependency set.
-    event DependencyAdded(uint256 indexed chainId);
-
-    /// @notice Event emitted when a dependency is removed from the interop dependency set.
-    event DependencyRemoved(uint256 indexed chainId);
-
-    /// @notice The interop dependency set, containing the chain IDs in it.
-    EnumerableSet.UintSet dependencySet;
-
     /// @notice Storage slot that the isDeposit is stored at.
     ///         This is a custom slot that is not part of the standard storage layout.
     /// keccak256(abi.encode(uint256(keccak256("l1Block.identifier.isDeposit")) - 1)) & ~bytes32(uint256(0xff))
     uint256 internal constant IS_DEPOSIT_SLOT = 0x921bd3a089295c6e5540e8fba8195448d253efd6f2e3e495b499b627dc36a300;
 
-    /// @custom:semver +interop-beta.3
+    /// @custom:semver +interop-beta.4
     function version() public pure override returns (string memory) {
-        return string.concat(super.version(), "+interop-beta.3");
+        return string.concat(super.version(), "+interop-beta.4");
     }
 
     /// @notice Returns whether the call was triggered from a a deposit or not.
@@ -61,20 +38,6 @@ contract L1BlockInterop is L1Block {
         assembly {
             isDeposit_ := sload(IS_DEPOSIT_SLOT)
         }
-    }
-
-    /// @notice Returns true if a chain ID is in the interop dependency set and false otherwise.
-    ///         The chain's chain ID is always considered to be in the dependency set.
-    /// @param _chainId The chain ID to check.
-    /// @return True if the chain ID to check is in the interop dependency set. False otherwise.
-    function isInDependencySet(uint256 _chainId) public view returns (bool) {
-        return _chainId == block.chainid || dependencySet.contains(_chainId);
-    }
-
-    /// @notice Returns the size of the interop dependency set.
-    /// @return The size of the interop dependency set.
-    function dependencySetSize() external view returns (uint8) {
-        return uint8(dependencySet.length());
     }
 
     /// @notice Updates the `isDeposit` flag and sets the L1 block values for an Interop upgraded chain.
@@ -109,10 +72,6 @@ contract L1BlockInterop is L1Block {
 
         if (_type == ConfigType.SET_GAS_PAYING_TOKEN) {
             _setGasPayingToken(_value);
-        } else if (_type == ConfigType.ADD_DEPENDENCY) {
-            _addDependency(_value);
-        } else if (_type == ConfigType.REMOVE_DEPENDENCY) {
-            _removeDependency(_value);
         }
     }
 
@@ -124,29 +83,5 @@ contract L1BlockInterop is L1Block {
         GasPayingToken.set({ _token: token, _decimals: decimals, _name: name, _symbol: symbol });
 
         emit GasPayingTokenSet({ token: token, decimals: decimals, name: name, symbol: symbol });
-    }
-
-    /// @notice Internal method to add a dependency to the interop dependency set.
-    /// @param _value The encoded value with which to add the dependency.
-    function _addDependency(bytes calldata _value) internal {
-        uint256 chainId = StaticConfig.decodeAddDependency(_value);
-
-        if (dependencySet.length() == type(uint8).max) revert DependencySetSizeTooLarge();
-
-        if (chainId == block.chainid || !dependencySet.add(chainId)) revert AlreadyDependency();
-
-        emit DependencyAdded(chainId);
-    }
-
-    /// @notice Internal method to remove a dependency from the interop dependency set.
-    /// @param _value The encoded value with which to remove the dependency.
-    function _removeDependency(bytes calldata _value) internal {
-        uint256 chainId = StaticConfig.decodeRemoveDependency(_value);
-
-        if (chainId == block.chainid) revert CantRemovedDependency();
-
-        if (!dependencySet.remove(chainId)) revert NotDependency();
-
-        emit DependencyRemoved(chainId);
     }
 }

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -9,7 +9,6 @@ import { TransientReentrancyAware } from "src/libraries/TransientContext.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
-import { IDependencySet } from "interfaces/L2/IDependencySet.sol";
 import { ICrossL2Inbox, Identifier } from "interfaces/L2/ICrossL2Inbox.sol";
 
 /// @notice Thrown when a non-written slot in transient storage is attempted to be read from.
@@ -71,8 +70,8 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     uint16 public constant messageVersion = uint16(0);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.14
-    string public constant version = "1.0.0-beta.14";
+    /// @custom:semver 1.0.0-beta.15
+    string public constant version = "1.0.0-beta.15";
 
     /// @notice Mapping of message hashes to boolean receipt values. Note that a message will only be present in this
     ///         mapping if it has successfully been relayed on this chain, and can therefore not be relayed again.
@@ -136,7 +135,6 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
         if (_destination == block.chainid) revert MessageDestinationSameChain();
         if (_target == Predeploys.CROSS_L2_INBOX) revert MessageTargetCrossL2Inbox();
         if (_target == Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER) revert MessageTargetL2ToL2CrossDomainMessenger();
-        if (!IDependencySet(Predeploys.L1_BLOCK_ATTRIBUTES).isInDependencySet(_destination)) revert InvalidChainId();
 
         uint256 nonce = messageNonce();
         emit SentMessage(_destination, _target, nonce, msg.sender, _message);

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -41,9 +41,6 @@ error ReentrantCall();
 /// @notice Thrown when a call to the target contract during message relay fails.
 error TargetCallFailed();
 
-/// @notice Thrown when attempting to use a chain ID that is not in the dependency set.
-error InvalidChainId();
-
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000023
 /// @title L2ToL2CrossDomainMessenger

--- a/packages/contracts-bedrock/src/libraries/L1BlockErrors.sol
+++ b/packages/contracts-bedrock/src/libraries/L1BlockErrors.sol
@@ -6,15 +6,3 @@ error NotDepositor();
 
 /// @notice Error when a non-cross L2 Inbox sender tries to call the `isDeposit()` method.
 error NotCrossL2Inbox();
-
-/// @notice Error when a chain ID is not in the interop dependency set.
-error NotDependency();
-
-/// @notice Error when the interop dependency set size is too large.
-error DependencySetSizeTooLarge();
-
-/// @notice Error when a chain ID already in the interop dependency set is attempted to be added.
-error AlreadyDependency();
-
-/// @notice Error when the chain's chain ID is attempted to be removed from the interop dependency set.
-error CantRemovedDependency();

--- a/packages/contracts-bedrock/test/L1/OptimismPortalInterop.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortalInterop.t.sol
@@ -44,52 +44,6 @@ contract OptimismPortalInterop_Test is CommonTest {
         _optimismPortalInterop().setConfig(ConfigType.SET_GAS_PAYING_TOKEN, _value);
     }
 
-    /// @dev Tests that the config for adding a dependency can be set.
-    function testFuzz_setConfig_addDependency_succeeds(bytes calldata _value) public {
-        vm.expectEmit(address(optimismPortal));
-        emitTransactionDeposited({
-            _from: Constants.DEPOSITOR_ACCOUNT,
-            _to: Predeploys.L1_BLOCK_ATTRIBUTES,
-            _value: 0,
-            _mint: 0,
-            _gasLimit: 200_000,
-            _isCreation: false,
-            _data: abi.encodeCall(IL1BlockInterop.setConfig, (ConfigType.ADD_DEPENDENCY, _value))
-        });
-
-        vm.prank(address(_optimismPortalInterop().systemConfig()));
-        _optimismPortalInterop().setConfig(ConfigType.ADD_DEPENDENCY, _value);
-    }
-
-    /// @dev Tests that setting the add dependency config as not the system config reverts.
-    function testFuzz_setConfig_addDependencyButNotSystemConfig_reverts(bytes calldata _value) public {
-        vm.expectRevert(Unauthorized.selector);
-        _optimismPortalInterop().setConfig(ConfigType.ADD_DEPENDENCY, _value);
-    }
-
-    /// @dev Tests that the config for removing a dependency can be set.
-    function testFuzz_setConfig_removeDependency_succeeds(bytes calldata _value) public {
-        vm.expectEmit(address(optimismPortal));
-        emitTransactionDeposited({
-            _from: Constants.DEPOSITOR_ACCOUNT,
-            _to: Predeploys.L1_BLOCK_ATTRIBUTES,
-            _value: 0,
-            _mint: 0,
-            _gasLimit: 200_000,
-            _isCreation: false,
-            _data: abi.encodeCall(IL1BlockInterop.setConfig, (ConfigType.REMOVE_DEPENDENCY, _value))
-        });
-
-        vm.prank(address(_optimismPortalInterop().systemConfig()));
-        _optimismPortalInterop().setConfig(ConfigType.REMOVE_DEPENDENCY, _value);
-    }
-
-    /// @dev Tests that setting the remove dependency config as not the system config reverts.
-    function testFuzz_setConfig_removeDependencyButNotSystemConfig_reverts(bytes calldata _value) public {
-        vm.expectRevert(Unauthorized.selector);
-        _optimismPortalInterop().setConfig(ConfigType.REMOVE_DEPENDENCY, _value);
-    }
-
     /// @dev Returns the OptimismPortalInterop instance.
     function _optimismPortalInterop() internal view returns (IOptimismPortalInterop) {
         return IOptimismPortalInterop(payable(address(optimismPortal)));

--- a/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
@@ -149,6 +149,34 @@ contract SuperchainConfig_AddDependency_Test is CommonTest {
         superchainConfig.addDependency(_chainId, _systemConfig);
     }
 
+    /// @notice Tests that `addDependency` reverts when the dependency set is too large.
+    function test_addDependency_dependencySetTooLarge_reverts() external {
+        vm.startPrank(superchainConfig.dependencyManager());
+
+        // Add the maximum number of dependencies to the dependency set
+        uint256 i;
+        for (i; i < type(uint8).max; i++) {
+            superchainConfig.addDependency(i, address(systemConfig));
+        }
+
+        // Check that the dependency set is full and that expect the next call to revert
+        assertEq(superchainConfig.dependencySetSize(), type(uint8).max);
+        vm.expectRevert(SuperchainConfig.DependencySetTooLarge.selector);
+
+        // Try to add another dependency to the dependency set
+        uint256 chainId = i + 1;
+        superchainConfig.addDependency(chainId, address(systemConfig));
+
+        vm.stopPrank();
+    }
+
+    /// @notice Tests that `addDependency` reverts when the chain ID is the same as the current chain ID.
+    function test_addDependency_sameChainID_reverts() external {
+        vm.prank(superchainConfig.dependencyManager());
+        vm.expectRevert(SuperchainConfig.InvalidChainID.selector);
+        superchainConfig.addDependency(block.chainid, address(systemConfig));
+    }
+
     /// @notice Tests that `addDependency` reverts when the chain is already in the dependency set.
     function test_addDependency_chainAlreadyExists_reverts(uint256 _chainId) external {
         vm.assume(_chainId != block.chainid);
@@ -159,30 +187,6 @@ contract SuperchainConfig_AddDependency_Test is CommonTest {
         vm.expectRevert(SuperchainConfig.DependencyAlreadyAdded.selector);
         superchainConfig.addDependency(_chainId, address(systemConfig));
         vm.stopPrank();
-    }
-
-    /// @notice Tests that `addDependency` reverts when the dependency set is too large.
-    function test_addDependency_dependencySetTooLarge_reverts() external {
-        vm.startPrank(superchainConfig.dependencyManager());
-
-        uint256 i;
-        for (i; i < type(uint8).max; i++) {
-            superchainConfig.addDependency(i, address(systemConfig));
-        }
-
-        assertEq(superchainConfig.dependencySetSize(), type(uint8).max);
-
-        vm.expectRevert(SuperchainConfig.DependencySetTooLarge.selector);
-        superchainConfig.addDependency(i + 1, address(systemConfig));
-
-        vm.stopPrank();
-    }
-
-    /// @notice Tests that `addDependency` reverts when the chain ID is the same as the current chain ID.
-    function test_addDependency_sameChainID_reverts() external {
-        vm.prank(superchainConfig.dependencyManager());
-        vm.expectRevert(SuperchainConfig.InvalidChainID.selector);
-        superchainConfig.addDependency(block.chainid, address(systemConfig));
     }
 
     /// @notice Tests that `addDependency` successfully adds a chain to the dependency set when it is empty.
@@ -237,8 +241,7 @@ contract SuperchainConfig_DependencySet_Test is CommonTest {
 
     EnumerableSet.UintSet internal chainIds;
 
-    /// @notice Tests that the dependency set returns properly the dependencies added.
-    function test_dependencySet_succeeds(uint256[] calldata _chainIdsArray) public {
+    function _addDependencies(uint256[] calldata _chainIdsArray) internal {
         vm.assume(_chainIdsArray.length <= type(uint8).max);
 
         // Ensure there are no repeated values on the input array
@@ -254,6 +257,13 @@ contract SuperchainConfig_DependencySet_Test is CommonTest {
             superchainConfig.addDependency(chainIds.at(i), address(systemConfig));
         }
 
+        vm.stopPrank();
+    }
+
+    /// @notice Tests that the dependency set returns properly the dependencies added.
+    function test_dependencySet_succeeds(uint256[] calldata _chainIdsArray) public {
+        _addDependencies(_chainIdsArray);
+
         // Check that the dependency set has the same length as the dependencies
         uint256[] memory dependencySet = superchainConfig.dependencySet();
         assertEq(dependencySet.length, chainIds.length());
@@ -262,10 +272,13 @@ contract SuperchainConfig_DependencySet_Test is CommonTest {
         for (uint256 i; i < chainIds.length(); i++) {
             assertEq(dependencySet[i], chainIds.at(i));
         }
+    }
 
-        // Check that the dependency set size is the same as the dependencies
-        assertEq(superchainConfig.dependencySetSize(), uint8(chainIds.length()));
+    /// @notice Tests that the dependency set size returns properly the number of dependencies added.
+    function test_dependencySetSize_succeeds(uint256[] calldata _chainIdsArray) public {
+        _addDependencies(_chainIdsArray);
 
-        vm.stopPrank();
+        // Check that the dependency set has the same length as the dependencies
+        assertEq(superchainConfig.dependencySetSize(), chainIds.length());
     }
 }

--- a/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
@@ -246,8 +246,7 @@ contract SuperchainConfig_DependencySet_Test is CommonTest {
 
         // Ensure there are no repeated values on the input array
         for (uint256 i; i < _chainIdsArray.length; i++) {
-            vm.assume(_chainIdsArray[i] != block.chainid);
-            chainIds.add(_chainIdsArray[i]);
+            if (_chainIdsArray[i] != block.chainid) chainIds.add(_chainIdsArray[i]);
         }
 
         vm.startPrank(superchainConfig.dependencyManager());

--- a/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
@@ -9,33 +9,10 @@ import { Unauthorized } from "src/libraries/errors/CommonErrors.sol";
 
 // Target contract
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
-import { SuperchainConfig, ISharedLockbox, ISystemConfigInterop } from "src/L1/SuperchainConfig.sol";
+import { SuperchainConfig, ISharedLockbox, ISystemConfig } from "src/L1/SuperchainConfig.sol";
 
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-
-/// @notice For testing purposes contract, with setters to facilitate replicating complex scenarios when needed.
-contract SuperchainConfigForTest is SuperchainConfig {
-    using EnumerableSet for EnumerableSet.UintSet;
-
-    constructor(address _sharedLockbox) SuperchainConfig(_sharedLockbox) { }
-
-    function forTest_addChainOnDependencySet(uint256 _chainId) external {
-        _dependencySet.add(_chainId);
-    }
-
-    function forTest_addChainAndSystemConfig(uint256 _chainId, address _systemConfig) external {
-        _dependencySet.add(_chainId);
-        systemConfigs[_chainId] = _systemConfig;
-    }
-
-    function forTest_setUpgrader(address _upgrader) external {
-        bytes32 slot = UPGRADER_SLOT;
-        assembly {
-            sstore(slot, _upgrader)
-        }
-    }
-}
 
 contract SuperchainConfig_Init_Test is CommonTest {
     function setUp() public virtual override {
@@ -47,7 +24,7 @@ contract SuperchainConfig_Init_Test is CommonTest {
     function test_initialize_succeeds() external view {
         assertFalse(superchainConfig.paused());
         assertEq(superchainConfig.guardian(), deploy.cfg().superchainConfigGuardian());
-        assertEq(superchainConfig.upgrader(), deploy.cfg().finalSystemOwner());
+        assertEq(superchainConfig.dependencyManager(), deploy.cfg().finalSystemOwner());
     }
 
     /// @dev Tests that it can be intialized as paused.
@@ -78,7 +55,7 @@ contract SuperchainConfig_Init_Test is CommonTest {
 
         assertTrue(ISuperchainConfig(address(newProxy)).paused());
         assertEq(ISuperchainConfig(address(newProxy)).guardian(), deploy.cfg().superchainConfigGuardian());
-        assertEq(ISuperchainConfig(address(newProxy)).upgrader(), deploy.cfg().finalSystemOwner());
+        assertEq(ISuperchainConfig(address(newProxy)).dependencyManager(), deploy.cfg().finalSystemOwner());
     }
 }
 
@@ -144,8 +121,8 @@ contract SuperchainConfig_Unpause_Test is CommonTest {
     }
 }
 
-contract SuperchainConfig_AddChain_Test is CommonTest {
-    event ChainAdded(uint256 indexed chainId, address indexed systemConfig, address indexed portal);
+contract SuperchainConfig_AddDependency_Test is CommonTest {
+    event DependencyAdded(uint256 indexed chainId, address indexed systemConfig, address indexed portal);
 
     function setUp() public virtual override {
         super.enableInterop();
@@ -157,47 +134,59 @@ contract SuperchainConfig_AddChain_Test is CommonTest {
         vm.expectCall(_target, _calldata);
     }
 
-    /// @notice Tests that `addChain` reverts when called by an unauthorized address.
-    function test_addChain_unauthorized_reverts(address _caller, uint256 _chainId, address _systemConfig) external {
-        vm.assume(_caller != superchainConfig.upgrader());
+    /// @notice Tests that `addDependency` reverts when called by an unauthorized address.
+    function test_addDependency_unauthorized_reverts(
+        address _caller,
+        uint256 _chainId,
+        address _systemConfig
+    )
+        external
+    {
+        vm.assume(_caller != superchainConfig.dependencyManager());
 
         vm.expectRevert(Unauthorized.selector);
         vm.prank(_caller);
-        superchainConfig.addChain(_chainId, _systemConfig);
+        superchainConfig.addDependency(_chainId, _systemConfig);
     }
 
-    /// @notice Tests that `addChain` reverts when the input chain already contains dependencies on its set.
-    function test_addChain_alreadyHasDependencies_reverts(uint256 _chainId, address _systemConfig) external {
-        // Mock the number of dependencies to be greater than 0.
-        uint256 numberOfDependencies = 1;
-        _mockAndExpect(
-            _systemConfig,
-            abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector),
-            abi.encode(numberOfDependencies)
-        );
+    /// @notice Tests that `addDependency` reverts when the chain is already in the dependency set.
+    function test_addDependency_chainAlreadyExists_reverts(uint256 _chainId) external {
+        vm.assume(_chainId != block.chainid);
 
-        vm.prank(superchainConfig.upgrader());
-        vm.expectRevert(ISuperchainConfig.ChainAlreadyHasDependencies.selector);
-        superchainConfig.addChain(_chainId, _systemConfig);
+        vm.startPrank(superchainConfig.dependencyManager());
+        superchainConfig.addDependency(_chainId, address(systemConfig));
+
+        vm.expectRevert(SuperchainConfig.DependencyAlreadyAdded.selector);
+        superchainConfig.addDependency(_chainId, address(systemConfig));
+        vm.stopPrank();
     }
 
-    /// @notice Tests that `addChain` reverts when the chain is already in the dependency set.
-    function test_addChain_chainAlreadyExists_reverts(uint256 _chainId, address _systemConfig) external {
-        SuperchainConfigForTest superchainConfig = new SuperchainConfigForTest(address(sharedLockbox));
-        superchainConfig.forTest_addChainOnDependencySet(_chainId);
+    /// @notice Tests that `addDependency` reverts when the dependency set is too large.
+    function test_addDependency_dependencySetTooLarge_reverts() external {
+        vm.startPrank(superchainConfig.dependencyManager());
 
-        // Mock the call over `dependencyCounter` to return 0 and avoid a previous revert
-        _mockAndExpect(
-            _systemConfig, abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector), abi.encode(0)
-        );
+        uint256 i;
+        for (i; i < type(uint8).max; i++) {
+            superchainConfig.addDependency(i, address(systemConfig));
+        }
 
-        vm.prank(superchainConfig.upgrader());
-        vm.expectRevert(SuperchainConfig.ChainAlreadyAdded.selector);
-        superchainConfig.addChain(_chainId, _systemConfig);
+        assertEq(superchainConfig.dependencySetSize(), type(uint8).max);
+
+        vm.expectRevert(SuperchainConfig.DependencySetTooLarge.selector);
+        superchainConfig.addDependency(i + 1, address(systemConfig));
+
+        vm.stopPrank();
     }
 
-    /// @notice Tests that `addChain` successfully adds a chain to the dependency set when it is empty.
-    function test_addChain_onEmptyDependencySet_succeeds(uint256 _chainId, address _portal) external {
+    /// @notice Tests that `addDependency` reverts when the chain ID is the same as the current chain ID.
+    function test_addDependency_sameChainID_reverts() external {
+        vm.prank(superchainConfig.dependencyManager());
+        vm.expectRevert(SuperchainConfig.InvalidChainID.selector);
+        superchainConfig.addDependency(block.chainid, address(systemConfig));
+    }
+
+    /// @notice Tests that `addDependency` successfully adds a chain to the dependency set when it is empty.
+    function test_addDependency_onEmptyDependencySet_succeeds(uint256 _chainId, address _portal) external {
         vm.assume(!superchainConfig.isInDependencySet(_chainId));
 
         // Store the PORTAL address we expect to be used in a call in the SystemConfig OptimsimPortal slot, and expect
@@ -207,106 +196,22 @@ contract SuperchainConfig_AddChain_Test is CommonTest {
             bytes32(uint256(keccak256("systemconfig.optimismportal")) - 1),
             bytes32(uint256(uint160(_portal)))
         );
-        vm.expectCall(address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.optimismPortal.selector));
+        vm.expectCall(address(systemConfig), abi.encodeWithSelector(ISystemConfig.optimismPortal.selector));
 
         // Mock and expect the call to authorize the portal on the SharedLockbox with the `_portal` address
         vm.expectCall(address(sharedLockbox), abi.encodeWithSelector(ISharedLockbox.authorizePortal.selector, _portal));
 
-        // Expect the `addDependency` function call to not be called since the dependency set is empty
-        uint64 zeroCalls = 0;
-        vm.expectCall(
-            address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector), zeroCalls
-        );
-
-        // Expect the ChainAdded event to be emitted
+        // Expect the DependencyAdded event to be emitted
         vm.expectEmit(address(superchainConfig));
-        emit ChainAdded(_chainId, address(systemConfig), _portal);
+        emit DependencyAdded(_chainId, address(systemConfig), _portal);
 
         // Add the new chain to the dependency set
-        vm.prank(superchainConfig.upgrader());
-        superchainConfig.addChain(_chainId, address(systemConfig));
+        vm.prank(superchainConfig.dependencyManager());
+        superchainConfig.addDependency(_chainId, address(systemConfig));
 
         // Check that the new chain is in the dependency set
         assertTrue(superchainConfig.isInDependencySet(_chainId));
-    }
-
-    /// @notice Tests that `addChain` successfully adds a chain to the dependency set when it is not empty.
-    ///         This tests deploys a new SuperchainConfigForTest contract and mocks several calls regarding SystemConfig
-    ///         and SharedLockbox contracts of the added chains with the purpose of reducing test complexity and making
-    ///         it more readable on the trade-off of getting a less realistic environment -- but finally checking the
-    ///         logic that is being tested when having multiple dependencies.
-    function test_addChain_withMultipleDependencies_succeeds(uint256 _chainId, address _portal) external {
-        vm.assume(_chainId > 3);
-
-        // Deploy a new SuperchainConfigForTest contract and set the address(sharedLockbox) and upgrader addresses
-        SuperchainConfigForTest superchainConfigForTest = new SuperchainConfigForTest(address(sharedLockbox));
-        superchainConfigForTest.forTest_setUpgrader(superchainConfig.upgrader());
-
-        // Define the chains to be added to the dependency set
-        (uint256 chainIdOne, address systemConfigOne) = (1, makeAddr("SystemConfigOne"));
-        (uint256 chainIdTwo, address systemConfigTwo) = (2, makeAddr("SystemConfigTwo"));
-        (uint256 chainIdThree, address systemConfigThree) = (3, makeAddr("SystemConfigThree"));
-
-        // Add the first three chains to the dependency set
-        superchainConfigForTest.forTest_addChainAndSystemConfig(chainIdOne, systemConfigOne);
-        superchainConfigForTest.forTest_addChainAndSystemConfig(chainIdTwo, systemConfigTwo);
-        superchainConfigForTest.forTest_addChainAndSystemConfig(chainIdThree, systemConfigThree);
-
-        // Mock and expect the call to `dependencyCounter` to return 0 for the new chain
-        _mockAndExpect(
-            address(systemConfig),
-            abi.encodeWithSelector(ISystemConfigInterop.dependencyCounter.selector),
-            abi.encode(0)
-        );
-
-        // Mock and expect the calls when looping through the first chain of the dependency set
-        _mockAndExpect(
-            systemConfigOne, abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, _chainId), ""
-        );
-        _mockAndExpect(
-            address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, chainIdOne), ""
-        );
-
-        // Mock and expect the calls when looping through the second chain of the dependency set
-        _mockAndExpect(
-            systemConfigTwo, abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, _chainId), ""
-        );
-        _mockAndExpect(
-            address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, chainIdTwo), ""
-        );
-
-        // Mock and expect the calls when looping through the third chain of the dependency set
-        _mockAndExpect(
-            systemConfigThree, abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, _chainId), ""
-        );
-        _mockAndExpect(
-            address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.addDependency.selector, chainIdThree), ""
-        );
-
-        // Store the PORTAL address we expect to be used in a call in the SystemConfig's OptimsimPortal slot, and expect
-        // it to be called
-        vm.store(
-            address(systemConfig),
-            bytes32(uint256(keccak256("systemconfig.optimismportal")) - 1),
-            bytes32(uint256(uint160(_portal)))
-        );
-        vm.expectCall(address(systemConfig), abi.encodeWithSelector(ISystemConfigInterop.optimismPortal.selector));
-
-        // Mock and expect the call to authorize the portal on the SharedLockbox with the `_portal` address
-        _mockAndExpect(
-            address(sharedLockbox), abi.encodeWithSelector(ISharedLockbox.authorizePortal.selector, _portal), ""
-        );
-
-        // Expect the ChainAdded event to be emitted
-        vm.expectEmit(address(superchainConfigForTest));
-        emit ChainAdded(_chainId, address(systemConfig), _portal);
-
-        // Add the new chain to the dependency set
-        vm.prank(superchainConfigForTest.upgrader());
-        superchainConfigForTest.addChain(_chainId, address(systemConfig));
-
-        // Check that the new chain is in the dependency set
-        assertTrue(superchainConfigForTest.isInDependencySet(_chainId));
+        assertEq(superchainConfig.dependencySetSize(), 1);
     }
 }
 
@@ -320,9 +225,9 @@ contract SuperchainConfig_IsInDependencySet_Test is CommonTest {
 
     /// @dev Tests that `isInDependencySet` returns true when the chain is in the dependency set.
     function test_isInDependencySet_true_succeeds(uint256 _chainId) external {
-        SuperchainConfigForTest superchainConfig = new SuperchainConfigForTest(address(sharedLockbox));
-        superchainConfig.forTest_addChainOnDependencySet(_chainId);
-
+        vm.assume(_chainId != block.chainid);
+        vm.prank(superchainConfig.dependencyManager());
+        superchainConfig.addDependency(_chainId, address(systemConfig));
         assertTrue(superchainConfig.isInDependencySet(_chainId));
     }
 }
@@ -334,25 +239,33 @@ contract SuperchainConfig_DependencySet_Test is CommonTest {
 
     /// @notice Tests that the dependency set returns properly the dependencies added.
     function test_dependencySet_succeeds(uint256[] calldata _chainIdsArray) public {
-        SuperchainConfigForTest superchainConfigForTest = new SuperchainConfigForTest(address(sharedLockbox));
+        vm.assume(_chainIdsArray.length <= type(uint8).max);
 
         // Ensure there are no repeated values on the input array
         for (uint256 i; i < _chainIdsArray.length; i++) {
+            vm.assume(_chainIdsArray[i] != block.chainid);
             chainIds.add(_chainIdsArray[i]);
         }
 
+        vm.startPrank(superchainConfig.dependencyManager());
+
         // Add the dependencies to the dependency set
         for (uint256 i; i < chainIds.length(); i++) {
-            superchainConfigForTest.forTest_addChainOnDependencySet(chainIds.at(i));
+            superchainConfig.addDependency(chainIds.at(i), address(systemConfig));
         }
 
         // Check that the dependency set has the same length as the dependencies
-        uint256[] memory dependencySet = superchainConfigForTest.dependencySet();
+        uint256[] memory dependencySet = superchainConfig.dependencySet();
         assertEq(dependencySet.length, chainIds.length());
 
         // Check that the dependency set has the same chain IDs as the dependencies
         for (uint256 i; i < chainIds.length(); i++) {
             assertEq(dependencySet[i], chainIds.at(i));
         }
+
+        // Check that the dependency set size is the same as the dependencies
+        assertEq(superchainConfig.dependencySetSize(), uint8(chainIds.length()));
+
+        vm.stopPrank();
     }
 }

--- a/packages/contracts-bedrock/test/L2/L1BlockInterop.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1BlockInterop.t.sol
@@ -14,8 +14,6 @@ import { IL1BlockInterop, ConfigType } from "interfaces/L2/IL1BlockInterop.sol";
 
 contract L1BlockInteropTest is CommonTest {
     event GasPayingTokenSet(address indexed token, uint8 indexed decimals, bytes32 name, bytes32 symbol);
-    event DependencyAdded(uint256 indexed chainId);
-    event DependencyRemoved(uint256 indexed chainId);
 
     modifier prankDepositor() {
         vm.startPrank(_l1BlockInterop().DEPOSITOR_ACCOUNT());
@@ -28,56 +26,6 @@ contract L1BlockInteropTest is CommonTest {
     function setUp() public virtual override {
         super.enableInterop();
         super.setUp();
-    }
-
-    /// @dev Tests that an arbitrary chain ID can be added to the dependency set.
-    function testFuzz_isInDependencySet_succeeds(uint256 _chainId) public prankDepositor {
-        vm.assume(_chainId != block.chainid);
-
-        _l1BlockInterop().setConfig(ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(_chainId));
-
-        assertTrue(_l1BlockInterop().isInDependencySet(_chainId));
-    }
-
-    /// @dev Tests that `isInDependencySet` returns true when the chain's chain ID is passed as the input.
-    function test_isInDependencySet_chainChainId_succeeds() public view {
-        assertTrue(_l1BlockInterop().isInDependencySet(block.chainid));
-    }
-
-    /// @dev Tests that `isInDependencySet` reverts when the input chain ID is not in the dependency set
-    ///      and is not the chain's chain ID.
-    function testFuzz_isInDependencySet_notDependency_reverts(uint256 _chainId) public view {
-        vm.assume(_chainId != block.chainid);
-
-        // Check that the chain ID is not in the dependency set
-        assertFalse(_l1BlockInterop().isInDependencySet(_chainId));
-    }
-
-    /// @dev Tests that `isInDependencySet` returns false when the dependency set is empty.
-    function testFuzz_isInDependencySet_dependencySetEmpty_succeeds(uint256 _chainId) public view {
-        vm.assume(_chainId != block.chainid);
-
-        assertEq(_l1BlockInterop().dependencySetSize(), 0);
-
-        assertFalse(_l1BlockInterop().isInDependencySet(_chainId));
-    }
-
-    /// @dev Tests that the dependency set size is correct when adding an arbitrary number of chain IDs.
-    function testFuzz_dependencySetSize_succeeds(uint8 _dependencySetSize) public prankDepositor {
-        uint256 uniqueCount = 0;
-
-        for (uint256 i = 0; i < _dependencySetSize; i++) {
-            if (i == block.chainid) continue;
-            _l1BlockInterop().setConfig(ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(i));
-            uniqueCount++;
-        }
-
-        assertEq(_l1BlockInterop().dependencySetSize(), uniqueCount);
-    }
-
-    /// @dev Tests that the dependency set size is correct when the dependency set is empty.
-    function test_dependencySetSize_dependencySetEmpty_succeeds() public view {
-        assertEq(_l1BlockInterop().dependencySetSize(), 0);
     }
 
     /// @dev Tests that the config for setting the gas paying token succeeds.
@@ -117,83 +65,6 @@ contract L1BlockInteropTest is CommonTest {
             ConfigType.SET_GAS_PAYING_TOKEN,
             StaticConfig.encodeSetGasPayingToken({ _token: _token, _decimals: _decimals, _name: _name, _symbol: _symbol })
         );
-    }
-
-    /// @dev Tests that the config for adding a dependency can be set.
-    function testFuzz_setConfig_addDependency_succeeds(uint256 _chainId) public prankDepositor {
-        vm.assume(_chainId != block.chainid);
-
-        vm.expectEmit(address(l1Block));
-        emit DependencyAdded(_chainId);
-
-        _l1BlockInterop().setConfig(ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(_chainId));
-    }
-
-    /// @dev Tests that adding a dependency reverts if it's the chain's chain id
-    function test_setConfig_addDependencyButChainChainId_reverts() public prankDepositor {
-        vm.expectRevert(AlreadyDependency.selector);
-        _l1BlockInterop().setConfig(ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(block.chainid));
-    }
-
-    /// @dev Tests that adding a dependency already in the set reverts
-    function test_setConfig_addDependencyButAlreadyDependency_reverts(uint256 _chainId) public prankDepositor {
-        vm.assume(_chainId != block.chainid);
-
-        _l1BlockInterop().setConfig(ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(_chainId));
-
-        vm.expectRevert(AlreadyDependency.selector);
-        _l1BlockInterop().setConfig(ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(_chainId));
-    }
-
-    /// @dev Tests that setting the add dependency config as not the depositor reverts.
-    function testFuzz_setConfig_addDependencyButNotDepositor_reverts(uint256 _chainId) public {
-        vm.expectRevert(NotDepositor.selector);
-        _l1BlockInterop().setConfig(ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(_chainId));
-    }
-
-    /// @dev Tests that setting the add dependency config when the dependency set size is too large reverts.
-    function test_setConfig_addDependencyButDependencySetSizeTooLarge_reverts() public prankDepositor {
-        for (uint256 i = 0; i < type(uint8).max; i++) {
-            _l1BlockInterop().setConfig(ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(i));
-        }
-
-        assertEq(_l1BlockInterop().dependencySetSize(), type(uint8).max);
-
-        vm.expectRevert(DependencySetSizeTooLarge.selector);
-        _l1BlockInterop().setConfig(ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(1));
-    }
-
-    /// @dev Tests that the config for removing a dependency can be set.
-    function testFuzz_setConfig_removeDependency_succeeds(uint256 _chainId) public prankDepositor {
-        vm.assume(_chainId != block.chainid);
-
-        // Add the chain ID to the dependency set before removing it
-        _l1BlockInterop().setConfig(ConfigType.ADD_DEPENDENCY, StaticConfig.encodeAddDependency(_chainId));
-
-        vm.expectEmit(address(l1Block));
-        emit DependencyRemoved(_chainId);
-
-        _l1BlockInterop().setConfig(ConfigType.REMOVE_DEPENDENCY, StaticConfig.encodeRemoveDependency(_chainId));
-    }
-
-    /// @dev Tests that setting the remove dependency config as not the depositor reverts.
-    function testFuzz_setConfig_removeDependencyButNotDepositor_reverts(uint256 _chainId) public {
-        vm.expectRevert(NotDepositor.selector);
-        _l1BlockInterop().setConfig(ConfigType.REMOVE_DEPENDENCY, StaticConfig.encodeRemoveDependency(_chainId));
-    }
-
-    /// @dev Tests that setting the remove dependency config for the chain's chain ID reverts.
-    function test_setConfig_removeDependencyButChainChainId_reverts() public prankDepositor {
-        vm.expectRevert(CantRemovedDependency.selector);
-        _l1BlockInterop().setConfig(ConfigType.REMOVE_DEPENDENCY, StaticConfig.encodeRemoveDependency(block.chainid));
-    }
-
-    /// @dev Tests that setting the remove dependency config for a chain ID that is not in the dependency set reverts.
-    function testFuzz_setConfig_removeDependencyButNotDependency_reverts(uint256 _chainId) public prankDepositor {
-        vm.assume(_chainId != block.chainid);
-
-        vm.expectRevert(NotDependency.selector);
-        _l1BlockInterop().setConfig(ConfigType.REMOVE_DEPENDENCY, StaticConfig.encodeRemoveDependency(_chainId));
     }
 
     /// @dev Returns the L1BlockInterop instance.

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -22,7 +22,6 @@ import {
     MessageAlreadyRelayed,
     ReentrantCall,
     TargetCallFailed,
-    IDependencySet,
     InvalidChainId
 } from "src/L2/L2ToL2CrossDomainMessenger.sol";
 
@@ -90,13 +89,6 @@ contract L2ToL2CrossDomainMessengerTest is Test {
 
         // Ensure that the target contract is not CrossL2Inbox or L2ToL2CrossDomainMessenger
         vm.assume(_target != Predeploys.CROSS_L2_INBOX && _target != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
-
-        // Mock the call over the `isInDependencySet` function to return true
-        vm.mockCall(
-            Predeploys.L1_BLOCK_ATTRIBUTES,
-            abi.encodeCall(IDependencySet.isInDependencySet, (_destination)),
-            abi.encode(true)
-        );
 
         // Get the current message nonce
         uint256 messageNonce = l2ToL2CrossDomainMessenger.messageNonce();
@@ -204,34 +196,6 @@ contract L2ToL2CrossDomainMessengerTest is Test {
             _target: Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER,
             _message: _message
         });
-    }
-
-    /// @notice Tests the `sendMessage` function reverts when the `destination` is not in the dependency set.
-    function testFuzz_sendMessage_notInDependencySet_reverts(
-        uint256 _destination,
-        address _target,
-        bytes calldata _message
-    )
-        external
-    {
-        // Ensure the destination is not the same as the source, otherwise the function will revert
-        vm.assume(_destination != block.chainid);
-
-        // Ensure that the target contract is not CrossL2Inbox or L2ToL2CrossDomainMessenger
-        vm.assume(_target != Predeploys.CROSS_L2_INBOX && _target != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
-
-        // Mock the call over the `isInDependencySet` function to return false
-        vm.mockCall(
-            Predeploys.L1_BLOCK_ATTRIBUTES,
-            abi.encodeCall(IDependencySet.isInDependencySet, (_destination)),
-            abi.encode(false)
-        );
-
-        // Expect a revert with the InvalidChainId selector
-        vm.expectRevert(InvalidChainId.selector);
-
-        // Call `sendMessage` with a destination that is not in the dependency set to provoke revert
-        l2ToL2CrossDomainMessenger.sendMessage(_destination, _target, _message);
     }
 
     /// @dev Tests that the `relayMessage` function succeeds and emits the correct RelayedMessage event.

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -21,8 +21,7 @@ import {
     MessageTargetL2ToL2CrossDomainMessenger,
     MessageAlreadyRelayed,
     ReentrantCall,
-    TargetCallFailed,
-    InvalidChainId
+    TargetCallFailed
 } from "src/L2/L2ToL2CrossDomainMessenger.sol";
 
 // Interfaces

--- a/packages/contracts-bedrock/test/opcm/ManageDependencies.t.sol
+++ b/packages/contracts-bedrock/test/opcm/ManageDependencies.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import { Test } from "forge-std/Test.sol";
-import { ISystemConfigInterop } from "interfaces/L1/ISystemConfigInterop.sol";
 import { ManageDependencies, ManageDependenciesInput } from "scripts/deploy/ManageDependencies.s.sol";
 
 contract ManageDependencies_Test is Test {
@@ -21,25 +20,6 @@ contract ManageDependencies_Test is Test {
         testChainId = 123;
 
         vm.etch(mockSystemConfig, hex"01");
-    }
-
-    function test_run_add_succeeds() public {
-        input.set(input.systemConfig.selector, mockSystemConfig);
-        input.set(input.chainId.selector, testChainId);
-        input.set(input.remove.selector, false);
-
-        // Expect the addDependency call
-        vm.mockCall(mockSystemConfig, abi.encodeCall(ISystemConfigInterop.addDependency, testChainId), bytes(""));
-        script.run(input);
-    }
-
-    function test_run_remove_succeeds() public {
-        input.set(input.systemConfig.selector, mockSystemConfig);
-        input.set(input.chainId.selector, testChainId);
-        input.set(input.remove.selector, true);
-
-        vm.mockCall(mockSystemConfig, abi.encodeCall(ISystemConfigInterop.removeDependency, testChainId), bytes(""));
-        script.run(input);
     }
 }
 

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -45,7 +45,8 @@ contract Specification_Test is CommonTest {
         COUNCILSAFE,
         COUNCILSAFEOWNER,
         PORTAL,
-        SUPERCHAINCONFIG
+        SUPERCHAINCONFIG,
+        DEPENDENCYMANAGER
     }
 
     /// @notice Represents the specification of a function.
@@ -413,20 +414,24 @@ contract Specification_Test is CommonTest {
 
         // SuperchainConfig
         _addSpec({ _name: "SuperchainConfig", _sel: _getSel("GUARDIAN_SLOT()") });
-        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("UPGRADER_SLOT()") });
+        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("DEPENDENCY_MANAGER_SLOT()") });
         _addSpec({ _name: "SuperchainConfig", _sel: _getSel("PAUSED_SLOT()") });
         _addSpec({ _name: "SuperchainConfig", _sel: _getSel("SHARED_LOCKBOX()") });
         _addSpec({ _name: "SuperchainConfig", _sel: _getSel("guardian()") });
-        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("upgrader()") });
-        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("systemConfigs(uint256)") });
+        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("dependencyManager()") });
         _addSpec({ _name: "SuperchainConfig", _sel: _getSel("initialize(address,address,bool)") });
         _addSpec({ _name: "SuperchainConfig", _sel: _getSel("pause(string)"), _auth: Role.GUARDIAN });
         _addSpec({ _name: "SuperchainConfig", _sel: _getSel("paused()") });
         _addSpec({ _name: "SuperchainConfig", _sel: _getSel("unpause()"), _auth: Role.GUARDIAN });
         _addSpec({ _name: "SuperchainConfig", _sel: _getSel("version()") });
-        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("addChain(uint256,address)") });
+        _addSpec({
+            _name: "SuperchainConfig",
+            _sel: _getSel("addDependency(uint256,address)"),
+            _auth: Role.DEPENDENCYMANAGER
+        });
         _addSpec({ _name: "SuperchainConfig", _sel: _getSel("isInDependencySet(uint256)") });
         _addSpec({ _name: "SuperchainConfig", _sel: _getSel("dependencySet()") });
+        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("dependencySetSize()") });
 
         // SharedLockbox
         _addSpec({ _name: "SharedLockbox", _sel: _getSel("SUPERCHAIN_CONFIG()") });
@@ -566,14 +571,6 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "SystemConfigInterop", _sel: _getSel("basefeeScalar()") });
         _addSpec({ _name: "SystemConfigInterop", _sel: _getSel("blobbasefeeScalar()") });
         _addSpec({ _name: "SystemConfigInterop", _sel: _getSel("maximumGasLimit()") });
-        _addSpec({ _name: "SystemConfigInterop", _sel: _getSel("addDependency(uint256)"), _auth: Role.SUPERCHAINCONFIG });
-        _addSpec({
-            _name: "SystemConfigInterop",
-            _sel: _getSel("removeDependency(uint256)"),
-            _auth: Role.SUPERCHAINCONFIG
-        });
-        _addSpec({ _name: "SystemConfigInterop", _sel: _getSel("dependencyCounter()") });
-        _addSpec({ _name: "SystemConfigInterop", _sel: _getSel("SUPERCHAIN_CONFIG()") });
 
         // ProxyAdmin
         _addSpec({ _name: "ProxyAdmin", _sel: _getSel("addressManager()") });


### PR DESCRIPTION
The rationale behind this PR is found in the following [PR](https://github.com/ethereum-optimism/optimism/pull/13513)

The `SuperchainConfig` is now the only source for storing the `dependencySet`

The changes have impact in `L1BlockInterop`, `SystemConfigInterop`, `CrossL2Inbox` and `L2toL2CDM`