### PR TITLE
feat: six and seven properties

### DIFF
--- a/packages/contracts-bedrock/test/invariants/interop/FuzzTest.t.sol
+++ b/packages/contracts-bedrock/test/invariants/interop/FuzzTest.t.sol
@@ -258,4 +258,23 @@ contract FuzzTest is Handler {
             assertWithMsg(L2_TO_L2_MESSENGER.successfulMessages(messageHash), "Unknown Revert Error");
         }
     }
+
+    /// @custom:property-id 6
+    /// @custom:property The ETHLiquidity#mint call MUST always revert when the caller is not the SuperchainWETH
+    /// contract
+    function test_mintRevertsIfCallerNotSuperWETH(address _caller, uint256 _amount) public isInitialized {
+        require(_caller != address(ETH_LIQUIDITY));
+
+        _amount = clampLte(_amount, address(ETH_LIQUIDITY).balance);
+
+        (bool success) =
+            _prankNewActorAndCall(_caller, address(ETH_LIQUIDITY), abi.encodeCall(ETH_LIQUIDITY.mint, (_amount)));
+        if (!success) {
+            console.log("Caller false: ", _caller);
+            assert(_caller != address(SUPER_WETH));
+        } else {
+            console.log("Caller true: ", _caller);
+            assert(_caller == address(SUPER_WETH));
+        }
+    }
 }

--- a/packages/contracts-bedrock/test/invariants/interop/Setup.sol
+++ b/packages/contracts-bedrock/test/invariants/interop/Setup.sol
@@ -63,8 +63,6 @@ contract Setup is PropertiesAsserts, HandlerActors {
         ISuperchainTokenBridge(Predeploys.SUPERCHAIN_TOKEN_BRIDGE);
     ISuperToken public immutable SUPER_TOKEN;
 
-    // VM
-    IStdCheats public vm = IStdCheats(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     // System addresses
     address public immutable dependencyManager = vm.addr(uint256(keccak256("DependencyManager")));
     address public immutable guardian = vm.addr(uint256(keccak256("Guardian")));

--- a/packages/contracts-bedrock/test/invariants/interop/helpers/Actors.t.sol
+++ b/packages/contracts-bedrock/test/invariants/interop/helpers/Actors.t.sol
@@ -15,21 +15,12 @@ import { IL2ToL2CrossDomainMessenger } from "interfaces/L2/IL2ToL2CrossDomainMes
 contract Actors {
     event ActorsLog(string);
 
-    IStdCheats internal _vm = IStdCheats(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+    IStdCheats internal vm = IStdCheats(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     address public superchainTokenBridge = Predeploys.SUPERCHAIN_TOKEN_BRIDGE;
     address public l2ToL2ToCDM = Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER;
 
-    function callBridgeRelayERC20(
-        address _token,
-        address _from,
-        address _to,
-        uint256 _amount,
-        uint256 _source
-    )
-        public
-        returns (bool)
-    {
+    function callBridgeRelayERC20(address _token, address _from, address _to, uint256 _amount) public returns (bool) {
         try ISuperchainTokenBridge(superchainTokenBridge).relayERC20(_token, _from, _to, _amount) {
             return true;
         } catch {
@@ -74,7 +65,7 @@ contract Actors {
         public
         returns (bool _success, bytes memory _returnData)
     {
-        emit ActorsLog(string.concat("call using actor: ", _vm.toString(address(this))));
+        emit ActorsLog(string.concat("call using actor: ", vm.toString(address(this))));
 
         (_success, _returnData) = _target.call{ value: _msgValue }(_payload);
     }
@@ -83,6 +74,9 @@ contract Actors {
 }
 
 contract HandlerActors is GhostStorage {
+    // VM
+    IStdCheats public vm = IStdCheats(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
     function currentActor() public view returns (Actors _actor) {
         uint256 _seed = uint256(uint160(msg.sender));
         _actor = Actors(payable(_ghost_actors[(_seed % _ghost_actors.length) - 1]));
@@ -90,5 +84,27 @@ contract HandlerActors is GhostStorage {
 
     function randomActor(uint256 _seed) public view returns (Actors _actor) {
         _actor = Actors(payable(_ghost_actors[_seed % _ghost_actors.length]));
+    }
+
+    /// NOTE: Needed because prank is failing
+    function _prankNewActorAndCall(
+        address _caller,
+        address _target,
+        bytes memory _data
+    )
+        internal
+        returns (bool success)
+    {
+        // get code before
+        bytes memory originalCode = address(_caller).code;
+
+        // set code to be an actor
+        vm.etch(_caller, address(currentActor()).code);
+
+        // Call target through direct call
+        (success,) = _caller.call(abi.encodeCall(Actors.directCall, (_target, 0, _data)));
+
+        // Set code back to original
+        vm.etch(_caller, originalCode);
     }
 }


### PR DESCRIPTION
This didn't work, the call after prank returned success but was never reached:

```solidity
    /// @custom:property-id 6
    /// @custom:property The ETHLiquidity#mint call MUST always revert when the caller is not the SuperchainWETH
    /// contract
    function test_mintRevertsIfCallerNotSuperWETH(address _caller, uint256 _amount) public isInitialized {

        _amount = clampLte(_amount, address(ETH_LIQUIDITY).balance);

        vm.prank(_caller);
        try ETH_LIQUIDITY.mint(_amount) {
            console.log("Caller true: ", _caller);
            assert(_caller == address(SUPER_WETH));
        } catch {
            console.log("Caller false: ", _caller);
            assert(_caller != address(SUPER_WETH));
        }
    }
    ```
