### PR TITLE
fix: handle two versions of superchain config before and after migration

### DIFF
--- a/packages/contracts-bedrock/test/invariants/interop/Setup.sol
+++ b/packages/contracts-bedrock/test/invariants/interop/Setup.sol
@@ -157,7 +157,7 @@ contract Setup is PropertiesAsserts, HandlerActors {
         _ghost_isL2Contract[address(SUPER_TOKEN)] = true;
 
         // Deploy SuperchainConfig
-        _setCode(superchainConfigAddress, DEPLOYER_8_15.deploySuperchainConfigInterop(), true);
+        _setCode(superchainConfigAddress, DEPLOYER_8_15.deploySuperchainConfig(), true);
         SUPERCHAIN_CONFIG = ISuperchainConfigInterop(superchainConfigAddress);
         _ghost_isL1Contract[superchainConfigAddress] = true;
 
@@ -210,7 +210,7 @@ contract Setup is PropertiesAsserts, HandlerActors {
 
     function _initializeProxies() internal {
         // Initialize SuperchainConfig
-        SUPERCHAIN_CONFIG.initialize(guardian, false, clusterManager, sharedLockboxAddress);
+        SUPERCHAIN_CONFIG.initialize(guardian, false);
 
         // Initialize SystemConfig
         ISystemConfig.Addresses memory addresses = ISystemConfig.Addresses({
@@ -274,7 +274,6 @@ contract Setup is PropertiesAsserts, HandlerActors {
         assert(address(SHARED_LOCKBOX.superchainConfig()) == superchainConfigAddress);
 
         // Superchain Config
-        assert(address(SUPERCHAIN_CONFIG.sharedLockbox()) == sharedLockboxAddress);
         assert(SUPERCHAIN_CONFIG.guardian() == guardian);
         assert(SUPERCHAIN_CONFIG.paused() == false);
 

--- a/packages/contracts-bedrock/test/invariants/interop/helpers/Handler.sol
+++ b/packages/contracts-bedrock/test/invariants/interop/helpers/Handler.sol
@@ -331,13 +331,48 @@ contract Handler is Setup {
     function handler_migrateAndAddL1Dependency() public initialize {
         require(!_ghost_isMigrated);
 
-        // Upgrade the portal to the new implementation through the proxy admin
+        // Upgrade the superchain config to the new implementation through the proxy admin
         (bool success,) = proxyOwner.directCall(
+            address(proxyAdmin),
+            _ZERO_VALUE,
+            abi.encodeWithSelector(
+                ProxyAdmin.upgrade.selector, address(SUPERCHAIN_CONFIG), address(new StorageSetter())
+            )
+        );
+        assert(success);
+
+        // Reset the initialized flag to enable the new implementation to be initialized
+        try StorageSetter(address(SUPERCHAIN_CONFIG)).setBytes32(bytes32(0), bytes32(abi.encodePacked(false))) {
+            // Assert the `_initialized` slot was set to false
+            assert(StorageSetter(address(SUPERCHAIN_CONFIG)).getBool(bytes32(0)) == false);
+        } catch {
+            assert(false);
+        }
+
+        // Upgrade the superchain config interop to the new implementation through the proxy admin
+        (success,) = proxyOwner.directCall(
+            address(proxyAdmin),
+            _ZERO_VALUE,
+            abi.encodeWithSelector(
+                ProxyAdmin.upgrade.selector, address(SUPERCHAIN_CONFIG), DEPLOYER_8_15.deploySuperchainConfigInterop()
+            )
+        );
+        assert(success);
+
+        // Initialize the superchain config interop
+        try SUPERCHAIN_CONFIG.initialize(guardian, false, clusterManager, sharedLockboxAddress) {
+            assert(address(SUPERCHAIN_CONFIG.sharedLockbox()) == sharedLockboxAddress);
+            assert(address(SUPERCHAIN_CONFIG.clusterManager()) == clusterManager);
+        } catch {
+            assert(false);
+        }
+
+        // Upgrade the portal to the new implementation through the proxy admin
+        (success,) = proxyOwner.directCall(
             address(proxyAdmin),
             _ZERO_VALUE,
             abi.encodeWithSelector(ProxyAdmin.upgrade.selector, address(PORTAL), address(new StorageSetter()))
         );
-
         assert(success);
 
         // Reset the initialized flag to enable the new implementation to be initialized

--- a/packages/contracts-bedrock/test/invariants/interop/interfaces/IDeployer815.sol
+++ b/packages/contracts-bedrock/test/invariants/interop/interfaces/IDeployer815.sol
@@ -24,6 +24,8 @@ interface IDeployer815 {
 
     function deployProxy(address _admin) external returns (address proxy);
 
+    function deploySuperchainConfig() external returns (address superchainConfig);
+
     function deploySuperchainConfigInterop() external returns (address superchainConfigInterop);
 
     function deploySuperchainWETH() external returns (address superchainWETH);

--- a/packages/contracts-bedrock/test/invariants/interop/utils/Deployer815.sol
+++ b/packages/contracts-bedrock/test/invariants/interop/utils/Deployer815.sol
@@ -7,6 +7,7 @@ import { L1BlockInterop } from "src/L2/L1BlockInterop.sol";
 import { OptimismPortalInteropMock } from "test/invariants/interop/mocks/OptimismPortalMock.sol";
 import { OptimismPortal2Mock } from "test/invariants/interop/mocks/OptimismPortalMock.sol";
 import { Proxy } from "src/universal/Proxy.sol";
+import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
 import { SuperchainConfigInterop } from "src/L1/SuperchainConfigInterop.sol";
 import { SuperchainWETH } from "src/L2/SuperchainWETH.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
@@ -48,6 +49,10 @@ contract Deployer815 {
 
     function deploySuperchainConfigInterop() public returns (address _superchainConfigInterop) {
         _superchainConfigInterop = address(new SuperchainConfigInterop());
+    }
+
+    function deploySuperchainConfig() public returns (address _superchainConfig) {
+        _superchainConfig = address(new SuperchainConfig());
     }
 
     function deploySuperchainWETH() public returns (address _superchainWETH) {


### PR DESCRIPTION
Context: `SuperchainConfigInterop` is designed to be used after migration only, even though it is still possible to use it without interop feature enabled, this flow is closer to the one to be used in production.