### PR TITLE
fix: second comments

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
@@ -30,8 +30,8 @@ interface IETHLockbox is IPAOBase, ISemver {
     function lockETH() external payable;
     function unlockETH(uint256 _value) external;
     function authorizePortal(IOptimismPortal2 _portal) external;
-    function authorizeLockbox(address _lockbox) external;
-    function migrateLiquidity(address _lockbox) external;
+    function authorizeLockbox(IETHLockbox _lockbox) external;
+    function migrateLiquidity(IETHLockbox _lockbox) external;
 
     function __constructor__() external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IPAOBase } from "interfaces/L1/IPAOBase.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 
 interface IETHLockbox is IPAOBase, ISemver {
     error ETHLockbox_Unauthorized();
@@ -20,7 +21,7 @@ interface IETHLockbox is IPAOBase, ISemver {
     event LiquidityMigrated(address indexed lockbox);
     event LiquidityReceived(address indexed lockbox);
 
-    function initialize(address _superchainConfig, address[] calldata _portals) external;
+    function initialize(ISuperchainConfig _superchainConfig, IOptimismPortal2[] calldata _portals) external;
     function superchainConfig() external view returns (ISuperchainConfig);
     function paused() external view returns (bool);
     function authorizedPortals(address) external view returns (bool);
@@ -28,7 +29,7 @@ interface IETHLockbox is IPAOBase, ISemver {
     function receiveLiquidity() external payable;
     function lockETH() external payable;
     function unlockETH(uint256 _value) external;
-    function authorizePortal(address _portal) external;
+    function authorizePortal(IOptimismPortal2 _portal) external;
     function authorizeLockbox(address _lockbox) external;
     function migrateLiquidity(address _lockbox) external;
 

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -61,7 +61,7 @@ interface IOptimismPortal2 is IPAOBase {
     function disputeGameFactory() external view returns (IDisputeGameFactory);
     function disputeGameFinalityDelaySeconds() external view returns (uint256);
     function donateETH() external payable;
-    function updateLockbox(address _newLockbox) external;
+    function updateLockbox(IETHLockbox _newLockbox) external;
     function finalizeWithdrawalTransaction(Types.WithdrawalTransaction memory _tx) external;
     function finalizeWithdrawalTransactionExternalProof(
         Types.WithdrawalTransaction memory _tx,

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
@@ -62,7 +62,7 @@ interface IOptimismPortalInterop is IPAOBase {
     function disputeGameFactory() external view returns (IDisputeGameFactory);
     function disputeGameFinalityDelaySeconds() external view returns (uint256);
     function donateETH() external payable;
-    function updateLockbox(address _newLockbox) external;
+    function updateLockbox(IETHLockbox _newLockbox) external;
     function finalizeWithdrawalTransaction(Types.WithdrawalTransaction memory _tx) external;
     function finalizeWithdrawalTransactionExternalProof(
         Types.WithdrawalTransaction memory _tx,

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -22,7 +22,7 @@ import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
-import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
 import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 import { ProtocolVersion, IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
@@ -368,7 +368,7 @@ library ChainAssertions {
         internal
         view
     {
-        IOptimismPortal2 portal = IOptimismPortal2(payable(_contracts.OptimismPortal));
+        IOptimismPortal portal = IOptimismPortal(payable(_contracts.OptimismPortal));
         console.log(
             "Running chain assertions on the OptimismPortal2 %s at %s",
             _isProxy ? "proxy" : "implementation",

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -19,7 +19,7 @@ import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol"
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IOPContractsManagerInterop } from "interfaces/L1/IOPContractsManagerInterop.sol";
-import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
@@ -150,7 +150,7 @@ contract DeployImplementationsInput is BaseDeployIO {
 contract DeployImplementationsOutput is BaseDeployIO {
     IOPContractsManager internal _opcm;
     IDelayedWETH internal _delayedWETHImpl;
-    IOptimismPortal2 internal _optimismPortalImpl;
+    IOptimismPortal internal _optimismPortalImpl;
     IETHLockbox internal _ethLockboxImpl;
     IPreimageOracle internal _preimageOracleSingleton;
     IMIPS internal _mipsSingleton;
@@ -171,7 +171,7 @@ contract DeployImplementationsOutput is BaseDeployIO {
         if (_sel == this.opcm.selector) _opcm = IOPContractsManager(_addr);
         else if (_sel == this.superchainConfigImpl.selector) _superchainConfigImpl = ISuperchainConfig(_addr);
         else if (_sel == this.protocolVersionsImpl.selector) _protocolVersionsImpl = IProtocolVersions(_addr);
-        else if (_sel == this.optimismPortalImpl.selector) _optimismPortalImpl = IOptimismPortal2(payable(_addr));
+        else if (_sel == this.optimismPortalImpl.selector) _optimismPortalImpl = IOptimismPortal(payable(_addr));
         else if (_sel == this.ethLockboxImpl.selector) _ethLockboxImpl = IETHLockbox(payable(_addr));
         else if (_sel == this.delayedWETHImpl.selector) _delayedWETHImpl = IDelayedWETH(payable(_addr));
         else if (_sel == this.preimageOracleSingleton.selector) _preimageOracleSingleton = IPreimageOracle(_addr);
@@ -231,7 +231,7 @@ contract DeployImplementationsOutput is BaseDeployIO {
         return _protocolVersionsImpl;
     }
 
-    function optimismPortalImpl() public view returns (IOptimismPortal2) {
+    function optimismPortalImpl() public view returns (IOptimismPortal) {
         DeployUtils.assertValidContractAddress(address(_optimismPortalImpl));
         return _optimismPortalImpl;
     }
@@ -316,7 +316,7 @@ contract DeployImplementationsOutput is BaseDeployIO {
     }
 
     function assertValidOptimismPortalImpl(DeployImplementationsInput) internal view {
-        IOptimismPortal2 portal = optimismPortalImpl();
+        IOptimismPortal portal = optimismPortalImpl();
 
         DeployUtils.assertInitialized({ _contractAddress: address(portal), _isProxy: false, _slot: 0, _offset: 0 });
 
@@ -726,11 +726,11 @@ contract DeployImplementations is Script {
         virtual
     {
         uint256 proofMaturityDelaySeconds = _dii.proofMaturityDelaySeconds();
-        IOptimismPortal2 impl = IOptimismPortal2(
+        IOptimismPortal impl = IOptimismPortal(
             DeployUtils.createDeterministic({
                 _name: "OptimismPortal2",
                 _args: DeployUtils.encodeConstructor(
-                    abi.encodeCall(IOptimismPortal2.__constructor__, (proofMaturityDelaySeconds))
+                    abi.encodeCall(IOptimismPortal.__constructor__, (proofMaturityDelaySeconds))
                 ),
                 _salt: _salt
             })

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -624,6 +624,7 @@ contract DeployOPChain is Script {
 
         // Check once the portal is updated to use the new lockbox.
         require(address(portal.ethLockbox()) == address(_doo.ethLockboxProxy()), "PORTAL-90");
+        require(portal.PAO() == _doi.opChainProxyAdminOwner(), "PORTAL-100");
     }
 
     function assertValidETHLockbox(DeployOPChainInput _doi, DeployOPChainOutput _doo) internal {
@@ -631,6 +632,7 @@ contract DeployOPChain is Script {
 
         require(address(lockbox.superchainConfig()) == address(_doi.opcm().superchainConfig()), "ETHLOCKBOX-10");
         require(lockbox.authorizedPortals(address(_doo.optimismPortalProxy())), "ETHLOCKBOX-20");
+        require(lockbox.PAO() == _doi.opChainProxyAdminOwner(), "ETHLOCKBOX-30");
     }
 
     function assertValidDisputeGameFactory(DeployOPChainInput _doi, DeployOPChainOutput _doo) internal {

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -27,7 +27,7 @@ import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
 import { Claim, Duration, GameType, GameTypes, Hash } from "src/dispute/lib/Types.sol";
 
-import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
@@ -225,7 +225,7 @@ contract DeployOPChainOutput is BaseDeployIO {
     IOptimismMintableERC20Factory internal _optimismMintableERC20FactoryProxy;
     IL1StandardBridge internal _l1StandardBridgeProxy;
     IL1CrossDomainMessenger internal _l1CrossDomainMessengerProxy;
-    IOptimismPortal2 internal _optimismPortalProxy;
+    IOptimismPortal internal _optimismPortalProxy;
     IETHLockbox internal _ethLockboxProxy;
     IDisputeGameFactory internal _disputeGameFactoryProxy;
     IAnchorStateRegistry internal _anchorStateRegistryProxy;
@@ -244,7 +244,7 @@ contract DeployOPChainOutput is BaseDeployIO {
         else if (_sel == this.optimismMintableERC20FactoryProxy.selector) _optimismMintableERC20FactoryProxy = IOptimismMintableERC20Factory(_addr) ;
         else if (_sel == this.l1StandardBridgeProxy.selector) _l1StandardBridgeProxy = IL1StandardBridge(payable(_addr)) ;
         else if (_sel == this.l1CrossDomainMessengerProxy.selector) _l1CrossDomainMessengerProxy = IL1CrossDomainMessenger(_addr) ;
-        else if (_sel == this.optimismPortalProxy.selector) _optimismPortalProxy = IOptimismPortal2(payable(_addr)) ;
+        else if (_sel == this.optimismPortalProxy.selector) _optimismPortalProxy = IOptimismPortal(payable(_addr)) ;
         else if (_sel == this.ethLockboxProxy.selector) _ethLockboxProxy = IETHLockbox(payable(_addr)) ;
         else if (_sel == this.disputeGameFactoryProxy.selector) _disputeGameFactoryProxy = IDisputeGameFactory(_addr) ;
         else if (_sel == this.anchorStateRegistryProxy.selector) _anchorStateRegistryProxy = IAnchorStateRegistry(_addr) ;
@@ -296,7 +296,7 @@ contract DeployOPChainOutput is BaseDeployIO {
         return _l1CrossDomainMessengerProxy;
     }
 
-    function optimismPortalProxy() public returns (IOptimismPortal2) {
+    function optimismPortalProxy() public returns (IOptimismPortal) {
         DeployUtils.assertValidContractAddress(address(_optimismPortalProxy));
         DeployUtils.assertERC1967ImplementationSet(address(_optimismPortalProxy));
         return _optimismPortalProxy;
@@ -607,7 +607,7 @@ contract DeployOPChain is Script {
     }
 
     function assertValidOptimismPortal(DeployOPChainInput _doi, DeployOPChainOutput _doo) internal {
-        IOptimismPortal2 portal = _doo.optimismPortalProxy();
+        IOptimismPortal portal = _doo.optimismPortalProxy();
         ISuperchainConfig superchainConfig = ISuperchainConfig(address(_doi.opcm().superchainConfig()));
 
         require(address(portal.anchorStateRegistry()) == address(_doo.anchorStateRegistryProxy()), "PORTAL-10");

--- a/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
+++ b/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
@@ -366,21 +366,6 @@ library DeployUtils {
         }
     }
 
-    function assertInitializedOZv5(address _contractAddress, bool _isProxy) internal view {
-        // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.Initializable")) - 1)) & ~bytes32(uint256(0xff))
-        bytes32 INITIALIZABLE_STORAGE = 0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
-
-        bytes32 slotVal = vm.load(_contractAddress, INITIALIZABLE_STORAGE);
-        uint64 initialized = uint64(uint256(slotVal) & 0xFFFFFFFFFFFFFFFF);
-        if (_isProxy) {
-            require(initialized == 1, "DeployUtils: storage value is not 1 at the given slot and offset");
-        } else {
-            require(
-                initialized == type(uint64).max, "DeployUtils: storage value is not 0xff at the given slot and offset"
-            );
-        }
-    }
-
     /// @notice Etches a contract, labels it, and allows cheatcodes for it.
     /// @param _etchTo Address of the contract to etch.
     /// @param _cname The contract name (also used to label the contract).

--- a/packages/contracts-bedrock/snapshots/abi/ETHLockbox.json
+++ b/packages/contracts-bedrock/snapshots/abi/ETHLockbox.json
@@ -20,7 +20,7 @@
   {
     "inputs": [
       {
-        "internalType": "address",
+        "internalType": "contract IETHLockbox",
         "name": "_lockbox",
         "type": "address"
       }
@@ -33,7 +33,7 @@
   {
     "inputs": [
       {
-        "internalType": "address",
+        "internalType": "contract IOptimismPortal2",
         "name": "_portal",
         "type": "address"
       }
@@ -84,12 +84,12 @@
   {
     "inputs": [
       {
-        "internalType": "address",
+        "internalType": "contract ISuperchainConfig",
         "name": "_superchainConfig",
         "type": "address"
       },
       {
-        "internalType": "address[]",
+        "internalType": "contract IOptimismPortal2[]",
         "name": "_portals",
         "type": "address[]"
       }
@@ -109,7 +109,7 @@
   {
     "inputs": [
       {
-        "internalType": "address",
+        "internalType": "contract IETHLockbox",
         "name": "_lockbox",
         "type": "address"
       }

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
@@ -589,7 +589,7 @@
   {
     "inputs": [
       {
-        "internalType": "address",
+        "internalType": "contract IETHLockbox",
         "name": "_newLockbox",
         "type": "address"
       }

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortalInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortalInterop.json
@@ -607,7 +607,7 @@
   {
     "inputs": [
       {
-        "internalType": "address",
+        "internalType": "contract IETHLockbox",
         "name": "_newLockbox",
         "type": "address"
       }

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -5,7 +5,7 @@
   },
   "src/L1/ETHLockbox.sol": {
     "initCodeHash": "0xb5da33c92a6f0bc00eaaaec5d0b99c9c15a9dd9d7a25c416cd6740a96e7fc4d5",
-    "sourceCodeHash": "0x27817f59ef48aad41a20c9d8881546141b23ffd69e0879a9a98a4e83b70c9e45"
+    "sourceCodeHash": "0x12af194d8fe23ff1c15c378151c7cb9e5a3854531b69c1153475432ef9f73d5e"
   },
   "src/L1/L1CrossDomainMessenger.sol": {
     "initCodeHash": "0x03a3c0eb2418aba9f93bb89723ba2ee7cb9e1988ca00f380503c960149c85b7a",
@@ -21,7 +21,7 @@
   },
   "src/L1/OPContractsManager.sol": {
     "initCodeHash": "0x6eaf1dcd6b87f4372445e8a8936efa4e9879cfd05c1de8a306acb69266ee03d9",
-    "sourceCodeHash": "0x4a697d6318965a81b35634c07eb76e7042d074adf5a5b5e6447f9d752cfb8c58"
+    "sourceCodeHash": "0x9205651bfa81ac60fc331892c792ae6f668601556270ac6a5cda9c5e2258f524"
   },
   "src/L1/OPContractsManagerInterop.sol": {
     "initCodeHash": "0x7865201a60d422cda5b33a2ff22b4ab707a15ba54016182d2a6cca367d618d74",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -5,7 +5,7 @@
   },
   "src/L1/ETHLockbox.sol": {
     "initCodeHash": "0xb5da33c92a6f0bc00eaaaec5d0b99c9c15a9dd9d7a25c416cd6740a96e7fc4d5",
-    "sourceCodeHash": "0xc9ac52290abc2f3c7071e12116593f4bad504961ffa11825161072a5aa94c23c"
+    "sourceCodeHash": "0x27817f59ef48aad41a20c9d8881546141b23ffd69e0879a9a98a4e83b70c9e45"
   },
   "src/L1/L1CrossDomainMessenger.sol": {
     "initCodeHash": "0x03a3c0eb2418aba9f93bb89723ba2ee7cb9e1988ca00f380503c960149c85b7a",
@@ -21,7 +21,7 @@
   },
   "src/L1/OPContractsManager.sol": {
     "initCodeHash": "0x6eaf1dcd6b87f4372445e8a8936efa4e9879cfd05c1de8a306acb69266ee03d9",
-    "sourceCodeHash": "0x624703c5d5b8a1d36ff44b61d1a1512e3a1776f179f2cc386f28d1b789c9fe9b"
+    "sourceCodeHash": "0x4a697d6318965a81b35634c07eb76e7042d074adf5a5b5e6447f9d752cfb8c58"
   },
   "src/L1/OPContractsManagerInterop.sol": {
     "initCodeHash": "0x7865201a60d422cda5b33a2ff22b4ab707a15ba54016182d2a6cca367d618d74",
@@ -33,7 +33,7 @@
   },
   "src/L1/OptimismPortal2.sol": {
     "initCodeHash": "0x084ac1d109f9bdaba389fdad4dc3887af745b825356e1c70bc5ba43a23a8c7b7",
-    "sourceCodeHash": "0x91acba845145aca7a342cdafb55129546acefce122562739ebc0fdb655edad1a"
+    "sourceCodeHash": "0xf23dea8126e89157c43561cee63f8701118c3017d7662ed066d3fa157f32b441"
   },
   "src/L1/OptimismPortalInterop.sol": {
     "initCodeHash": "0x5f0e909be4f924aaf4742a84ed1dd134d84e5b91101e8cbd6c7ffbf893b4da84",

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -164,7 +164,6 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
     /// @param _portal The address of the portal to authorize.
     function _authorizePortal(address _portal) internal {
         if (!_samePAO(_portal)) revert ETHLockbox_DifferentPAO();
-        if (authorizedPortals[_portal]) revert ETHLockbox_AlreadyAuthorized();
 
         authorizedPortals[_portal] = true;
         emit PortalAuthorized(_portal);

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -12,6 +12,7 @@ import { Constants } from "src/libraries/Constants.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
 /// @custom:proxied true
 /// @title ETHLockbox
@@ -139,24 +140,24 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
 
     /// @notice Authorizes an ETH lockbox to migrate its liquidity to the current ETH lockbox.
     /// @param _lockbox The address of the ETH lockbox to authorize.
-    function authorizeLockbox(address _lockbox) external {
+    function authorizeLockbox(IETHLockbox _lockbox) external {
         if (msg.sender != PAO()) revert ETHLockbox_Unauthorized();
-        if (!_samePAO(_lockbox)) revert ETHLockbox_DifferentPAO();
-        if (authorizedLockboxes[_lockbox]) revert ETHLockbox_AlreadyAuthorized();
+        if (!_samePAO(address(_lockbox))) revert ETHLockbox_DifferentPAO();
+        if (authorizedLockboxes[address(_lockbox)]) revert ETHLockbox_AlreadyAuthorized();
 
-        authorizedLockboxes[_lockbox] = true;
-        emit LockboxAuthorized(_lockbox);
+        authorizedLockboxes[address(_lockbox)] = true;
+        emit LockboxAuthorized(address(_lockbox));
     }
 
     /// @notice Migrates liquidity from the current ETH lockbox to another.
     /// @param _lockbox The address of the ETH lockbox to migrate liquidity to.
-    function migrateLiquidity(address _lockbox) external {
+    function migrateLiquidity(IETHLockbox _lockbox) external {
         if (msg.sender != PAO()) revert ETHLockbox_Unauthorized();
-        if (!_samePAO(_lockbox)) revert ETHLockbox_DifferentPAO();
+        if (!_samePAO(address(_lockbox))) revert ETHLockbox_DifferentPAO();
 
-        ETHLockbox(_lockbox).receiveLiquidity{ value: address(this).balance }();
+        IETHLockbox(_lockbox).receiveLiquidity{ value: address(this).balance }();
 
-        emit LiquidityMigrated(_lockbox);
+        emit LiquidityMigrated(address(_lockbox));
     }
 
     /// @notice Authorizes a portal to lock and unlock ETH.

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -10,7 +10,7 @@ import { Constants } from "src/libraries/Constants.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
-import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 /// @custom:proxied true
@@ -82,18 +82,24 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
     /// @notice Initializer.
     /// @param _superchainConfig The address of the SuperchainConfig contract.
     /// @param _portals The addresses of the portals to authorize.
-    function initialize(address _superchainConfig, address[] calldata _portals) external initializer {
+    function initialize(
+        ISuperchainConfig _superchainConfig,
+        IOptimismPortal2[] calldata _portals
+    )
+        external
+        initializer
+    {
         superchainConfig = ISuperchainConfig(_superchainConfig);
         for (uint256 i; i < _portals.length; i++) {
-            _authorizePortal(_portals[i]);
+            _authorizePortal(address(_portals[i]));
         }
     }
 
     /// @notice Authorizes a portal to lock and unlock ETH.
     /// @param _portal The address of the portal to authorize.
-    function authorizePortal(address _portal) external {
+    function authorizePortal(IOptimismPortal2 _portal) external {
         if (msg.sender != PAO()) revert ETHLockbox_Unauthorized();
-        _authorizePortal(_portal);
+        _authorizePortal(address(_portal));
     }
 
     /// @notice Getter for the current paused status.
@@ -122,12 +128,12 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
         if (paused()) revert ETHLockbox_Paused();
         if (!authorizedPortals[msg.sender]) revert ETHLockbox_Unauthorized();
         /// NOTE: Check l2Sender is not set to avoid this function to be called as a target on a withdrawal transaction
-        if (IOptimismPortal(payable(msg.sender)).l2Sender() != Constants.DEFAULT_L2_SENDER) {
+        if (IOptimismPortal2(payable(msg.sender)).l2Sender() != Constants.DEFAULT_L2_SENDER) {
             revert ETHLockbox_NoWithdrawalTransactions();
         }
 
         // Using `donateETH` to avoid triggering a deposit
-        IOptimismPortal(payable(msg.sender)).donateETH{ value: _value }();
+        IOptimismPortal2(payable(msg.sender)).donateETH{ value: _value }();
         emit ETHUnlocked(msg.sender, _value);
     }
 

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -10,7 +10,7 @@ import { Constants } from "src/libraries/Constants.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
-import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
@@ -85,7 +85,7 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
     /// @param _portals The addresses of the portals to authorize.
     function initialize(
         ISuperchainConfig _superchainConfig,
-        IOptimismPortal2[] calldata _portals
+        IOptimismPortal[] calldata _portals
     )
         external
         initializer
@@ -98,7 +98,7 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
 
     /// @notice Authorizes a portal to lock and unlock ETH.
     /// @param _portal The address of the portal to authorize.
-    function authorizePortal(IOptimismPortal2 _portal) external {
+    function authorizePortal(IOptimismPortal _portal) external {
         if (msg.sender != PAO()) revert ETHLockbox_Unauthorized();
         _authorizePortal(address(_portal));
     }
@@ -129,12 +129,12 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
         if (paused()) revert ETHLockbox_Paused();
         if (!authorizedPortals[msg.sender]) revert ETHLockbox_Unauthorized();
         /// NOTE: Check l2Sender is not set to avoid this function to be called as a target on a withdrawal transaction
-        if (IOptimismPortal2(payable(msg.sender)).l2Sender() != Constants.DEFAULT_L2_SENDER) {
+        if (IOptimismPortal(payable(msg.sender)).l2Sender() != Constants.DEFAULT_L2_SENDER) {
             revert ETHLockbox_NoWithdrawalTransactions();
         }
 
         // Using `donateETH` to avoid triggering a deposit
-        IOptimismPortal2(payable(msg.sender)).donateETH{ value: _value }();
+        IOptimismPortal(payable(msg.sender)).donateETH{ value: _value }();
         emit ETHUnlocked(msg.sender, _value);
     }
 

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -23,7 +23,7 @@ import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
-import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
@@ -76,7 +76,7 @@ contract OPContractsManager is ISemver {
         IL1CrossDomainMessenger l1CrossDomainMessengerProxy;
         IETHLockbox ethLockboxProxy;
         // Fault proof contracts below.
-        IOptimismPortal2 optimismPortalProxy;
+        IOptimismPortal optimismPortalProxy;
         IDisputeGameFactory disputeGameFactoryProxy;
         IAnchorStateRegistry anchorStateRegistryProxy;
         IFaultDisputeGame faultDisputeGame;
@@ -309,7 +309,7 @@ contract OPContractsManager is ISemver {
         output.l1ERC721BridgeProxy =
             IL1ERC721Bridge(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "L1ERC721Bridge"));
         output.optimismPortalProxy =
-            IOptimismPortal2(payable(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "OptimismPortal")));
+            IOptimismPortal(payable(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "OptimismPortal")));
         output.ethLockboxProxy = IETHLockbox(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "ETHLockbox"));
         output.systemConfigProxy =
             ISystemConfig(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "SystemConfig"));
@@ -397,7 +397,7 @@ contract OPContractsManager is ISemver {
             output.opChainProxyAdmin, address(output.optimismPortalProxy), implementation.optimismPortalImpl, data
         );
 
-        IOptimismPortal2[] memory portals = new IOptimismPortal2[](1);
+        IOptimismPortal[] memory portals = new IOptimismPortal[](1);
         portals[0] = output.optimismPortalProxy;
         data = encodeETHLockboxInitializer(portals);
         upgradeToAndCall(output.opChainProxyAdmin, address(output.ethLockboxProxy), implementation.ethLockboxImpl, data);
@@ -520,7 +520,7 @@ contract OPContractsManager is ISemver {
             // Grab the respected game type BEFORE upgrading the OptimismPortal or the function
             // won't work because the new implementation tries to get it from the
             // AnchorStateRegistry which doesn't have it yet.
-            GameType respectedGameType = IOptimismPortal2(payable(opChainAddrs.optimismPortal)).respectedGameType();
+            GameType respectedGameType = IOptimismPortal(payable(opChainAddrs.optimismPortal)).respectedGameType();
 
             // -------- Upgrade Contracts Stored in SystemConfig --------
             upgradeTo(
@@ -614,8 +614,8 @@ contract OPContractsManager is ISemver {
                     );
 
                     // Initialize the ETHLockbox.
-                    IOptimismPortal2[] memory portals = new IOptimismPortal2[](1);
-                    portals[0] = IOptimismPortal2(payable(opChainAddrs.optimismPortal));
+                    IOptimismPortal[] memory portals = new IOptimismPortal[](1);
+                    portals[0] = IOptimismPortal(payable(opChainAddrs.optimismPortal));
                     upgradeToAndCall(
                         _opChainConfigs[i].proxyAdmin,
                         address(ethLockbox),
@@ -625,7 +625,7 @@ contract OPContractsManager is ISemver {
 
                     // Upgrade the OptimismPortal to have a reference to the new AnchorStateRegistry and ETHLockbox,
                     // and migrate the ETH balance to the ETHLockbox.
-                    IOptimismPortal2(payable(opChainAddrs.optimismPortal)).upgrade(
+                    IOptimismPortal(payable(opChainAddrs.optimismPortal)).upgrade(
                         newAnchorStateRegistryProxy, ethLockbox
                     );
                 }
@@ -889,13 +889,13 @@ contract OPContractsManager is ISemver {
         returns (bytes memory)
     {
         return abi.encodeCall(
-            IOptimismPortal2.initialize,
+            IOptimismPortal.initialize,
             (_output.systemConfigProxy, superchainConfig, _output.anchorStateRegistryProxy, _output.ethLockboxProxy)
         );
     }
 
     /// @notice Helper method for encoding the ETHLockbox initializer data.
-    function encodeETHLockboxInitializer(IOptimismPortal2[] memory _portals)
+    function encodeETHLockboxInitializer(IOptimismPortal[] memory _portals)
         internal
         view
         virtual

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -397,8 +397,8 @@ contract OPContractsManager is ISemver {
             output.opChainProxyAdmin, address(output.optimismPortalProxy), implementation.optimismPortalImpl, data
         );
 
-        address[] memory portals = new address[](1);
-        portals[0] = address(output.optimismPortalProxy);
+        IOptimismPortal2[] memory portals = new IOptimismPortal2[](1);
+        portals[0] = output.optimismPortalProxy;
         data = encodeETHLockboxInitializer(portals);
         upgradeToAndCall(output.opChainProxyAdmin, address(output.ethLockboxProxy), implementation.ethLockboxImpl, data);
 
@@ -614,8 +614,8 @@ contract OPContractsManager is ISemver {
                     );
 
                     // Initialize the ETHLockbox.
-                    address[] memory portals = new address[](1);
-                    portals[0] = opChainAddrs.optimismPortal;
+                    IOptimismPortal2[] memory portals = new IOptimismPortal2[](1);
+                    portals[0] = IOptimismPortal2(payable(opChainAddrs.optimismPortal));
                     upgradeToAndCall(
                         _opChainConfigs[i].proxyAdmin,
                         address(ethLockbox),
@@ -895,8 +895,13 @@ contract OPContractsManager is ISemver {
     }
 
     /// @notice Helper method for encoding the ETHLockbox initializer data.
-    function encodeETHLockboxInitializer(address[] memory _portals) internal view virtual returns (bytes memory) {
-        return abi.encodeCall(IETHLockbox.initialize, (address(superchainConfig), _portals));
+    function encodeETHLockboxInitializer(IOptimismPortal2[] memory _portals)
+        internal
+        view
+        virtual
+        returns (bytes memory)
+    {
+        return abi.encodeCall(IETHLockbox.initialize, (superchainConfig, _portals));
     }
 
     /// @notice Helper method for encoding the SystemConfig initializer data.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -327,13 +327,13 @@ contract OptimismPortal2 is PAOBase, Initializable, ResourceMetering, ISemver {
 
     /// @notice Updates the ETHLockbox contract.
     /// @param _newLockbox The address of the new ETHLockbox contract.
-    function updateLockbox(address _newLockbox) external {
+    function updateLockbox(IETHLockbox _newLockbox) external {
         if (msg.sender != PAO()) revert OptimismPortal_Unauthorized();
 
         address oldLockbox = address(ethLockbox);
         ethLockbox = IETHLockbox(_newLockbox);
 
-        emit LockboxUpdated(oldLockbox, _newLockbox);
+        emit LockboxUpdated(oldLockbox, address(_newLockbox));
     }
 
     /// @notice Proves a withdrawal transaction.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -544,8 +544,8 @@ contract OptimismPortal2 is PAOBase, Initializable, ResourceMetering, ISemver {
     ///         deriving deposit transactions. Note that if a deposit is made by a contract, its
     ///         address will be aliased when retrieved using `tx.origin` or `msg.sender`. Consider
     ///         using the CrossDomainMessenger contracts for a simpler developer experience.
-    /// @dev    The `msg.value` is locked on the ETHLockbox and minted as ETH when the deposit arrives on L2,
-    ///         while `_value` specifies how much ETH to send to the target.
+    /// @dev    The `msg.value` is locked on the ETHLockbox and minted as ETH when the deposit
+    ///         arrives on L2, while `_value` specifies how much ETH to send to the target.
     /// @param _to         Target address on L2.
     /// @param _value      ETH value to send to the recipient.
     /// @param _gasLimit   Amount of L2 gas to purchase by burning gas on L1.

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -21,7 +21,7 @@ import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
-import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 
 contract StandardValidatorBase {
@@ -204,7 +204,7 @@ contract StandardValidatorBase {
             _admin.getProxyImplementation(address(_messenger)) == l1CrossDomainMessengerImpl, "L1xDM-20", _errors
         );
 
-        IOptimismPortal _portal = IOptimismPortal(payable(_sysCfg.optimismPortal()));
+        IOptimismPortal2 _portal = IOptimismPortal2(payable(_sysCfg.optimismPortal()));
 
         _errors = internalRequire(
             address(_messenger.OTHER_MESSENGER()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER, "L1xDM-30", _errors
@@ -297,7 +297,7 @@ contract StandardValidatorBase {
         view
         returns (string memory)
     {
-        IOptimismPortal _portal = IOptimismPortal(payable(_sysCfg.optimismPortal()));
+        IOptimismPortal2 _portal = IOptimismPortal2(payable(_sysCfg.optimismPortal()));
         _errors = internalRequire(stringEq(_portal.version(), optimismPortalVersion()), "PORTAL-10", _errors);
         _errors =
             internalRequire(_admin.getProxyImplementation(address(_portal)) == optimismPortalImpl, "PORTAL-20", _errors);

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -21,7 +21,7 @@ import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
-import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 
 contract StandardValidatorBase {
@@ -204,7 +204,7 @@ contract StandardValidatorBase {
             _admin.getProxyImplementation(address(_messenger)) == l1CrossDomainMessengerImpl, "L1xDM-20", _errors
         );
 
-        IOptimismPortal2 _portal = IOptimismPortal2(payable(_sysCfg.optimismPortal()));
+        IOptimismPortal _portal = IOptimismPortal(payable(_sysCfg.optimismPortal()));
 
         _errors = internalRequire(
             address(_messenger.OTHER_MESSENGER()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER, "L1xDM-30", _errors
@@ -297,7 +297,7 @@ contract StandardValidatorBase {
         view
         returns (string memory)
     {
-        IOptimismPortal2 _portal = IOptimismPortal2(payable(_sysCfg.optimismPortal()));
+        IOptimismPortal _portal = IOptimismPortal(payable(_sysCfg.optimismPortal()));
         _errors = internalRequire(stringEq(_portal.version(), optimismPortalVersion()), "PORTAL-10", _errors);
         _errors =
             internalRequire(_admin.getProxyImplementation(address(_portal)) == optimismPortalImpl, "PORTAL-20", _errors);

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -235,14 +235,14 @@ contract ETHLockboxTest is CommonTest {
     function testFuzz_unlockETH_multiplePortals_succeeds(IOptimismPortal2 _portal, uint256 _value) public {
         assumeNotForgeAddress(address(_portal));
 
-        vm.assume(!ethLockbox.authorizedPortals(address(_portal)));
-
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
         vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
 
-        // Set the portal as an authorized portal
-        vm.prank(PAO);
-        ethLockbox.authorizePortal(_portal);
+        // Set the portal as an authorized portal if needed
+        if (!ethLockbox.authorizedPortals(address(_portal))) {
+            vm.prank(PAO);
+            ethLockbox.authorizePortal(_portal);
+        }
 
         // Deal the ETH amount to the lockbox
         vm.deal(address(ethLockbox), _value);
@@ -277,27 +277,6 @@ contract ETHLockboxTest is CommonTest {
         // Call the `authorizePortal` function with an unauthorized caller
         vm.prank(_caller);
         ethLockbox.authorizePortal(optimismPortal2);
-    }
-
-    /// @notice Tests the `authorizePortal` function reverts when the portal is already authorized.
-    function testFuzz_authorizePortal_alreadyAuthorized_reverts(IOptimismPortal2 _portal) public {
-        assumeNotForgeAddress(address(_portal));
-        // Authorize the portal
-        if (!ethLockbox.authorizedPortals(address(_portal))) {
-            // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
-            vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
-
-            // Authorize the portal
-            vm.prank(PAO);
-            ethLockbox.authorizePortal(_portal);
-        }
-
-        // Expect the revert with `AlreadyAuthorized` selector
-        vm.expectRevert(IETHLockbox.ETHLockbox_AlreadyAuthorized.selector);
-
-        // Call the `authorizePortal` function with the portal
-        vm.prank(PAO);
-        ethLockbox.authorizePortal(_portal);
     }
 
     /// @notice Tests the `authorizePortal` function reverts when the PAO of the portal is not the same as the PAO of
@@ -339,7 +318,6 @@ contract ETHLockboxTest is CommonTest {
     /// @notice Tests the `authorizeLockbox` function succeeds
     function testFuzz_authorizePortal_succeeds(IOptimismPortal2 _portal) public {
         assumeNotForgeAddress(address(_portal));
-        vm.assume(!ethLockbox.authorizedPortals(address(_portal)));
 
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
         vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -79,7 +79,7 @@ contract ETHLockboxTest is CommonTest {
 
         // Authorize the lockbox
         vm.prank(PAO);
-        ethLockbox.authorizeLockbox(_lockbox);
+        ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
 
         // Get the balance of the lockbox before the receive
         uint256 _lockboxBalanceBefore = address(ethLockbox).balance;
@@ -356,7 +356,7 @@ contract ETHLockboxTest is CommonTest {
 
         // Call the `authorizeLockbox` function with an unauthorized caller
         vm.prank(_caller);
-        ethLockbox.authorizeLockbox(address(optimismPortal2));
+        ethLockbox.authorizeLockbox(ethLockbox);
     }
 
     /// @notice Tests the `authorizeLockbox` function reverts when the lockbox is already authorized.
@@ -366,7 +366,7 @@ contract ETHLockboxTest is CommonTest {
             vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
 
             vm.prank(PAO);
-            ethLockbox.authorizeLockbox(_lockbox);
+            ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
         }
 
         // Expect the revert with `AlreadyAuthorized` selector
@@ -374,7 +374,7 @@ contract ETHLockboxTest is CommonTest {
 
         // Call the `authorizeLockbox` function with the lockbox
         vm.prank(PAO);
-        ethLockbox.authorizeLockbox(_lockbox);
+        ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
     }
 
     /// @notice Tests the `authorizeLockbox` function reverts when the PAO of the lockbox is not the same as the PAO of
@@ -387,7 +387,7 @@ contract ETHLockboxTest is CommonTest {
 
         // Call the `authorizeLockbox` function with the lockbox
         vm.prank(PAO);
-        ethLockbox.authorizeLockbox(_lockbox);
+        ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
     }
 
     /// @notice Tests the `authorizeLockbox` function succeeds
@@ -403,7 +403,7 @@ contract ETHLockboxTest is CommonTest {
 
         // Authorize the lockbox
         vm.prank(PAO);
-        ethLockbox.authorizeLockbox(_lockbox);
+        ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
 
         // Assert the lockbox is authorized
         assertTrue(ethLockbox.authorizedLockboxes(_lockbox));
@@ -418,7 +418,7 @@ contract ETHLockboxTest is CommonTest {
 
         // Call the `migrateLiquidity` function with an unauthorized caller
         vm.prank(_caller);
-        ethLockbox.migrateLiquidity(address(optimismPortal2));
+        ethLockbox.migrateLiquidity(ethLockbox);
     }
 
     /// @notice Tests the `migrateLiquidity` function reverts when the PAO of the lockbox is not the same as the PAO of
@@ -431,7 +431,7 @@ contract ETHLockboxTest is CommonTest {
 
         // Call the `migrateLiquidity` function with the lockbox
         vm.prank(PAO);
-        ethLockbox.migrateLiquidity(_lockbox);
+        ethLockbox.migrateLiquidity(IETHLockbox(_lockbox));
     }
 
     /// @notice Tests the `migrateLiquidity` function succeeds
@@ -456,7 +456,7 @@ contract ETHLockboxTest is CommonTest {
 
         // Call the `migrateLiquidity` function with the lockbox
         vm.prank(PAO);
-        ethLockbox.migrateLiquidity(_lockbox);
+        ethLockbox.migrateLiquidity(IETHLockbox(_lockbox));
 
         // Assert the liquidity was migrated
         assertEq(address(_lockbox).balance, newLockboxBalanceBefore + ethLockboxBalanceBefore);

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -11,6 +11,7 @@ import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IPAOBase } from "interfaces/L1/IPAOBase.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 
 // Test
 import { CommonTest } from "test/setup/CommonTest.sol";
@@ -45,8 +46,8 @@ contract ETHLockboxTest is CommonTest {
     /// @notice Tests it reverts when the contract is already initialized.
     function test_initialize_alreadyInitialized_reverts() public {
         vm.expectRevert("Initializable: contract is already initialized");
-        address[] memory _portals = new address[](1);
-        ethLockbox.initialize(address(superchainConfig), _portals);
+        IOptimismPortal2[] memory _portals = new IOptimismPortal2[](1);
+        ethLockbox.initialize(superchainConfig, _portals);
     }
 
     /// @notice Tests the proxy admin owner is correctly returned.
@@ -130,8 +131,8 @@ contract ETHLockboxTest is CommonTest {
     }
 
     /// @notice Tests the ETH is correctly locked when the caller is an authorized portal with different portals.
-    function testFuzz_lockETH_multiplePortals_succeeds(address _portal, uint256 _amount) public {
-        vm.assume(_portal != address(ethLockbox));
+    function testFuzz_lockETH_multiplePortals_succeeds(IOptimismPortal2 _portal, uint256 _amount) public {
+        vm.assume(address(_portal) != address(ethLockbox));
 
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
         vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
@@ -141,7 +142,7 @@ contract ETHLockboxTest is CommonTest {
         ethLockbox.authorizePortal(_portal);
 
         // Deal the ETH amount to the portal
-        vm.deal(_portal, _amount);
+        vm.deal(address(_portal), _amount);
 
         // Get the balance of the portal and lockbox before the lock to compare later on the assertions
         uint256 _portalBalanceBefore = address(_portal).balance;
@@ -149,10 +150,10 @@ contract ETHLockboxTest is CommonTest {
 
         // Look for the emit of the `ETHLocked` event
         vm.expectEmit(address(ethLockbox));
-        emit ETHLocked(_portal, _amount);
+        emit ETHLocked(address(_portal), _amount);
 
         // Call the `lockETH` function with the portal
-        vm.prank(_portal);
+        vm.prank(address(_portal));
         ethLockbox.lockETH{ value: _amount }();
 
         // Assert the portal's balance decreased and the lockbox's balance increased by the amount locked
@@ -227,8 +228,8 @@ contract ETHLockboxTest is CommonTest {
     }
 
     /// @notice Tests the ETH is correctly unlocked when the caller is an authorized portal.
-    function testFuzz_unlockETH_multiplePortals_succeeds(address _portal, uint256 _value) public {
-        vm.assume(_portal != address(ethLockbox));
+    function testFuzz_unlockETH_multiplePortals_succeeds(IOptimismPortal2 _portal, uint256 _value) public {
+        vm.assume(address(_portal) != address(ethLockbox));
 
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
         vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
@@ -269,13 +270,13 @@ contract ETHLockboxTest is CommonTest {
 
         // Call the `authorizePortal` function with an unauthorized caller
         vm.prank(_caller);
-        ethLockbox.authorizePortal(address(optimismPortal2));
+        ethLockbox.authorizePortal(optimismPortal2);
     }
 
     /// @notice Tests the `authorizePortal` function reverts when the portal is already authorized.
-    function testFuzz_authorizePortal_alreadyAuthorized_reverts(address _portal) public {
+    function testFuzz_authorizePortal_alreadyAuthorized_reverts(IOptimismPortal2 _portal) public {
         // Authorize the portal
-        if (!ethLockbox.authorizedPortals(_portal)) {
+        if (!ethLockbox.authorizedPortals(address(_portal))) {
             // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
             vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
 
@@ -294,7 +295,7 @@ contract ETHLockboxTest is CommonTest {
 
     /// @notice Tests the `authorizePortal` function reverts when the PAO of the portal is not the same as the PAO of
     ///         the lockbox.
-    function testFuzz_authorizePortal_differentPAO_reverts(address _portal) public {
+    function testFuzz_authorizePortal_differentPAO_reverts(IOptimismPortal2 _portal) public {
         vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(address(0)));
 
         // Expect the revert with `DifferentOwner` selector
@@ -321,29 +322,29 @@ contract ETHLockboxTest is CommonTest {
 
         // Call the `authorizePortal` function with the portal
         vm.prank(PAO);
-        ethLockbox.authorizePortal(address(optimismPortal2));
+        ethLockbox.authorizePortal(optimismPortal2);
 
         // Assert the portal is authorized
         assertTrue(ethLockbox.authorizedPortals(address(optimismPortal2)));
     }
 
     /// @notice Tests the `authorizeLockbox` function succeeds
-    function testFuzz_authorizePortal_succeeds(address _portal) public {
-        vm.assume(!ethLockbox.authorizedPortals(_portal));
+    function testFuzz_authorizePortal_succeeds(IOptimismPortal2 _portal) public {
+        vm.assume(!ethLockbox.authorizedPortals(address(_portal)));
 
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
         vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
 
         // Expect the `PortalAuthorized` event to be emitted
         vm.expectEmit(address(ethLockbox));
-        emit PortalAuthorized(_portal);
+        emit PortalAuthorized(address(_portal));
 
         // Call the `authorizePortal` function with the portal
         vm.prank(PAO);
         ethLockbox.authorizePortal(_portal);
 
         // Assert the portal is authorized
-        assertTrue(ethLockbox.authorizedPortals(_portal));
+        assertTrue(ethLockbox.authorizedPortals(address(_portal)));
     }
 
     /// @notice Tests the `authorizeLockbox` function reverts when the caller is not the proxy admin.

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -69,7 +69,8 @@ contract ETHLockboxTest is CommonTest {
 
     /// @notice Tests the liquidity is correctly received.
     function testFuzz_receiveLiquidity_succeeds(address _lockbox, uint256 _value) public {
-        vm.assume(!ethLockbox.authorizedLockboxes(_lockbox));
+        assumeNotForgeAddress(_lockbox);
+        vm.assume(address(_lockbox) != address(ethLockbox));
 
         // Deal the value to the lockbox
         deal(address(_lockbox), _value);
@@ -77,12 +78,14 @@ contract ETHLockboxTest is CommonTest {
         // Mock the admin owner of the lockbox to be the same as the current lockbox proxy admin owner
         vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
 
-        // Authorize the lockbox
-        vm.prank(PAO);
-        ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
+        // Authorize the lockbox if needed
+        if (!ethLockbox.authorizedLockboxes(_lockbox)) {
+            vm.prank(PAO);
+            ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
+        }
 
         // Get the balance of the lockbox before the receive
-        uint256 _lockboxBalanceBefore = address(ethLockbox).balance;
+        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
 
         // Expect the `LiquidityReceived` event to be emitted
         vm.expectEmit(address(ethLockbox));
@@ -93,7 +96,7 @@ contract ETHLockboxTest is CommonTest {
         ethLockbox.receiveLiquidity{ value: _value }();
 
         // Assert the lockbox's balance increased by the amount received
-        assertEq(address(ethLockbox).balance, _lockboxBalanceBefore + _value);
+        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + _value);
     }
 
     /// @notice Tests it reverts when the caller is not an authorized portal.
@@ -114,8 +117,8 @@ contract ETHLockboxTest is CommonTest {
         vm.deal(address(optimismPortal2), _amount);
 
         // Get the balance of the portal and lockbox before the lock to compare later on the assertions
-        uint256 _portalBalanceBefore = address(optimismPortal2).balance;
-        uint256 _lockboxBalanceBefore = address(ethLockbox).balance;
+        uint256 portalBalanceBefore = address(optimismPortal2).balance;
+        uint256 lockboxBalanceBefore = address(ethLockbox).balance;
 
         // Look for the emit of the `ETHLocked` event
         vm.expectEmit(address(ethLockbox));
@@ -126,27 +129,29 @@ contract ETHLockboxTest is CommonTest {
         ethLockbox.lockETH{ value: _amount }();
 
         // Assert the portal's balance decreased and the lockbox's balance increased by the amount locked
-        assertEq(address(optimismPortal2).balance, _portalBalanceBefore - _amount);
-        assertEq(address(ethLockbox).balance, _lockboxBalanceBefore + _amount);
+        assertEq(address(optimismPortal2).balance, portalBalanceBefore - _amount);
+        assertEq(address(ethLockbox).balance, lockboxBalanceBefore + _amount);
     }
 
     /// @notice Tests the ETH is correctly locked when the caller is an authorized portal with different portals.
     function testFuzz_lockETH_multiplePortals_succeeds(IOptimismPortal2 _portal, uint256 _amount) public {
+        assumeNotForgeAddress(address(_portal));
         vm.assume(address(_portal) != address(ethLockbox));
 
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
         vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
 
-        // Set the portal as an authorized portal
-        vm.prank(PAO);
-        ethLockbox.authorizePortal(_portal);
+        // Set the portal as an authorized portal if needed
+        if (!ethLockbox.authorizedPortals(address(_portal))) {
+            vm.prank(PAO);
+            ethLockbox.authorizePortal(_portal);
+        }
 
         // Deal the ETH amount to the portal
         vm.deal(address(_portal), _amount);
 
-        // Get the balance of the portal and lockbox before the lock to compare later on the assertions
-        uint256 _portalBalanceBefore = address(_portal).balance;
-        uint256 _lockboxBalanceBefore = address(ethLockbox).balance;
+        // Get the balance of the lockbox before the lock to compare later on the assertions
+        uint256 lockboxBalanceBefore = address(ethLockbox).balance;
 
         // Look for the emit of the `ETHLocked` event
         vm.expectEmit(address(ethLockbox));
@@ -157,8 +162,7 @@ contract ETHLockboxTest is CommonTest {
         ethLockbox.lockETH{ value: _amount }();
 
         // Assert the portal's balance decreased and the lockbox's balance increased by the amount locked
-        assertEq(address(_portal).balance, _portalBalanceBefore - _amount);
-        assertEq(address(ethLockbox).balance, _lockboxBalanceBefore + _amount);
+        assertEq(address(ethLockbox).balance, lockboxBalanceBefore + _amount);
     }
 
     /// @notice Tests `unlockETH` reverts when the contract is paused.
@@ -229,7 +233,9 @@ contract ETHLockboxTest is CommonTest {
 
     /// @notice Tests the ETH is correctly unlocked when the caller is an authorized portal.
     function testFuzz_unlockETH_multiplePortals_succeeds(IOptimismPortal2 _portal, uint256 _value) public {
-        vm.assume(address(_portal) != address(ethLockbox));
+        assumeNotForgeAddress(address(_portal));
+
+        vm.assume(!ethLockbox.authorizedPortals(address(_portal)));
 
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
         vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
@@ -275,6 +281,7 @@ contract ETHLockboxTest is CommonTest {
 
     /// @notice Tests the `authorizePortal` function reverts when the portal is already authorized.
     function testFuzz_authorizePortal_alreadyAuthorized_reverts(IOptimismPortal2 _portal) public {
+        assumeNotForgeAddress(address(_portal));
         // Authorize the portal
         if (!ethLockbox.authorizedPortals(address(_portal))) {
             // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
@@ -296,6 +303,7 @@ contract ETHLockboxTest is CommonTest {
     /// @notice Tests the `authorizePortal` function reverts when the PAO of the portal is not the same as the PAO of
     ///         the lockbox.
     function testFuzz_authorizePortal_differentPAO_reverts(IOptimismPortal2 _portal) public {
+        assumeNotForgeAddress(address(_portal));
         vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(address(0)));
 
         // Expect the revert with `DifferentOwner` selector
@@ -330,6 +338,7 @@ contract ETHLockboxTest is CommonTest {
 
     /// @notice Tests the `authorizeLockbox` function succeeds
     function testFuzz_authorizePortal_succeeds(IOptimismPortal2 _portal) public {
+        assumeNotForgeAddress(address(_portal));
         vm.assume(!ethLockbox.authorizedPortals(address(_portal)));
 
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
@@ -361,6 +370,8 @@ contract ETHLockboxTest is CommonTest {
 
     /// @notice Tests the `authorizeLockbox` function reverts when the lockbox is already authorized.
     function testFuzz_authorizeLockbox_alreadyAuthorized_reverts(address _lockbox) public {
+        assumeNotForgeAddress(_lockbox);
+
         // Authorize the lockbox
         if (!ethLockbox.authorizedLockboxes(_lockbox)) {
             vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
@@ -369,17 +380,20 @@ contract ETHLockboxTest is CommonTest {
             ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
         }
 
+        // Call the `authorizeLockbox` function with the lockbox
+        vm.startPrank(ethLockbox.PAO());
+
         // Expect the revert with `AlreadyAuthorized` selector
         vm.expectRevert(IETHLockbox.ETHLockbox_AlreadyAuthorized.selector);
 
-        // Call the `authorizeLockbox` function with the lockbox
-        vm.prank(PAO);
         ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
     }
 
     /// @notice Tests the `authorizeLockbox` function reverts when the PAO of the lockbox is not the same as the PAO of
     ///         the proxy admin.
     function testFuzz_authorizeLockbox_differentPAO_reverts(address _lockbox) public {
+        assumeNotForgeAddress(_lockbox);
+
         vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(address(0)));
 
         // Expect the revert with `ETHLockbox_DifferentPAO` selector
@@ -392,6 +406,7 @@ contract ETHLockboxTest is CommonTest {
 
     /// @notice Tests the `authorizeLockbox` function succeeds
     function testFuzz_authorizeLockbox_succeeds(address _lockbox) public {
+        assumeNotForgeAddress(_lockbox);
         vm.assume(!ethLockbox.authorizedLockboxes(_lockbox));
 
         // Mock the admin owner of the lockbox to be the same as the current lockbox proxy admin owner
@@ -424,6 +439,8 @@ contract ETHLockboxTest is CommonTest {
     /// @notice Tests the `migrateLiquidity` function reverts when the PAO of the lockbox is not the same as the PAO of
     ///         the proxy admin.
     function testFuzz_migrateLiquidity_differentPAO_reverts(address _lockbox) public {
+        assumeNotForgeAddress(_lockbox);
+
         vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(address(0)));
 
         // Expect the revert with `ETHLockbox_DifferentPAO` selector
@@ -436,6 +453,9 @@ contract ETHLockboxTest is CommonTest {
 
     /// @notice Tests the `migrateLiquidity` function succeeds
     function testFuzz_migrateLiquidity_succeeds(uint256 _balance, address _lockbox) public {
+        assumeNotForgeAddress(_lockbox);
+        vm.assume(address(_lockbox) != address(ethLockbox));
+
         // Mock on the lockbox that will receive the migration for it to succeed
         vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
         vm.mockCall(
@@ -459,7 +479,7 @@ contract ETHLockboxTest is CommonTest {
         ethLockbox.migrateLiquidity(IETHLockbox(_lockbox));
 
         // Assert the liquidity was migrated
-        assertEq(address(_lockbox).balance, newLockboxBalanceBefore + ethLockboxBalanceBefore);
         assertEq(address(ethLockbox).balance, 0);
+        assertEq(address(_lockbox).balance, newLockboxBalanceBefore + ethLockboxBalanceBefore);
     }
 }

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -15,7 +15,7 @@ import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
 
 // Target contract dependencies
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
-import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 contract L1CrossDomainMessenger_Test is CommonTest {
@@ -68,7 +68,7 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         vm.expectCall(
             address(optimismPortal2),
             abi.encodeCall(
-                IOptimismPortal2.depositTransaction,
+                IOptimismPortal.depositTransaction,
                 (
                     Predeploys.L2_CROSS_DOMAIN_MESSENGER,
                     0,
@@ -736,7 +736,7 @@ contract L1CrossDomainMessenger_ReinitReentryTest is CommonTest {
             vm.store(address(l1CrossDomainMessenger), 0, bytes32(uint256(0)));
 
             // call the initializer function
-            l1CrossDomainMessenger.initialize(ISuperchainConfig(superchainConfig), IOptimismPortal2(optimismPortal2));
+            l1CrossDomainMessenger.initialize(ISuperchainConfig(superchainConfig), IOptimismPortal(optimismPortal2));
 
             // attempt to re-replay the withdrawal
             vm.expectEmit(address(l1CrossDomainMessenger));

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -15,7 +15,7 @@ import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
 
 // Target contract dependencies
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
-import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 contract L1CrossDomainMessenger_Test is CommonTest {
@@ -68,7 +68,7 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         vm.expectCall(
             address(optimismPortal2),
             abi.encodeCall(
-                IOptimismPortal.depositTransaction,
+                IOptimismPortal2.depositTransaction,
                 (
                     Predeploys.L2_CROSS_DOMAIN_MESSENGER,
                     0,
@@ -736,7 +736,7 @@ contract L1CrossDomainMessenger_ReinitReentryTest is CommonTest {
             vm.store(address(l1CrossDomainMessenger), 0, bytes32(uint256(0)));
 
             // call the initializer function
-            l1CrossDomainMessenger.initialize(ISuperchainConfig(superchainConfig), IOptimismPortal(optimismPortal2));
+            l1CrossDomainMessenger.initialize(ISuperchainConfig(superchainConfig), IOptimismPortal2(optimismPortal2));
 
             // attempt to re-replay the withdrawal
             vm.expectEmit(address(l1CrossDomainMessenger));

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -471,7 +471,7 @@ contract OptimismPortal2_Test is CommonTest {
         vm.expectRevert(IOptimismPortal2.OptimismPortal_Unauthorized.selector);
 
         vm.prank(_caller);
-        optimismPortal2.updateLockbox(address(1));
+        optimismPortal2.updateLockbox(IETHLockbox(address(1)));
     }
 
     /// @dev Tests that `updateLockbox` updates the ETHLockbox contract.
@@ -483,7 +483,7 @@ contract OptimismPortal2_Test is CommonTest {
         emit LockboxUpdated(oldLockbox, _newLockbox);
 
         vm.prank(optimismPortal2.PAO());
-        optimismPortal2.updateLockbox(_newLockbox);
+        optimismPortal2.updateLockbox(IETHLockbox(_newLockbox));
 
         assertEq(address(optimismPortal2.ethLockbox()), _newLockbox);
     }

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -21,7 +21,7 @@ import "src/dispute/lib/Types.sol";
 
 // Interfaces
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
-import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
@@ -46,7 +46,7 @@ contract OptimismPortal2_Test is CommonTest {
     /// @notice Marked virtual to be overridden in
     ///         test/kontrol/deployment/DeploymentSummary.t.sol
     function test_constructor_succeeds() external virtual {
-        IOptimismPortal2 opImpl = IOptimismPortal2(payable(EIP1967Helper.getImplementation(address(optimismPortal2))));
+        IOptimismPortal opImpl = IOptimismPortal(payable(EIP1967Helper.getImplementation(address(optimismPortal2))));
         assertEq(address(opImpl.anchorStateRegistry()), address(0));
         assertEq(address(opImpl.systemConfig()), address(0));
         assertEq(address(opImpl.superchainConfig()), address(0));
@@ -205,7 +205,7 @@ contract OptimismPortal2_Test is CommonTest {
         // TODO(opcm upgrades): remove skip once upgrade path is implemented
         skipIfForkTest("OptimismPortal2_Test: error is different on OP Mainnet");
         // contract creation must have a target of address(0)
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_BadTarget.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_BadTarget.selector);
         optimismPortal2.depositTransaction(address(1), 1, 0, true, hex"");
     }
 
@@ -216,7 +216,7 @@ contract OptimismPortal2_Test is CommonTest {
         skipIfForkTest("OptimismPortal2_Test: error is different on OP Mainnet");
         uint256 size = 120_001;
         uint64 gasLimit = optimismPortal2.minimumGasLimit(uint64(size));
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_CalldataTooLarge.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_CalldataTooLarge.selector);
         optimismPortal2.depositTransaction({
             _to: address(0),
             _value: 0,
@@ -230,7 +230,7 @@ contract OptimismPortal2_Test is CommonTest {
     function test_depositTransaction_smallGasLimit_reverts() external {
         // TODO(opcm upgrades): remove skip once upgrade path is implemented
         skipIfForkTest("OptimismPortal2_Test: error is different on OP Mainnet");
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_GasLimitTooLow.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_GasLimitTooLow.selector);
         optimismPortal2.depositTransaction({ _to: address(1), _value: 0, _gasLimit: 0, _isCreation: false, _data: hex"" });
     }
 
@@ -242,7 +242,7 @@ contract OptimismPortal2_Test is CommonTest {
             gasLimit = uint64(bound(gasLimit, 0, gasLimit - 1));
             // TODO(opcm upgrades): remove skip once upgrade path is implemented
             skipIfForkTest("OptimismPortal2_Test: error is different on OP Mainnet");
-            vm.expectRevert(IOptimismPortal2.OptimismPortal_GasLimitTooLow.selector);
+            vm.expectRevert(IOptimismPortal.OptimismPortal_GasLimitTooLow.selector);
         }
 
         optimismPortal2.depositTransaction({
@@ -470,7 +470,7 @@ contract OptimismPortal2_Test is CommonTest {
     /// @dev Tests that `updateLockbox` reverts if the caller is not the PAO.
     function testFuzz_updateLockbox_notPAO_reverts(address _caller) external {
         vm.assume(_caller != optimismPortal2.PAO());
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_Unauthorized.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_Unauthorized.selector);
 
         vm.prank(_caller);
         optimismPortal2.updateLockbox(IETHLockbox(address(1)));
@@ -574,7 +574,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
 
     /// @dev Asserts that the reentrant call will revert.
     function callPortalAndExpectRevert() external payable {
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_NoReentrancy.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_NoReentrancy.selector);
         // Arguments here don't matter, as the require check is the first thing that happens.
         // We assume that this has already been proven.
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
@@ -585,11 +585,11 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
     /// @dev Tests that `finalizeWithdrawalTransaction` reverts when the target is the portal contract or the lockbox.
     function test_finalizeWithdrawalTransaction_badTarget_reverts() external {
         _defaultTx.target = address(optimismPortal2);
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_BadTarget.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_BadTarget.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
         _defaultTx.target = address(ethLockbox);
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_BadTarget.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_BadTarget.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
     }
 
@@ -598,7 +598,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         vm.prank(optimismPortal2.guardian());
         superchainConfig.pause("identifier");
 
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_CallPaused.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_CallPaused.selector);
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
             _disputeGameIndex: _proposedGameIndex,
@@ -610,7 +610,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
     /// @dev Tests that `proveWithdrawalTransaction` reverts when the target is the portal contract.
     function test_proveWithdrawalTransaction_onSelfCall_reverts() external {
         _defaultTx.target = address(optimismPortal2);
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_BadTarget.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_BadTarget.selector);
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
             _disputeGameIndex: _proposedGameIndex,
@@ -619,7 +619,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         });
 
         _defaultTx.target = address(ethLockbox);
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_BadTarget.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_BadTarget.selector);
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
             _disputeGameIndex: _proposedGameIndex,
@@ -638,7 +638,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         vm.warp(_timestamp);
 
         // Should revert.
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidProofTimestamp.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidProofTimestamp.selector);
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
             _disputeGameIndex: _proposedGameIndex,
@@ -651,7 +651,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
     function test_proveWithdrawalTransaction_onInvalidOutputRootProof_reverts() external {
         // Modify the version to invalidate the withdrawal proof.
         _outputRootProof.version = bytes32(uint256(1));
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidOutputRootProof.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidOutputRootProof.selector);
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
             _disputeGameIndex: _proposedGameIndex,
@@ -695,7 +695,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         vm.mockCall(address(game), abi.encodeCall(game.status, ()), abi.encode(GameStatus.CHALLENGER_WINS));
         vm.mockCall(address(game2), abi.encodeCall(game.status, ()), abi.encode(GameStatus.CHALLENGER_WINS));
 
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidDisputeGame.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidDisputeGame.selector);
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
             _disputeGameIndex: _proposedGameIndex,
@@ -707,7 +707,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
     /// @dev Tests that `proveWithdrawalTransaction` reverts if the game was not the respected game type when created.
     function test_proveWithdrawalTransaction_wasNotRespectedGameTypeWhenCreated_reverts() external {
         vm.mockCall(address(game), abi.encodeCall(game.wasRespectedGameTypeWhenCreated, ()), abi.encode(false));
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidDisputeGame.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidDisputeGame.selector);
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
             _disputeGameIndex: _proposedGameIndex,
@@ -750,7 +750,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
     {
         _createdAt = uint64(bound(_createdAt, 0, optimismPortal2.respectedGameTypeUpdatedAt()));
         vm.mockCall(address(game), abi.encodeCall(game.createdAt, ()), abi.encode(uint64(_createdAt)));
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_ImproperDisputeGame.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_ImproperDisputeGame.selector);
         optimismPortal2.proveWithdrawalTransaction({
             _tx: _defaultTx,
             _disputeGameIndex: _proposedGameIndex,
@@ -896,7 +896,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         emit WithdrawalFinalized(_withdrawalHash, true);
         optimismPortal2.finalizeWithdrawalTransactionExternalProof(_defaultTx, address(0xb0b));
 
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_AlreadyFinalized.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_AlreadyFinalized.selector);
         optimismPortal2.finalizeWithdrawalTransactionExternalProof(_defaultTx, address(this));
 
         assert(address(bob).balance == bobBalanceBefore + 100);
@@ -918,7 +918,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1 seconds);
 
         vm.startPrank(alice, Constants.ESTIMATION_ADDRESS);
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_GasEstimation.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_GasEstimation.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
     }
 
@@ -1067,7 +1067,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         // Ensure both proofs are registered successfully.
         assertEq(optimismPortal2.numProofSubmitters(_withdrawalHash), 2);
 
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidRootClaim.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidRootClaim.selector);
         vm.prank(address(0xb0b));
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
@@ -1083,7 +1083,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         vm.prank(optimismPortal2.guardian());
         superchainConfig.pause("identifier");
 
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_CallPaused.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_CallPaused.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
     }
 
@@ -1091,7 +1091,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
     function test_finalizeWithdrawalTransaction_ifWithdrawalNotProven_reverts() external {
         uint256 bobBalanceBefore = address(bob).balance;
 
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_Unproven.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_Unproven.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
         assert(address(bob).balance == bobBalanceBefore);
@@ -1113,7 +1113,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
             _withdrawalProof: _withdrawalProof
         });
 
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_ProofNotOldEnough.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_ProofNotOldEnough.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
         assert(address(bob).balance == bobBalanceBefore);
@@ -1143,7 +1143,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         vm.mockCall(address(game), abi.encodeCall(game.createdAt, ()), abi.encode(block.timestamp + 1));
 
         // Attempt to finalize the withdrawal
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidProofTimestamp.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidProofTimestamp.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
         // Ensure that bob's balance has remained the same
@@ -1171,7 +1171,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
 
         // Attempt to finalize the withdrawal
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidRootClaim.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidRootClaim.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
         // Ensure that bob's balance has remained the same
@@ -1229,7 +1229,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         emit WithdrawalFinalized(_withdrawalHash, true);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_AlreadyFinalized.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_AlreadyFinalized.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
     }
 
@@ -1508,7 +1508,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
 
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1);
 
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidRootClaim.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidRootClaim.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
     }
 
@@ -1534,7 +1534,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         game.resolve();
 
         // Attempt to finalize the withdrawal directly after the game resolves. This should fail.
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidRootClaim.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidRootClaim.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
         // Finalize the withdrawal transaction. This should succeed.
@@ -1572,7 +1572,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         anchorStateRegistry.updateRetirementTimestamp();
 
         // Should revert.
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidRootClaim.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidRootClaim.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
     }
 
@@ -1602,7 +1602,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
 
         vm.mockCall(address(game), abi.encodeCall(game.wasRespectedGameTypeWhenCreated, ()), abi.encode(false));
 
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidRootClaim.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidRootClaim.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
     }
 
@@ -1655,13 +1655,13 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
 
         // Attempt to finalize the withdrawal transaction 1 second before the proof has matured. This should fail.
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds());
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_ProofNotOldEnough.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_ProofNotOldEnough.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
         // Warp 1 second in the future, past the proof maturity delay, and attempt to finalize the withdrawal.
         // This should also fail, since the dispute game has not resolved yet.
         vm.warp(block.timestamp + 1 seconds);
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidRootClaim.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidRootClaim.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
         // Finalize the dispute game and attempt to finalize the withdrawal again. This should also fail, since the
@@ -1669,7 +1669,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         game.resolveClaim(0, 0);
         game.resolve();
         vm.warp(block.timestamp + optimismPortal2.disputeGameFinalityDelaySeconds());
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidRootClaim.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidRootClaim.selector);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
         // Warp 1 second in the future, past the air gap dispute game delay, and attempt to finalize the withdrawal.
@@ -1732,7 +1732,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
         // Should revert.
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_AlreadyFinalized.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_AlreadyFinalized.selector);
         optimismPortal2.checkWithdrawal(_withdrawalHash, address(this));
     }
 
@@ -1740,7 +1740,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
     function test_checkWithdrawal_ifUnproven_reverts() external {
         // Don't prove the withdrawal transaction.
         // Should revert.
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_Unproven.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_Unproven.selector);
         optimismPortal2.checkWithdrawal(_withdrawalHash, address(this));
     }
 
@@ -1771,7 +1771,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         );
 
         // Should revert.
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidProofTimestamp.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidProofTimestamp.selector);
         optimismPortal2.checkWithdrawal(_withdrawalHash, address(this));
     }
 
@@ -1788,7 +1788,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
 
         // Should revert.
         vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() - 1);
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_ProofNotOldEnough.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_ProofNotOldEnough.selector);
         optimismPortal2.checkWithdrawal(_withdrawalHash, address(this));
     }
 
@@ -1809,7 +1809,7 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
         vm.mockCall(address(game), abi.encodeCall(game.status, ()), abi.encode(GameStatus.CHALLENGER_WINS));
 
         // Should revert.
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_InvalidRootClaim.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_InvalidRootClaim.selector);
         optimismPortal2.checkWithdrawal(_withdrawalHash, address(this));
     }
 }
@@ -1861,7 +1861,7 @@ contract OptimismPortal2_LiquidityMigration_Test is CommonTest {
     /// @notice Tests the liquidity migration from the portal to the lockbox reverts if not called by the admin owner.
     function testFuzz_migrateLiquidity_notPAO_reverts(address _caller) external {
         vm.assume(_caller != optimismPortal2.PAO());
-        vm.expectRevert(IOptimismPortal2.OptimismPortal_Unauthorized.selector);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_Unauthorized.selector);
         vm.prank(_caller);
         optimismPortal2.migrateLiquidity();
     }

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -328,6 +328,8 @@ contract OptimismPortal2_Test is CommonTest {
     )
         external
     {
+        assumeNotForgeAddress(_7702Target);
+
         _gasLimit = uint64(
             bound(
                 _gasLimit,

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -17,7 +17,7 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
-import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
@@ -89,7 +89,7 @@ contract DeployImplementationsOutput_Test is Test {
 
     function test_set_succeeds() public {
         IOPContractsManager opcm = IOPContractsManager(address(makeAddr("opcm")));
-        IOptimismPortal2 optimismPortalImpl = IOptimismPortal2(payable(makeAddr("optimismPortalImpl")));
+        IOptimismPortal optimismPortalImpl = IOptimismPortal(payable(makeAddr("optimismPortalImpl")));
         IETHLockbox ethLockboxImpl = IETHLockbox(payable(makeAddr("ethLockboxImpl")));
         IDelayedWETH delayedWETHImpl = IDelayedWETH(payable(makeAddr("delayedWETHImpl")));
         IPreimageOracle preimageOracleSingleton = IPreimageOracle(makeAddr("preimageOracleSingleton"));

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -22,7 +22,7 @@ import { Chains } from "scripts/libraries/Chains.sol";
 
 // Interfaces
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
-import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
@@ -96,7 +96,7 @@ contract Setup {
     IDelayedWETH delayedWETHPermissionedGameProxy;
 
     // L1 contracts - core
-    IOptimismPortal2 optimismPortal2;
+    IOptimismPortal optimismPortal2;
     IETHLockbox ethLockbox;
     ISystemConfig systemConfig;
     IL1StandardBridge l1StandardBridge;
@@ -228,7 +228,7 @@ contract Setup {
 
         console.log("Setup: completed L1 deployment, registering addresses now");
 
-        optimismPortal2 = IOptimismPortal2(artifacts.mustGetAddress("OptimismPortalProxy"));
+        optimismPortal2 = IOptimismPortal(artifacts.mustGetAddress("OptimismPortalProxy"));
         ethLockbox = IETHLockbox(artifacts.mustGetAddress("ETHLockboxProxy"));
         systemConfig = ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy"));
         l1StandardBridge = IL1StandardBridge(artifacts.mustGetAddress("L1StandardBridgeProxy"));

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -19,6 +19,7 @@ import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { ProtocolVersion } from "interfaces/L1/IProtocolVersions.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 
 /// @title Initializer_Test
 /// @dev Ensures that the `initialize()` function on contracts cannot be called more than
@@ -330,7 +331,9 @@ contract Initializer_Test is CommonTest {
             InitializeableContract({
                 name: "ETHLockboxImpl",
                 target: EIP1967Helper.getImplementation(address(ethLockbox)),
-                initCalldata: abi.encodeCall(ethLockbox.initialize, (address(0), new address[](0)))
+                initCalldata: abi.encodeCall(
+                    ethLockbox.initialize, (ISuperchainConfig(address(0)), new IOptimismPortal2[](0))
+                )
             })
         );
 
@@ -339,7 +342,9 @@ contract Initializer_Test is CommonTest {
             InitializeableContract({
                 name: "ETHLockboxProxy",
                 target: address(ethLockbox),
-                initCalldata: abi.encodeCall(ethLockbox.initialize, (address(0), new address[](0)))
+                initCalldata: abi.encodeCall(
+                    ethLockbox.initialize, (ISuperchainConfig(address(0)), new IOptimismPortal2[](0))
+                )
             })
         );
     }

--- a/packages/contracts-bedrock/test/vendor/InitializableOZv5.t.sol
+++ b/packages/contracts-bedrock/test/vendor/InitializableOZv5.t.sol
@@ -1,17 +1,15 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
-import { CommonTest } from "test/setup/CommonTest.sol";
+import { Test } from "forge-std/Test.sol";
 import { IOptimismSuperchainERC20 } from "interfaces/L2/IOptimismSuperchainERC20.sol";
+import { Initializable } from "@openzeppelin/contracts-v5/proxy/utils/Initializable.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
-
 /// @title InitializerOZv5_Test
 /// @dev Ensures that the `initialize()` function on contracts cannot be called more than
 ///      once. Tests the contracts inheriting from `Initializable` from OpenZeppelin Contracts v5.
 
-contract InitializerOZv5_Test is CommonTest {
-    error InvalidInitialization();
-
+contract InitializerOZv5_Test is Test {
     /// @notice The storage slot of the `initialized` flag in the `Initializable` contract from OZ v5.
     /// keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.Initializable")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant INITIALIZABLE_STORAGE = 0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
@@ -19,7 +17,6 @@ contract InitializerOZv5_Test is CommonTest {
     /// @notice Contains the address of an `Initializable` contract and the calldata
     ///         used to initialize it.
     struct InitializeableContract {
-        string name;
         address target;
         bytes initCalldata;
     }
@@ -28,18 +25,13 @@ contract InitializerOZv5_Test is CommonTest {
     ///         used to initialize them.
     InitializeableContract[] contracts;
 
-    function setUp() public override {
-        super.enableInterop();
-        super.enableAltDA();
-        super.setUp();
-
+    function setUp() public {
         // Initialize the `contracts` array with the addresses of the contracts to test and the
         // calldata used to initialize them
 
         // OptimismSuperchainERC20
         contracts.push(
             InitializeableContract({
-                name: "OptimismSuperchainERC20",
                 target: address(
                     DeployUtils.create1({
                         _name: "OptimismSuperchainERC20",
@@ -69,16 +61,12 @@ contract InitializerOZv5_Test is CommonTest {
             // Assert that the contract is already initialized.
             bytes32 slotVal = vm.load(_contract.target, INITIALIZABLE_STORAGE);
             uint64 initialized = uint64(uint256(slotVal));
-            assertTrue(
-                // Either 1 for initialized or type(uint64).max for initializer disabled.
-                initialized == 1 || initialized == type(uint64).max,
-                "Initializable: contract is not initialized"
-            );
+            assertEq(initialized, type(uint64).max);
 
             // Then, attempt to re-initialize the contract. This should fail.
             (bool success, bytes memory returnData) = _contract.target.call(_contract.initCalldata);
             assertFalse(success);
-            assertEq(bytes4(returnData), InvalidInitialization.selector);
+            assertEq(bytes4(returnData), Initializable.InvalidInitialization.selector);
         }
     }
 }


### PR DESCRIPTION
- [ ] `testFuzz_systemConfigDeposit_succeeds` is failing when high-fuzzing due to too many assumes
- [x] Undo (all?) changes over `test/vendor/InitializableOZv5.t.sol`
- [ ] Define if some action is needed in the code for the comment:  
  **_Checking if the new gas consumption breaks anything on the base gas defined on the L1CDM_**
  
- [x] Remove Portal already authorized check
- [ ] Rename PAO
- [ ] Remove lockbox already authorized check? 
