### PR TITLE
fix: portal withdrawal checks

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -21,11 +21,11 @@
   },
   "src/L1/OptimismPortal2.sol": {
     "initCodeHash": "0xfaa5f7f911871a00e43024bcf1344cfe846c3cb1aec83d898f5acdd98e3ae223",
-    "sourceCodeHash": "0x104a63a791328f3cfb762368a0e1249187b428e1b18a805e0cac441689603a60"
+    "sourceCodeHash": "0x54c2887c1257af936abf89c51655627c30ca202781a96fdab6109039a1d777a5"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0x71aaaf0c19eb19549024ba0eabd4cfe4f2ff5d4d0a9628acd539c3bc685fdfe2",
-    "sourceCodeHash": "0x6b6e82f72f34f89ed619e9e285ab46118b231b5e03c946dc482a08d52adf2831"
+    "initCodeHash": "0xf8747be93f06409fa3e661efaae879e7744f1c3ff2f0947ee47e879ed94badbd",
+    "sourceCodeHash": "0x210930bbccb9ad5aaa862f97e20965a60231a1e1f8da2e999ba941180815c8fa"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x5a76c8530cb24cf23d3baacc6eefaac226382af13f1e2a35535d2ec2b0573b29",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,12 +20,12 @@
     "sourceCodeHash": "0x1c37bb41a46a1c0fe6c8cef88037ecc6700675c4cfa8d673349f026ffd919526"
   },
   "src/L1/OptimismPortal2.sol": {
-    "initCodeHash": "0xfaa5f7f911871a00e43024bcf1344cfe846c3cb1aec83d898f5acdd98e3ae223",
-    "sourceCodeHash": "0x54c2887c1257af936abf89c51655627c30ca202781a96fdab6109039a1d777a5"
+    "initCodeHash": "0x7488f3311a94278272a5b642d9abd90bb68d72230d5dc3b82fb8c10ddfc2829b",
+    "sourceCodeHash": "0x1cad4f3a6d624ac0a84c8361e16f7f1785d65248b1be00637e003231b1c1a3f0"
   },
   "src/L1/OptimismPortalInterop.sol": {
-    "initCodeHash": "0xf8747be93f06409fa3e661efaae879e7744f1c3ff2f0947ee47e879ed94badbd",
-    "sourceCodeHash": "0x210930bbccb9ad5aaa862f97e20965a60231a1e1f8da2e999ba941180815c8fa"
+    "initCodeHash": "0x7094f190af70aed2bc8519f9ea6cfee5412d07ba5571a4376dfb56152b8eaed7",
+    "sourceCodeHash": "0x81275a82d66ef7d6786a5fd641e1f79c1cf90a1a7ba9c83bd4cfe78658f02b00"
   },
   "src/L1/ProtocolVersions.sol": {
     "initCodeHash": "0x5a76c8530cb24cf23d3baacc6eefaac226382af13f1e2a35535d2ec2b0573b29",

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -308,6 +308,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
         external
         whenNotPaused
     {
+        // Validate the withdrawal before it is proved.
+        _validateWithdrawal(_tx);
+
         // Prevent users from creating a deposit transaction where this address is the message
         // sender on L2. Because this is checked here, we do not need to check again in
         // `finalizeWithdrawalTransaction`.
@@ -402,6 +405,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
         public
         whenNotPaused
     {
+        // Validate the withdrawal before it is finalized.
+        _validateWithdrawal(_tx);
+
         // Make sure that the l2Sender has not yet been set. The l2Sender is set to a value other
         // than the default value when a withdrawal transaction is being finalized. This check is
         // a defacto reentrancy guard.
@@ -604,6 +610,10 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     function numProofSubmitters(bytes32 _withdrawalHash) external view returns (uint256) {
         return proofSubmitters[_withdrawalHash].length;
     }
+
+    /// @notice No-op function to be used to validate a withdrawal before it is proved or finalized.
+    /// @param _tx Withdrawal transaction to validate.
+    function _validateWithdrawal(Types.WithdrawalTransaction memory _tx) internal view virtual { }
 
     /// @notice No-op function to be used to lock ETH in the SharedLockbox in the interop contract.
     function _lockETH() internal virtual { }

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -294,6 +294,15 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
         }
     }
 
+    /// @notice Validates a withdrawal before it is proved or finalized.
+    /// @param _tx Withdrawal transaction to validate.
+    function _validateWithdrawal(Types.WithdrawalTransaction memory _tx) internal view virtual {
+        // Prevent users from creating a deposit transaction where this address is the message
+        // sender on L2. Because this is checked here, we do not need to check again in
+        // `finalizeWithdrawalTransaction`.
+        if (_tx.target == address(this)) revert BadTarget();
+    }
+
     /// @notice Proves a withdrawal transaction.
     /// @param _tx               Withdrawal transaction to finalize.
     /// @param _disputeGameIndex Index of the dispute game to prove the withdrawal against.
@@ -310,11 +319,6 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     {
         // Validate the withdrawal before it is proved.
         _validateWithdrawal(_tx);
-
-        // Prevent users from creating a deposit transaction where this address is the message
-        // sender on L2. Because this is checked here, we do not need to check again in
-        // `finalizeWithdrawalTransaction`.
-        if (_tx.target == address(this)) revert BadTarget();
 
         // Fetch the dispute game proxy from the `DisputeGameFactory` contract.
         (GameType gameType,, IDisputeGame gameProxy) = disputeGameFactory.gameAtIndex(_disputeGameIndex);
@@ -610,10 +614,6 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     function numProofSubmitters(bytes32 _withdrawalHash) external view returns (uint256) {
         return proofSubmitters[_withdrawalHash].length;
     }
-
-    /// @notice No-op function to be used to validate a withdrawal before it is proved or finalized.
-    /// @param _tx Withdrawal transaction to validate.
-    function _validateWithdrawal(Types.WithdrawalTransaction memory _tx) internal view virtual { }
 
     /// @notice No-op function to be used to lock ETH in the SharedLockbox in the interop contract.
     function _lockETH() internal virtual { }

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -97,7 +97,9 @@ contract OptimismPortalInterop is OptimismPortal2 {
 
     /// @notice Validates a withdrawal before it is proved or finalized.
     /// @param _tx Withdrawal transaction to validate.
-    function _validateWithdrawal(Types.WithdrawalTransaction memory _tx) internal view override {
+    function _validateWithdrawal(Types.WithdrawalTransaction memory _tx) internal view virtual override {
+        super._validateWithdrawal(_tx);
+
         OptimismPortalStorage storage s = _storage();
 
         // We don't allow the SharedLockbox to be the target of a withdrawal.

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -95,15 +95,21 @@ contract OptimismPortalInterop is OptimismPortal2 {
         return _storage().migrated;
     }
 
-    /// @notice Unlock and receive the ETH from the SharedLockbox.
-    /// @param _tx Withdrawal transaction to finalize.
-    function _unlockETH(Types.WithdrawalTransaction memory _tx) internal virtual override {
+    /// @notice Validates a withdrawal before it is proved or finalized.
+    /// @param _tx Withdrawal transaction to validate.
+    function _validateWithdrawal(Types.WithdrawalTransaction memory _tx) internal view override {
         OptimismPortalStorage storage s = _storage();
 
         // We don't allow the SharedLockbox to be the target of a withdrawal.
         // This is to prevent the SharedLockbox from being drained.
         // This check needs to be done for every withdrawal.
         if (_tx.target == s.sharedLockbox) revert MessageTargetSharedLockbox();
+    }
+
+    /// @notice Unlock and receive the ETH from the SharedLockbox.
+    /// @param _tx Withdrawal transaction to finalize.
+    function _unlockETH(Types.WithdrawalTransaction memory _tx) internal virtual override {
+        OptimismPortalStorage storage s = _storage();
 
         // If ETH liquidity has not been migrated to the SharedLockbox yet, maintain legacy behavior
         // where ETH accumulates in the portal contract itself rather than being managed by the lockbox


### PR DESCRIPTION
Fixes [L-0](https://www.notion.so/defi-wonderland/Final-Report-1909a4c092c78057a4abebe1fbe718fe?pvs=4#1909a4c092c780c5a44fe32688852490)

We could also add the `address(this)` [target check](https://github.com/defi-wonderland/optimism/blob/a3c806928e107c0c55c5f7890449503ac04c4bbc/packages/contracts-bedrock/src/L1/OptimismPortal2.sol#L303) to this PR