### PR TITLE
test: add upgrade isthmus basic test

### DIFF
--- a/packages/contracts-bedrock/test/L2/IsthmusUpgrade.t.sol
+++ b/packages/contracts-bedrock/test/L2/IsthmusUpgrade.t.sol
@@ -151,6 +151,24 @@ contract IsthmusUpgradeTest is Test {
         );
     }
 
+    /// @dev This test is used to test a deposit transaction upgrade
+    ///      This test assumes that a proper deposit transaction has already been sent, emitting the appropriate
+    ///      TransactionDeposited event.
+    function test_depositTransaction_upgrade() external {
+        vm.skip(!isForkTest());
+
+        // 1. Deploy the new implementation contract in L2
+        IL2CrossDomainMessenger newCrossDomainMessenger = IL2CrossDomainMessenger(
+            DeployUtils.createDeterministic({ _name: "L2CrossDomainMessenger", _args: bytes(""), _salt: _salt })
+        );
+
+        // 2. Upgrade the L2CrossDomainMessenger contract
+        vm.prank(IL2ProxyAdmin(Predeploys.L2_PROXY_ADMIN).owner());
+        IL2ProxyAdmin(Predeploys.L2_PROXY_ADMIN).upgrade(
+            payable(Predeploys.L2_CROSS_DOMAIN_MESSENGER), payable(address(newCrossDomainMessenger))
+        );
+    }
+
     /// @dev This function is used to upgrade the L1Block contract.
     function _upgradeL1Block() internal {
         IL1Block l1Block =

--- a/packages/contracts-bedrock/test/L2/IsthmusUpgrade.t.sol
+++ b/packages/contracts-bedrock/test/L2/IsthmusUpgrade.t.sol
@@ -8,53 +8,61 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
 import { Types } from "src/libraries/Types.sol";
+import { Events } from "test/setup/Events.sol";
 
 // Interfaces
 import { IL1Block } from "interfaces/L2/IL1Block.sol";
 import { IL2ProxyAdmin } from "interfaces/L2/IL2ProxyAdmin.sol";
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
+import { ICrossDomainMessenger } from "interfaces/universal/ICrossDomainMessenger.sol";
+import { IStandardBridge } from "interfaces/universal/IStandardBridge.sol";
+import { IERC721Bridge } from "interfaces/universal/IERC721Bridge.sol";
 
 contract IsthmusUpgradeTest is Test {
     bytes32 internal _salt = DeployUtils.DEFAULT_SALT;
+
+    uint256 internal _l1Fork;
+    uint256 internal _l2Fork;
 
     function setUp() public {
         if (!isForkTest()) {
             return;
         }
 
-        vm.createSelectFork(vm.envString("FORK_RPC_URL"), vm.envUint("FORK_BLOCK_NUMBER"));
+        _l2Fork = vm.createFork(vm.envString("FORK_L2_RPC_URL"), vm.envUint("FORK_L2_BLOCK_NUMBER"));
+
+        _l1Fork = vm.createFork(vm.envString("FORK_L1_RPC_URL"), vm.envUint("FORK_L1_BLOCK_NUMBER"));
     }
 
     /// @notice Indicates whether a test is running against a forked production network.
-    function isForkTest() public view returns (bool) {
+    function isForkTest() internal view returns (bool) {
         return vm.envOr("FORK_TEST", false);
     }
 
     /// @dev This test is used to test the isthmus upgrade flow.
     ///      It is a forked test to be able to test the correct values for the fee vaults once the isthmus upgrade is
     ///      complete.
-    function test_setIsthmusUpgrade() external {
+    function test_setIsthmusUpgrade_feeVaults() external {
         vm.skip(!isForkTest());
 
-        /// 1. Deploy the L1Block contract
-        IL1Block l1Block =
-            IL1Block(DeployUtils.createDeterministic({ _name: "L1Block", _args: bytes(""), _salt: _salt }));
+        vm.selectFork(_l2Fork);
 
-        IL2ProxyAdmin proxyAdmin = IL2ProxyAdmin(Predeploys.L2_PROXY_ADMIN);
-
+        /// 1. Deploy the new L1Block implementation contract
         /// 2. Upgrade the L1Block contract
-        vm.prank(proxyAdmin.owner());
-        proxyAdmin.upgrade(payable(Predeploys.L1_BLOCK_ATTRIBUTES), address(l1Block));
-
+        _upgradeL1Block();
         assertEq(IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isIsthmus(), false);
 
-        /// 3. Perform the isthmus upgrade
+        /// 3. Perform the isthmus upgrade in the L1Block contract
         vm.prank(Constants.DEPOSITOR_ACCOUNT);
         IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).setIsthmus();
 
+        // Assert the isthmus upgrade was successful
         assertEq(IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isIsthmus(), true);
 
-        // Obtain the receipient, min withdrawal amount, and network for the fee vaults
+        // Obtain the receipient, min withdrawal amount, and network for each fee vault from the actual contracts.
+        // This is performed before the upgrade since post-isthmus fee vaults get their values from L1Block.
+
+        // Fee Vaults
         address baseFeeVaultRecipient = IFeeVault(payable(Predeploys.BASE_FEE_VAULT)).RECIPIENT();
         uint256 baseFeeVaultMinWithdrawalAmount = IFeeVault(payable(Predeploys.BASE_FEE_VAULT)).MIN_WITHDRAWAL_AMOUNT();
 
@@ -66,6 +74,111 @@ contract IsthmusUpgradeTest is Test {
             IFeeVault(payable(Predeploys.SEQUENCER_FEE_WALLET)).MIN_WITHDRAWAL_AMOUNT();
 
         // 4. Upgrade the remaining proxies
+        _upgradeProxies();
+
+        // Assert the fee vault configs match the pre-isthmus values
+        bytes memory baseFeeVaultConfig =
+            IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).getConfig(Types.ConfigType.BASE_FEE_VAULT_CONFIG);
+        assert(_checkFeeVaultConfig(baseFeeVaultConfig, baseFeeVaultRecipient, baseFeeVaultMinWithdrawalAmount));
+
+        bytes memory l1FeeVaultConfig =
+            IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).getConfig(Types.ConfigType.L1_FEE_VAULT_CONFIG);
+        assert(_checkFeeVaultConfig(l1FeeVaultConfig, l1FeeVaultRecipient, l1FeeVaultMinWithdrawalAmount));
+
+        bytes memory sequencerFeeVaultConfig =
+            IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).getConfig(Types.ConfigType.SEQUENCER_FEE_VAULT_CONFIG);
+        assert(
+            _checkFeeVaultConfig(
+                sequencerFeeVaultConfig, sequencerFeeVaultRecipient, sequencerFeeVaultMinWithdrawalAmount
+            )
+        );
+    }
+
+    /// @dev This test is used to test the isthmus upgrade flow.
+    ///      It is a forked test to be able to test the correct values for the other contracts once the isthmus upgrade
+    ///      is complete.
+    function test_setIsthmusUpgrade_otherContracts() external {
+        vm.skip(!isForkTest());
+
+        vm.selectFork(_l2Fork);
+
+        /// 1. Deploy the new L1Block implementation contract
+        /// 2. Upgrade the L1Block contract
+        _upgradeL1Block();
+
+        assertEq(IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isIsthmus(), false);
+
+        /// 3. Perform the isthmus upgrade in the L1Block contract
+        vm.prank(Constants.DEPOSITOR_ACCOUNT);
+        IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).setIsthmus();
+
+        // Assert the isthmus upgrade was successful
+        assertEq(IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isIsthmus(), true);
+
+        // Obtain the other messenger, standard bridge, and ERC721 bridge addresses from the actual contracts.
+        // This is performed before the upgrade since post-isthmus contracts get their values from L1Block.
+
+        // Cross Domain Messenger
+        ICrossDomainMessenger otherMessenger =
+            ICrossDomainMessenger(Predeploys.L2_CROSS_DOMAIN_MESSENGER).OTHER_MESSENGER();
+        // Standard Bridge
+        IStandardBridge otherStandardBridge = IStandardBridge(payable(Predeploys.L2_STANDARD_BRIDGE)).OTHER_BRIDGE();
+        // ERC721 Bridge
+        IERC721Bridge otherERC721Bridge = IERC721Bridge(payable(Predeploys.L2_ERC721_BRIDGE)).OTHER_BRIDGE();
+
+        // 4. Upgrade the remaining proxies
+        _upgradeProxies();
+
+        // Assert the L1 messenger configs match the pre-isthmus values
+        assertEq(
+            address(otherMessenger),
+            abi.decode(
+                IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).getConfig(Types.ConfigType.L1_CROSS_DOMAIN_MESSENGER_ADDRESS),
+                (address)
+            )
+        );
+
+        // Assert the L1 standard bridge configs match the pre-isthmus values
+        assertEq(
+            address(otherStandardBridge),
+            abi.decode(
+                IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).getConfig(Types.ConfigType.L1_STANDARD_BRIDGE_ADDRESS),
+                (address)
+            )
+        );
+
+        // Assert the L1 ERC721 bridge configs match the pre-isthmus values
+        assertEq(
+            address(otherERC721Bridge),
+            abi.decode(
+                IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).getConfig(Types.ConfigType.L1_ERC_721_BRIDGE_ADDRESS),
+                (address)
+            )
+        );
+    }
+
+    /// @dev This function is used to upgrade the L1Block contract.
+    function _upgradeL1Block() internal {
+        IL1Block l1Block =
+            IL1Block(DeployUtils.createDeterministic({ _name: "L1Block", _args: bytes(""), _salt: _salt }));
+
+        IL2ProxyAdmin proxyAdmin = IL2ProxyAdmin(Predeploys.L2_PROXY_ADMIN);
+
+        vm.prank(proxyAdmin.owner());
+        proxyAdmin.upgrade(payable(Predeploys.L1_BLOCK_ATTRIBUTES), address(l1Block));
+    }
+
+    /// @dev This function is used to upgrade the remaining proxies used in the isthmus upgrade flow.
+    function _upgradeProxies() internal {
+        IL2ProxyAdmin proxyAdmin = IL2ProxyAdmin(Predeploys.L2_PROXY_ADMIN);
+
+        // Bridges
+        address standardBridge =
+            DeployUtils.createDeterministic({ _name: "L2StandardBridge", _args: bytes(""), _salt: _salt });
+        address erc721Bridge =
+            DeployUtils.createDeterministic({ _name: "L2ERC721Bridge", _args: bytes(""), _salt: _salt });
+
+        // Fee Vaults
         address baseFeeVault =
             DeployUtils.createDeterministic({ _name: "BaseFeeVault", _args: bytes(""), _salt: _salt });
         address l1FeeVault = DeployUtils.createDeterministic({ _name: "L1FeeVault", _args: bytes(""), _salt: _salt });
@@ -76,42 +189,26 @@ contract IsthmusUpgradeTest is Test {
         proxyAdmin.upgrade(payable(Predeploys.BASE_FEE_VAULT), address(baseFeeVault));
         proxyAdmin.upgrade(payable(Predeploys.L1_FEE_VAULT), address(l1FeeVault));
         proxyAdmin.upgrade(payable(Predeploys.SEQUENCER_FEE_WALLET), address(sequencerFeeVault));
+        proxyAdmin.upgrade(payable(Predeploys.L2_STANDARD_BRIDGE), address(standardBridge));
+        proxyAdmin.upgrade(payable(Predeploys.L2_ERC721_BRIDGE), address(erc721Bridge));
         vm.stopPrank();
+    }
 
-        {
-            bytes memory baseFeeVaultConfig =
-                IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).getConfig(Types.ConfigType.BASE_FEE_VAULT_CONFIG);
-
-            assertEq(
-                abi.decode(baseFeeVaultConfig, (bytes32)),
-                Encoding.encodeFeeVaultConfig(
-                    baseFeeVaultRecipient, baseFeeVaultMinWithdrawalAmount, Types.WithdrawalNetwork.L2
-                )
-            );
-        }
-
-        {
-            bytes memory l1FeeVaultConfig =
-                IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).getConfig(Types.ConfigType.L1_FEE_VAULT_CONFIG);
-
-            assertEq(
-                abi.decode(l1FeeVaultConfig, (bytes32)),
-                Encoding.encodeFeeVaultConfig(
-                    l1FeeVaultRecipient, l1FeeVaultMinWithdrawalAmount, Types.WithdrawalNetwork.L2
-                )
-            );
-        }
-
-        {
-            bytes memory sequencerFeeVaultConfig =
-                IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).getConfig(Types.ConfigType.SEQUENCER_FEE_VAULT_CONFIG);
-
-            assertEq(
-                abi.decode(sequencerFeeVaultConfig, (bytes32)),
-                Encoding.encodeFeeVaultConfig(
-                    sequencerFeeVaultRecipient, sequencerFeeVaultMinWithdrawalAmount, Types.WithdrawalNetwork.L2
-                )
-            );
-        }
+    /// @dev This function compares the fee vault config to the expected values.
+    /// @param _config The fee vault config to compare.
+    /// @param _recipient The expected recipient of the fee vault.
+    /// @param _minWithdrawalAmount The expected minimum withdrawal amount of the fee vault.
+    /// @return true if the fee vault config matches the expected values, false otherwise.
+    function _checkFeeVaultConfig(
+        bytes memory _config,
+        address _recipient,
+        uint256 _minWithdrawalAmount
+    )
+        internal
+        pure
+        returns (bool)
+    {
+        return abi.decode(_config, (bytes32))
+            == Encoding.encodeFeeVaultConfig(_recipient, _minWithdrawalAmount, Types.WithdrawalNetwork.L2);
     }
 }

--- a/packages/contracts-bedrock/test/L2/IsthmusUpgrade.t.sol
+++ b/packages/contracts-bedrock/test/L2/IsthmusUpgrade.t.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+// Libraries
+import { Test } from "forge-std/Test.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Constants } from "src/libraries/Constants.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
+import { Types } from "src/libraries/Types.sol";
+
+// Interfaces
+import { IL1Block } from "interfaces/L2/IL1Block.sol";
+import { IL2ProxyAdmin } from "interfaces/L2/IL2ProxyAdmin.sol";
+import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
+
+contract IsthmusUpgradeTest is Test {
+    bytes32 internal _salt = DeployUtils.DEFAULT_SALT;
+
+    function setUp() public {
+        if (!isForkTest()) {
+            return;
+        }
+
+        vm.createSelectFork(vm.envString("FORK_RPC_URL"), vm.envUint("FORK_BLOCK_NUMBER"));
+    }
+
+    /// @notice Indicates whether a test is running against a forked production network.
+    function isForkTest() public view returns (bool) {
+        return vm.envOr("FORK_TEST", false);
+    }
+
+    /// @dev This test is used to test the isthmus upgrade flow.
+    ///      It is a forked test to be able to test the correct values for the fee vaults once the isthmus upgrade is
+    ///      complete.
+    function test_setIsthmusUpgrade() external {
+        vm.skip(!isForkTest());
+
+        /// 1. Deploy the L1Block contract
+        IL1Block l1Block =
+            IL1Block(DeployUtils.createDeterministic({ _name: "L1Block", _args: bytes(""), _salt: _salt }));
+
+        IL2ProxyAdmin proxyAdmin = IL2ProxyAdmin(Predeploys.L2_PROXY_ADMIN);
+
+        /// 2. Upgrade the L1Block contract
+        vm.prank(proxyAdmin.owner());
+        proxyAdmin.upgrade(payable(Predeploys.L1_BLOCK_ATTRIBUTES), address(l1Block));
+
+        assertEq(IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isIsthmus(), false);
+
+        /// 3. Perform the isthmus upgrade
+        vm.prank(Constants.DEPOSITOR_ACCOUNT);
+        IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).setIsthmus();
+
+        assertEq(IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isIsthmus(), true);
+
+        // Obtain the receipient, min withdrawal amount, and network for the fee vaults
+        address baseFeeVaultRecipient = IFeeVault(payable(Predeploys.BASE_FEE_VAULT)).RECIPIENT();
+        uint256 baseFeeVaultMinWithdrawalAmount = IFeeVault(payable(Predeploys.BASE_FEE_VAULT)).MIN_WITHDRAWAL_AMOUNT();
+
+        address l1FeeVaultRecipient = IFeeVault(payable(Predeploys.L1_FEE_VAULT)).RECIPIENT();
+        uint256 l1FeeVaultMinWithdrawalAmount = IFeeVault(payable(Predeploys.L1_FEE_VAULT)).MIN_WITHDRAWAL_AMOUNT();
+
+        address sequencerFeeVaultRecipient = IFeeVault(payable(Predeploys.SEQUENCER_FEE_WALLET)).RECIPIENT();
+        uint256 sequencerFeeVaultMinWithdrawalAmount =
+            IFeeVault(payable(Predeploys.SEQUENCER_FEE_WALLET)).MIN_WITHDRAWAL_AMOUNT();
+
+        // 4. Upgrade the remaining proxies
+        address baseFeeVault =
+            DeployUtils.createDeterministic({ _name: "BaseFeeVault", _args: bytes(""), _salt: _salt });
+        address l1FeeVault = DeployUtils.createDeterministic({ _name: "L1FeeVault", _args: bytes(""), _salt: _salt });
+        address sequencerFeeVault =
+            DeployUtils.createDeterministic({ _name: "SequencerFeeVault", _args: bytes(""), _salt: _salt });
+
+        vm.startPrank(proxyAdmin.owner());
+        proxyAdmin.upgrade(payable(Predeploys.BASE_FEE_VAULT), address(baseFeeVault));
+        proxyAdmin.upgrade(payable(Predeploys.L1_FEE_VAULT), address(l1FeeVault));
+        proxyAdmin.upgrade(payable(Predeploys.SEQUENCER_FEE_WALLET), address(sequencerFeeVault));
+        vm.stopPrank();
+
+        {
+            bytes memory baseFeeVaultConfig =
+                IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).getConfig(Types.ConfigType.BASE_FEE_VAULT_CONFIG);
+
+            assertEq(
+                abi.decode(baseFeeVaultConfig, (bytes32)),
+                Encoding.encodeFeeVaultConfig(
+                    baseFeeVaultRecipient, baseFeeVaultMinWithdrawalAmount, Types.WithdrawalNetwork.L2
+                )
+            );
+        }
+
+        {
+            bytes memory l1FeeVaultConfig =
+                IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).getConfig(Types.ConfigType.L1_FEE_VAULT_CONFIG);
+
+            assertEq(
+                abi.decode(l1FeeVaultConfig, (bytes32)),
+                Encoding.encodeFeeVaultConfig(
+                    l1FeeVaultRecipient, l1FeeVaultMinWithdrawalAmount, Types.WithdrawalNetwork.L2
+                )
+            );
+        }
+
+        {
+            bytes memory sequencerFeeVaultConfig =
+                IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).getConfig(Types.ConfigType.SEQUENCER_FEE_VAULT_CONFIG);
+
+            assertEq(
+                abi.decode(sequencerFeeVaultConfig, (bytes32)),
+                Encoding.encodeFeeVaultConfig(
+                    sequencerFeeVaultRecipient, sequencerFeeVaultMinWithdrawalAmount, Types.WithdrawalNetwork.L2
+                )
+            );
+        }
+    }
+}

--- a/packages/contracts-bedrock/test/L2/IsthmusUpgrade.t.sol
+++ b/packages/contracts-bedrock/test/L2/IsthmusUpgrade.t.sol
@@ -17,21 +17,19 @@ import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
 import { ICrossDomainMessenger } from "interfaces/universal/ICrossDomainMessenger.sol";
 import { IStandardBridge } from "interfaces/universal/IStandardBridge.sol";
 import { IERC721Bridge } from "interfaces/universal/IERC721Bridge.sol";
+import { IL2CrossDomainMessenger } from "interfaces/L2/IL2CrossDomainMessenger.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 
 contract IsthmusUpgradeTest is Test {
     bytes32 internal _salt = DeployUtils.DEFAULT_SALT;
-
-    uint256 internal _l1Fork;
-    uint256 internal _l2Fork;
 
     function setUp() public {
         if (!isForkTest()) {
             return;
         }
 
-        _l2Fork = vm.createFork(vm.envString("FORK_L2_RPC_URL"), vm.envUint("FORK_L2_BLOCK_NUMBER"));
-
-        _l1Fork = vm.createFork(vm.envString("FORK_L1_RPC_URL"), vm.envUint("FORK_L1_BLOCK_NUMBER"));
+        vm.createSelectFork(vm.envString("FORK_RPC_URL"), vm.envUint("FORK_BLOCK_NUMBER"));
     }
 
     /// @notice Indicates whether a test is running against a forked production network.
@@ -44,8 +42,6 @@ contract IsthmusUpgradeTest is Test {
     ///      complete.
     function test_setIsthmusUpgrade_feeVaults() external {
         vm.skip(!isForkTest());
-
-        vm.selectFork(_l2Fork);
 
         /// 1. Deploy the new L1Block implementation contract
         /// 2. Upgrade the L1Block contract
@@ -99,8 +95,6 @@ contract IsthmusUpgradeTest is Test {
     ///      is complete.
     function test_setIsthmusUpgrade_otherContracts() external {
         vm.skip(!isForkTest());
-
-        vm.selectFork(_l2Fork);
 
         /// 1. Deploy the new L1Block implementation contract
         /// 2. Upgrade the L1Block contract


### PR DESCRIPTION
Adding a basic forked test for the upgrade path described in `L1Block::setIsthmus`. Opted to use forked test so asserting the configuration moving from the fee vaults to the L1Block is easily achievable. 

Closes OPT-711
Closes OPT-712