### PR TITLE
fix: pr second comments

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.0;
 
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
-import { IPAOBase } from "interfaces/L1/IPAOBase.sol";
+import { IProxyAdminOwnerBase } from "interfaces/L1/IProxyAdminOwnerBase.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 
-interface IETHLockbox is IPAOBase, ISemver {
+interface IETHLockbox is IProxyAdminOwnerBase, ISemver {
     error ETHLockbox_Unauthorized();
     error ETHLockbox_Paused();
     error ETHLockbox_NoWithdrawalTransactions();
-    error ETHLockbox_DifferentPAO();
+    error ETHLockbox_DifferentProxyAdminOwner();
 
     event Initialized(uint8 version);
     event ETHLocked(address indexed portal, uint256 amount);

--- a/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
@@ -10,7 +10,6 @@ interface IETHLockbox is IPAOBase, ISemver {
     error ETHLockbox_Unauthorized();
     error ETHLockbox_Paused();
     error ETHLockbox_NoWithdrawalTransactions();
-    error ETHLockbox_AlreadyAuthorized();
     error ETHLockbox_DifferentPAO();
 
     event Initialized(uint8 version);

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -8,10 +8,10 @@ import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol"
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
-import { IPAOBase } from "interfaces/L1/IPAOBase.sol";
+import { IProxyAdminOwnerBase } from "interfaces/L1/IProxyAdminOwnerBase.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
-interface IOptimismPortal2 is IPAOBase {
+interface IOptimismPortal2 is IProxyAdminOwnerBase {
     error OptimismPortal_Unauthorized();
     error ContentLengthMismatch();
     error EmptyItem();

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
@@ -10,9 +10,9 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { ConfigType } from "interfaces/L2/IL1BlockInterop.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
-import { IPAOBase } from "interfaces/L1/IPAOBase.sol";
+import { IProxyAdminOwnerBase } from "interfaces/L1/IProxyAdminOwnerBase.sol";
 
-interface IOptimismPortalInterop is IPAOBase {
+interface IOptimismPortalInterop is IProxyAdminOwnerBase {
     error ContentLengthMismatch();
     error EmptyItem();
     error InvalidDataRemainder();

--- a/packages/contracts-bedrock/interfaces/L1/IPAOBase.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IPAOBase.sol
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
-
-interface IPAOBase {
-    function PAO() external view returns (address);
-}

--- a/packages/contracts-bedrock/interfaces/L1/IProxyAdminOwnerBase.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IProxyAdminOwnerBase.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IProxyAdminOwnerBase {
+    function proxyAdminOwner() external view returns (address);
+}

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -424,7 +424,7 @@ library ChainAssertions {
         if (_isProxy) {
             require(ethLockbox.superchainConfig() == superchainConfig, "CHECK-ELB-20");
             require(ethLockbox.authorizedPortals(_contracts.OptimismPortal), "CHECK-ELB-30");
-            require(ethLockbox.PAO() == _cfg.finalSystemOwner(), "CHECK-ELB-40");
+            require(ethLockbox.proxyAdminOwner() == _cfg.finalSystemOwner(), "CHECK-ELB-40");
         } else {
             require(address(ethLockbox.superchainConfig()) == address(0), "CHECK-ELB-50");
             require(ethLockbox.authorizedPortals(_contracts.OptimismPortal) == false, "CHECK-ELB-60");

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -624,7 +624,7 @@ contract DeployOPChain is Script {
 
         // Check once the portal is updated to use the new lockbox.
         require(address(portal.ethLockbox()) == address(_doo.ethLockboxProxy()), "PORTAL-90");
-        require(portal.PAO() == _doi.opChainProxyAdminOwner(), "PORTAL-100");
+        require(portal.proxyAdminOwner() == _doi.opChainProxyAdminOwner(), "PORTAL-100");
     }
 
     function assertValidETHLockbox(DeployOPChainInput _doi, DeployOPChainOutput _doo) internal {
@@ -632,7 +632,7 @@ contract DeployOPChain is Script {
 
         require(address(lockbox.superchainConfig()) == address(_doi.opcm().superchainConfig()), "ETHLOCKBOX-10");
         require(lockbox.authorizedPortals(address(_doo.optimismPortalProxy())), "ETHLOCKBOX-20");
-        require(lockbox.PAO() == _doi.opChainProxyAdminOwner(), "ETHLOCKBOX-30");
+        require(lockbox.proxyAdminOwner() == _doi.opChainProxyAdminOwner(), "ETHLOCKBOX-30");
     }
 
     function assertValidDisputeGameFactory(DeployOPChainInput _doi, DeployOPChainOutput _doo) internal {

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.25;
 
 // Contracts
-import { PAOBase } from "src/L1/PAOBase.sol";
+import { ProxyAdminOwnerBase } from "src/L1/ProxyAdminOwnerBase.sol";
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 // Libraries
@@ -18,7 +18,7 @@ import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 /// @title ETHLockbox
 /// @notice Manages ETH liquidity locking and unlocking for authorized OptimismPortals, enabling unified ETH liquidity
 ///         management across chains in the superchain cluster.
-contract ETHLockbox is PAOBase, Initializable, ISemver {
+contract ETHLockbox is ProxyAdminOwnerBase, Initializable, ISemver {
     /// @notice Thrown when the lockbox is paused.
     error ETHLockbox_Paused();
 
@@ -29,7 +29,7 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
     error ETHLockbox_NoWithdrawalTransactions();
 
     /// @notice Thrown when the admin owner of the lockbox is different from the admin owner of the proxy admin.
-    error ETHLockbox_DifferentPAO();
+    error ETHLockbox_DifferentProxyAdminOwner();
 
     /// @notice Emitted when ETH is locked in the lockbox by an authorized portal.
     /// @param portal The address of the portal that locked the ETH.
@@ -96,7 +96,7 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
     /// @notice Authorizes a portal to lock and unlock ETH.
     /// @param _portal The address of the portal to authorize.
     function authorizePortal(IOptimismPortal _portal) external {
-        if (msg.sender != PAO()) revert ETHLockbox_Unauthorized();
+        if (msg.sender != proxyAdminOwner()) revert ETHLockbox_Unauthorized();
         _authorizePortal(address(_portal));
     }
 
@@ -138,8 +138,8 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
     /// @notice Authorizes an ETH lockbox to migrate its liquidity to the current ETH lockbox.
     /// @param _lockbox The address of the ETH lockbox to authorize.
     function authorizeLockbox(IETHLockbox _lockbox) external {
-        if (msg.sender != PAO()) revert ETHLockbox_Unauthorized();
-        if (!_samePAO(address(_lockbox))) revert ETHLockbox_DifferentPAO();
+        if (msg.sender != proxyAdminOwner()) revert ETHLockbox_Unauthorized();
+        if (!_sameproxyAdminOwner(address(_lockbox))) revert ETHLockbox_DifferentProxyAdminOwner();
 
         authorizedLockboxes[address(_lockbox)] = true;
         emit LockboxAuthorized(address(_lockbox));
@@ -148,8 +148,8 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
     /// @notice Migrates liquidity from the current ETH lockbox to another.
     /// @param _lockbox The address of the ETH lockbox to migrate liquidity to.
     function migrateLiquidity(IETHLockbox _lockbox) external {
-        if (msg.sender != PAO()) revert ETHLockbox_Unauthorized();
-        if (!_samePAO(address(_lockbox))) revert ETHLockbox_DifferentPAO();
+        if (msg.sender != proxyAdminOwner()) revert ETHLockbox_Unauthorized();
+        if (!_sameproxyAdminOwner(address(_lockbox))) revert ETHLockbox_DifferentProxyAdminOwner();
 
         IETHLockbox(_lockbox).receiveLiquidity{ value: address(this).balance }();
         emit LiquidityMigrated(address(_lockbox));
@@ -158,7 +158,7 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
     /// @notice Authorizes a portal to lock and unlock ETH.
     /// @param _portal The address of the portal to authorize.
     function _authorizePortal(address _portal) internal {
-        if (!_samePAO(_portal)) revert ETHLockbox_DifferentPAO();
+        if (!_sameproxyAdminOwner(_portal)) revert ETHLockbox_DifferentProxyAdminOwner();
         authorizedPortals[_portal] = true;
         emit PortalAuthorized(_portal);
     }

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -164,7 +164,6 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
     /// @param _portal The address of the portal to authorize.
     function _authorizePortal(address _portal) internal {
         if (!_samePAO(_portal)) revert ETHLockbox_DifferentPAO();
-        if (authorizedPortals[_portal]) revert ETHLockbox_AlreadyAuthorized();
 
         authorizedPortals[_portal] = true;
         emit PortalAuthorized(_portal);

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -25,9 +25,6 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
     /// @notice Thrown when the caller is not authorized.
     error ETHLockbox_Unauthorized();
 
-    /// @notice Thrown when an already authorized portal or lockbox attempts to be authorized again.
-    error ETHLockbox_AlreadyAuthorized();
-
     /// @notice Thrown when attempting to unlock ETH from the lockbox through a withdrawal transaction.
     error ETHLockbox_NoWithdrawalTransactions();
 
@@ -143,7 +140,6 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
     function authorizeLockbox(IETHLockbox _lockbox) external {
         if (msg.sender != PAO()) revert ETHLockbox_Unauthorized();
         if (!_samePAO(address(_lockbox))) revert ETHLockbox_DifferentPAO();
-        if (authorizedLockboxes[address(_lockbox)]) revert ETHLockbox_AlreadyAuthorized();
 
         authorizedLockboxes[address(_lockbox)] = true;
         emit LockboxAuthorized(address(_lockbox));
@@ -156,7 +152,6 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
         if (!_samePAO(address(_lockbox))) revert ETHLockbox_DifferentPAO();
 
         IETHLockbox(_lockbox).receiveLiquidity{ value: address(this).balance }();
-
         emit LiquidityMigrated(address(_lockbox));
     }
 
@@ -164,7 +159,6 @@ contract ETHLockbox is PAOBase, Initializable, ISemver {
     /// @param _portal The address of the portal to authorize.
     function _authorizePortal(address _portal) internal {
         if (!_samePAO(_portal)) revert ETHLockbox_DifferentPAO();
-
         authorizedPortals[_portal] = true;
         emit PortalAuthorized(_portal);
     }

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Contracts
-import { PAOBase } from "src/L1/PAOBase.sol";
+import { ProxyAdminOwnerBase } from "src/L1/ProxyAdminOwnerBase.sol";
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { ResourceMetering } from "src/L1/ResourceMetering.sol";
 
@@ -31,7 +31,7 @@ import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 /// @notice The OptimismPortal is a low-level contract responsible for passing messages between L1
 ///         and L2. Messages sent directly to the OptimismPortal have no form of replayability.
 ///         Users are encouraged to use the L1CrossDomainMessenger for a higher-level interface.
-contract OptimismPortal2 is PAOBase, Initializable, ResourceMetering, ISemver {
+contract OptimismPortal2 is ProxyAdminOwnerBase, Initializable, ResourceMetering, ISemver {
     /// @notice Represents a proven withdrawal.
     /// @custom:field disputeGameProxy Game that the withdrawal was proven against.
     /// @custom:field timestamp        Timestamp at which the withdrawal was proven.
@@ -328,7 +328,7 @@ contract OptimismPortal2 is PAOBase, Initializable, ResourceMetering, ISemver {
     /// @notice Updates the ETHLockbox contract.
     /// @param _newLockbox The address of the new ETHLockbox contract.
     function updateLockbox(IETHLockbox _newLockbox) external {
-        if (msg.sender != PAO()) revert OptimismPortal_Unauthorized();
+        if (msg.sender != proxyAdminOwner()) revert OptimismPortal_Unauthorized();
 
         address oldLockbox = address(ethLockbox);
         ethLockbox = IETHLockbox(_newLockbox);
@@ -536,7 +536,7 @@ contract OptimismPortal2 is PAOBase, Initializable, ResourceMetering, ISemver {
 
     /// @notice Migrates the total ETH balance to the ETHLockbox.
     function migrateLiquidity() public {
-        if (msg.sender != PAO()) revert OptimismPortal_Unauthorized();
+        if (msg.sender != proxyAdminOwner()) revert OptimismPortal_Unauthorized();
         _migrateLiquidity();
     }
 

--- a/packages/contracts-bedrock/src/L1/ProxyAdminOwnerBase.sol
+++ b/packages/contracts-bedrock/src/L1/ProxyAdminOwnerBase.sol
@@ -6,11 +6,11 @@ import { Storage } from "src/libraries/Storage.sol";
 import { Constants } from "src/libraries/Constants.sol";
 
 /// @notice Base contract for ProxyAdmin-owned contracts. It's main goal is to expose the ProxyAdmin owner address on
-///         a function and also to check if the current contract and a given proxy have the same PAO.
-abstract contract PAOBase {
+///         a function and also to check if the current contract and a given proxy have the same ProxyAdmin owner.
+abstract contract ProxyAdminOwnerBase {
     /// @notice Getter for the owner of the ProxyAdmin.
     ///         The ProxyAdmin is the owner of the current proxy contract.
-    function PAO() public view returns (address) {
+    function proxyAdminOwner() public view returns (address) {
         // Get the proxy admin address reading for the reserved slot it has on the Proxy contract.
         IProxyAdmin proxyAdmin = IProxyAdmin(Storage.getAddress(Constants.PROXY_OWNER_ADDRESS));
         // Return the owner of the proxy admin.
@@ -20,7 +20,7 @@ abstract contract PAOBase {
     /// @notice Checks if the ProxyAdmin owner of the current contract is the same as the ProxyAdmin owner of the given
     ///         proxy.
     /// @param _proxy The address of the proxy to check.
-    function _samePAO(address _proxy) internal view returns (bool) {
-        return PAO() == PAOBase(_proxy).PAO();
+    function _sameproxyAdminOwner(address _proxy) internal view returns (bool) {
+        return proxyAdminOwner() == ProxyAdminOwnerBase(_proxy).proxyAdminOwner();
     }
 }

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -235,14 +235,14 @@ contract ETHLockboxTest is CommonTest {
     function testFuzz_unlockETH_multiplePortals_succeeds(IOptimismPortal2 _portal, uint256 _value) public {
         assumeNotForgeAddress(address(_portal));
 
-        vm.assume(!ethLockbox.authorizedPortals(address(_portal)));
-
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
         vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
 
-        // Set the portal as an authorized portal
-        vm.prank(PAO);
-        ethLockbox.authorizePortal(_portal);
+        // Set the portal as an authorized portal if needed
+        if (!ethLockbox.authorizedPortals(address(_portal))) {
+            vm.prank(PAO);
+            ethLockbox.authorizePortal(_portal);
+        }
 
         // Deal the ETH amount to the lockbox
         vm.deal(address(ethLockbox), _value);
@@ -277,27 +277,6 @@ contract ETHLockboxTest is CommonTest {
         // Call the `authorizePortal` function with an unauthorized caller
         vm.prank(_caller);
         ethLockbox.authorizePortal(optimismPortal2);
-    }
-
-    /// @notice Tests the `authorizePortal` function reverts when the portal is already authorized.
-    function testFuzz_authorizePortal_alreadyAuthorized_reverts(IOptimismPortal2 _portal) public {
-        assumeNotForgeAddress(address(_portal));
-        // Authorize the portal
-        if (!ethLockbox.authorizedPortals(address(_portal))) {
-            // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
-            vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
-
-            // Authorize the portal
-            vm.prank(PAO);
-            ethLockbox.authorizePortal(_portal);
-        }
-
-        // Expect the revert with `AlreadyAuthorized` selector
-        vm.expectRevert(IETHLockbox.ETHLockbox_AlreadyAuthorized.selector);
-
-        // Call the `authorizePortal` function with the portal
-        vm.prank(PAO);
-        ethLockbox.authorizePortal(_portal);
     }
 
     /// @notice Tests the `authorizePortal` function reverts when the PAO of the portal is not the same as the PAO of
@@ -339,7 +318,6 @@ contract ETHLockboxTest is CommonTest {
     /// @notice Tests the `authorizeLockbox` function succeeds
     function testFuzz_authorizePortal_succeeds(IOptimismPortal2 _portal) public {
         assumeNotForgeAddress(address(_portal));
-        vm.assume(!ethLockbox.authorizedPortals(address(_portal)));
 
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
         vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -10,7 +10,7 @@ import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPort
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
-import { IPAOBase } from "interfaces/L1/IPAOBase.sol";
+import { IProxyAdminOwnerBase } from "interfaces/L1/IProxyAdminOwnerBase.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 
 // Test
@@ -30,11 +30,11 @@ contract ETHLockboxTest is CommonTest {
     event LiquidityReceived(address indexed lockbox);
 
     ProxyAdmin public proxyAdmin = ProxyAdmin(Predeploys.PROXY_ADMIN);
-    address public PAO;
+    address public proxyAdminOwner;
 
     function setUp() public virtual override {
         super.setUp();
-        PAO = proxyAdmin.owner();
+        proxyAdminOwner = proxyAdmin.owner();
     }
 
     /// @notice Tests the superchain config was correctly set during initialization.
@@ -51,8 +51,8 @@ contract ETHLockboxTest is CommonTest {
     }
 
     /// @notice Tests the proxy admin owner is correctly returned.
-    function test_proxyPAO_succeeds() public view {
-        assertEq(ethLockbox.PAO(), PAO);
+    function test_proxyProxyAdminOwner_succeeds() public view {
+        assertEq(ethLockbox.proxyAdminOwner(), proxyAdminOwner);
     }
 
     /// @notice Tests the paused status is correctly returned.
@@ -76,11 +76,13 @@ contract ETHLockboxTest is CommonTest {
         deal(address(_lockbox), _value);
 
         // Mock the admin owner of the lockbox to be the same as the current lockbox proxy admin owner
-        vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
+        vm.mockCall(
+            address(_lockbox), abi.encodeCall(IProxyAdminOwnerBase.proxyAdminOwner, ()), abi.encode(proxyAdmin.owner())
+        );
 
         // Authorize the lockbox if needed
         if (!ethLockbox.authorizedLockboxes(_lockbox)) {
-            vm.prank(PAO);
+            vm.prank(proxyAdminOwner);
             ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
         }
 
@@ -139,11 +141,13 @@ contract ETHLockboxTest is CommonTest {
         vm.assume(address(_portal) != address(ethLockbox));
 
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
-        vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
+        vm.mockCall(
+            address(_portal), abi.encodeCall(IProxyAdminOwnerBase.proxyAdminOwner, ()), abi.encode(proxyAdmin.owner())
+        );
 
         // Set the portal as an authorized portal if needed
         if (!ethLockbox.authorizedPortals(address(_portal))) {
-            vm.prank(PAO);
+            vm.prank(proxyAdminOwner);
             ethLockbox.authorizePortal(_portal);
         }
 
@@ -236,11 +240,13 @@ contract ETHLockboxTest is CommonTest {
         assumeNotForgeAddress(address(_portal));
 
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
-        vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
+        vm.mockCall(
+            address(_portal), abi.encodeCall(IProxyAdminOwnerBase.proxyAdminOwner, ()), abi.encode(proxyAdmin.owner())
+        );
 
         // Set the portal as an authorized portal if needed
         if (!ethLockbox.authorizedPortals(address(_portal))) {
-            vm.prank(PAO);
+            vm.prank(proxyAdminOwner);
             ethLockbox.authorizePortal(_portal);
         }
 
@@ -279,17 +285,17 @@ contract ETHLockboxTest is CommonTest {
         ethLockbox.authorizePortal(optimismPortal2);
     }
 
-    /// @notice Tests the `authorizePortal` function reverts when the PAO of the portal is not the same as the PAO of
-    ///         the lockbox.
-    function testFuzz_authorizePortal_differentPAO_reverts(IOptimismPortal2 _portal) public {
+    /// @notice Tests the `authorizePortal` function reverts when the proxy admin owner of the portal is not the same as
+    /// the one of the lockbox.
+    function testFuzz_authorizePortal_differentProxyAdminOwner_reverts(IOptimismPortal2 _portal) public {
         assumeNotForgeAddress(address(_portal));
-        vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(address(0)));
+        vm.mockCall(address(_portal), abi.encodeCall(IProxyAdminOwnerBase.proxyAdminOwner, ()), abi.encode(address(0)));
 
         // Expect the revert with `DifferentOwner` selector
-        vm.expectRevert(IETHLockbox.ETHLockbox_DifferentPAO.selector);
+        vm.expectRevert(IETHLockbox.ETHLockbox_DifferentProxyAdminOwner.selector);
 
         // Call the `authorizePortal` function
-        vm.prank(PAO);
+        vm.prank(proxyAdminOwner);
         ethLockbox.authorizePortal(_portal);
     }
 
@@ -308,7 +314,7 @@ contract ETHLockboxTest is CommonTest {
         emit PortalAuthorized(address(optimismPortal2));
 
         // Call the `authorizePortal` function with the portal
-        vm.prank(PAO);
+        vm.prank(proxyAdminOwner);
         ethLockbox.authorizePortal(optimismPortal2);
 
         // Assert the portal is authorized
@@ -320,14 +326,16 @@ contract ETHLockboxTest is CommonTest {
         assumeNotForgeAddress(address(_portal));
 
         // Mock the admin owner of the portal to be the same as the current lockbox proxy admin owner
-        vm.mockCall(address(_portal), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
+        vm.mockCall(
+            address(_portal), abi.encodeCall(IProxyAdminOwnerBase.proxyAdminOwner, ()), abi.encode(proxyAdmin.owner())
+        );
 
         // Expect the `PortalAuthorized` event to be emitted
         vm.expectEmit(address(ethLockbox));
         emit PortalAuthorized(address(_portal));
 
         // Call the `authorizePortal` function with the portal
-        vm.prank(PAO);
+        vm.prank(proxyAdminOwner);
         ethLockbox.authorizePortal(_portal);
 
         // Assert the portal is authorized
@@ -346,18 +354,19 @@ contract ETHLockboxTest is CommonTest {
         ethLockbox.authorizeLockbox(ethLockbox);
     }
 
-    /// @notice Tests the `authorizeLockbox` function reverts when the PAO of the lockbox is not the same as the PAO of
+    /// @notice Tests the `authorizeLockbox` function reverts when the proxy admin owner of the lockbox is not the same
+    /// as the proxy admin owner of
     ///         the proxy admin.
-    function testFuzz_authorizeLockbox_differentPAO_reverts(address _lockbox) public {
+    function testFuzz_authorizeLockbox_differentProxyAdminOwner_reverts(address _lockbox) public {
         assumeNotForgeAddress(_lockbox);
 
-        vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(address(0)));
+        vm.mockCall(address(_lockbox), abi.encodeCall(IProxyAdminOwnerBase.proxyAdminOwner, ()), abi.encode(address(0)));
 
-        // Expect the revert with `ETHLockbox_DifferentPAO` selector
-        vm.expectRevert(IETHLockbox.ETHLockbox_DifferentPAO.selector);
+        // Expect the revert with `ETHLockbox_DifferentProxyAdminOwner` selector
+        vm.expectRevert(IETHLockbox.ETHLockbox_DifferentProxyAdminOwner.selector);
 
         // Call the `authorizeLockbox` function with the lockbox
-        vm.prank(PAO);
+        vm.prank(proxyAdminOwner);
         ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
     }
 
@@ -366,14 +375,16 @@ contract ETHLockboxTest is CommonTest {
         assumeNotForgeAddress(_lockbox);
 
         // Mock the admin owner of the lockbox to be the same as the current lockbox proxy admin owner
-        vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
+        vm.mockCall(
+            address(_lockbox), abi.encodeCall(IProxyAdminOwnerBase.proxyAdminOwner, ()), abi.encode(proxyAdmin.owner())
+        );
 
         // Expect the `LockboxAuthorized` event to be emitted
         vm.expectEmit(address(ethLockbox));
         emit LockboxAuthorized(_lockbox);
 
         // Authorize the lockbox
-        vm.prank(PAO);
+        vm.prank(proxyAdminOwner);
         ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
 
         // Assert the lockbox is authorized
@@ -392,18 +403,19 @@ contract ETHLockboxTest is CommonTest {
         ethLockbox.migrateLiquidity(ethLockbox);
     }
 
-    /// @notice Tests the `migrateLiquidity` function reverts when the PAO of the lockbox is not the same as the PAO of
+    /// @notice Tests the `migrateLiquidity` function reverts when the proxy admin owner of the lockbox is not the same
+    /// as the proxy admin owner of
     ///         the proxy admin.
-    function testFuzz_migrateLiquidity_differentPAO_reverts(address _lockbox) public {
+    function testFuzz_migrateLiquidity_differentProxyAdminOwner_reverts(address _lockbox) public {
         assumeNotForgeAddress(_lockbox);
 
-        vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(address(0)));
+        vm.mockCall(address(_lockbox), abi.encodeCall(IProxyAdminOwnerBase.proxyAdminOwner, ()), abi.encode(address(0)));
 
-        // Expect the revert with `ETHLockbox_DifferentPAO` selector
-        vm.expectRevert(IETHLockbox.ETHLockbox_DifferentPAO.selector);
+        // Expect the revert with `ETHLockbox_DifferentProxyAdminOwner` selector
+        vm.expectRevert(IETHLockbox.ETHLockbox_DifferentProxyAdminOwner.selector);
 
         // Call the `migrateLiquidity` function with the lockbox
-        vm.prank(PAO);
+        vm.prank(proxyAdminOwner);
         ethLockbox.migrateLiquidity(IETHLockbox(_lockbox));
     }
 
@@ -413,7 +425,9 @@ contract ETHLockboxTest is CommonTest {
         vm.assume(address(_lockbox) != address(ethLockbox));
 
         // Mock on the lockbox that will receive the migration for it to succeed
-        vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
+        vm.mockCall(
+            address(_lockbox), abi.encodeCall(IProxyAdminOwnerBase.proxyAdminOwner, ()), abi.encode(proxyAdmin.owner())
+        );
         vm.mockCall(
             address(_lockbox), abi.encodeCall(IETHLockbox.authorizedLockboxes, (address(ethLockbox))), abi.encode(true)
         );
@@ -431,7 +445,7 @@ contract ETHLockboxTest is CommonTest {
         uint256 newLockboxBalanceBefore = address(_lockbox).balance;
 
         // Call the `migrateLiquidity` function with the lockbox
-        vm.prank(PAO);
+        vm.prank(proxyAdminOwner);
         ethLockbox.migrateLiquidity(IETHLockbox(_lockbox));
 
         // Assert the liquidity was migrated

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -346,27 +346,6 @@ contract ETHLockboxTest is CommonTest {
         ethLockbox.authorizeLockbox(ethLockbox);
     }
 
-    /// @notice Tests the `authorizeLockbox` function reverts when the lockbox is already authorized.
-    function testFuzz_authorizeLockbox_alreadyAuthorized_reverts(address _lockbox) public {
-        assumeNotForgeAddress(_lockbox);
-
-        // Authorize the lockbox
-        if (!ethLockbox.authorizedLockboxes(_lockbox)) {
-            vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));
-
-            vm.prank(PAO);
-            ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
-        }
-
-        // Call the `authorizeLockbox` function with the lockbox
-        vm.startPrank(ethLockbox.PAO());
-
-        // Expect the revert with `AlreadyAuthorized` selector
-        vm.expectRevert(IETHLockbox.ETHLockbox_AlreadyAuthorized.selector);
-
-        ethLockbox.authorizeLockbox(IETHLockbox(_lockbox));
-    }
-
     /// @notice Tests the `authorizeLockbox` function reverts when the PAO of the lockbox is not the same as the PAO of
     ///         the proxy admin.
     function testFuzz_authorizeLockbox_differentPAO_reverts(address _lockbox) public {
@@ -385,7 +364,6 @@ contract ETHLockboxTest is CommonTest {
     /// @notice Tests the `authorizeLockbox` function succeeds
     function testFuzz_authorizeLockbox_succeeds(address _lockbox) public {
         assumeNotForgeAddress(_lockbox);
-        vm.assume(!ethLockbox.authorizedLockboxes(_lockbox));
 
         // Mock the admin owner of the lockbox to be the same as the current lockbox proxy admin owner
         vm.mockCall(address(_lockbox), abi.encodeCall(IPAOBase.PAO, ()), abi.encode(proxyAdmin.owner()));

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -467,9 +467,9 @@ contract OptimismPortal2_Test is CommonTest {
         assertEq(accountAccesses[2].storageAccesses.length, 0);
     }
 
-    /// @dev Tests that `updateLockbox` reverts if the caller is not the PAO.
-    function testFuzz_updateLockbox_notPAO_reverts(address _caller) external {
-        vm.assume(_caller != optimismPortal2.PAO());
+    /// @dev Tests that `updateLockbox` reverts if the caller is not the proxy admin owner.
+    function testFuzz_updateLockbox_notProxyAdminOwner_reverts(address _caller) external {
+        vm.assume(_caller != optimismPortal2.proxyAdminOwner());
         vm.expectRevert(IOptimismPortal.OptimismPortal_Unauthorized.selector);
 
         vm.prank(_caller);
@@ -484,7 +484,7 @@ contract OptimismPortal2_Test is CommonTest {
         vm.expectEmit(address(optimismPortal2));
         emit LockboxUpdated(oldLockbox, _newLockbox);
 
-        vm.prank(optimismPortal2.PAO());
+        vm.prank(optimismPortal2.proxyAdminOwner());
         optimismPortal2.updateLockbox(IETHLockbox(_newLockbox));
 
         assertEq(address(optimismPortal2.ethLockbox()), _newLockbox);
@@ -1859,8 +1859,8 @@ contract OptimismPortal2_LiquidityMigration_Test is CommonTest {
     }
 
     /// @notice Tests the liquidity migration from the portal to the lockbox reverts if not called by the admin owner.
-    function testFuzz_migrateLiquidity_notPAO_reverts(address _caller) external {
-        vm.assume(_caller != optimismPortal2.PAO());
+    function testFuzz_migrateLiquidity_notProxyAdminOwner_reverts(address _caller) external {
+        vm.assume(_caller != optimismPortal2.proxyAdminOwner());
         vm.expectRevert(IOptimismPortal.OptimismPortal_Unauthorized.selector);
         vm.prank(_caller);
         optimismPortal2.migrateLiquidity();
@@ -1871,14 +1871,14 @@ contract OptimismPortal2_LiquidityMigration_Test is CommonTest {
         vm.deal(address(optimismPortal2), _portalBalance);
 
         uint256 lockboxBalanceBefore = address(ethLockbox).balance;
-        address PAO = optimismPortal2.PAO();
+        address proxyAdminOwner = optimismPortal2.proxyAdminOwner();
 
         vm.expectCall(address(ethLockbox), _portalBalance, abi.encodeCall(ethLockbox.lockETH, ()));
 
         vm.expectEmit(address(optimismPortal2));
         emit ETHMigrated(_portalBalance);
 
-        vm.prank(PAO);
+        vm.prank(proxyAdminOwner);
         optimismPortal2.migrateLiquidity();
 
         assertEq(address(optimismPortal2).balance, 0);

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -251,7 +251,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "OptimismPortalInterop", _sel: _getSel("upgrade(address,address)") });
         _addSpec({ _name: "OptimismPortalInterop", _sel: _getSel("ethLockbox()") });
         _addSpec({ _name: "OptimismPortalInterop", _sel: _getSel("migrateLiquidity()") });
-        _addSpec({ _name: "OptimismPortalInterop", _sel: _getSel("PAO()") });
+        _addSpec({ _name: "OptimismPortalInterop", _sel: _getSel("proxyAdminOwner()") });
         _addSpec({ _name: "OptimismPortalInterop", _sel: _getSel("setConfig(uint8,bytes)") });
 
         // OptimismPortal2
@@ -296,10 +296,10 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "OptimismPortal2", _sel: _getSel("upgrade(address,address)") });
         _addSpec({ _name: "OptimismPortal2", _sel: _getSel("ethLockbox()") });
         _addSpec({ _name: "OptimismPortal2", _sel: _getSel("migrateLiquidity()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("PAO()") });
+        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("proxyAdminOwner()") });
 
-        // PAOBase
-        _addSpec({ _name: "PAOBase", _sel: _getSel("PAO()") });
+        // ProxyAdminOwnerBase
+        _addSpec({ _name: "ProxyAdminOwnerBase", _sel: _getSel("proxyAdminOwner()") });
 
         // ProtocolVersions
         _addSpec({ _name: "ProtocolVersions", _sel: _getSel("RECOMMENDED_SLOT()") });
@@ -336,7 +336,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "ETHLockbox", _sel: _getSel("authorizePortal(address)") });
         _addSpec({ _name: "ETHLockbox", _sel: _getSel("authorizeLockbox(address)") });
         _addSpec({ _name: "ETHLockbox", _sel: _getSel("migrateLiquidity(address)") });
-        _addSpec({ _name: "ETHLockbox", _sel: _getSel("PAO()") });
+        _addSpec({ _name: "ETHLockbox", _sel: _getSel("proxyAdminOwner()") });
 
         // ResourceMetering
         _addSpec({ _name: "ResourceMetering", _sel: _getSel("params()") });

--- a/packages/contracts-bedrock/test/vendor/InitializableOZv5.t.sol
+++ b/packages/contracts-bedrock/test/vendor/InitializableOZv5.t.sol
@@ -1,17 +1,15 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
-import { CommonTest } from "test/setup/CommonTest.sol";
+import { Test } from "forge-std/Test.sol";
 import { IOptimismSuperchainERC20 } from "interfaces/L2/IOptimismSuperchainERC20.sol";
+import { Initializable } from "@openzeppelin/contracts-v5/proxy/utils/Initializable.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
-
 /// @title InitializerOZv5_Test
 /// @dev Ensures that the `initialize()` function on contracts cannot be called more than
 ///      once. Tests the contracts inheriting from `Initializable` from OpenZeppelin Contracts v5.
 
-contract InitializerOZv5_Test is CommonTest {
-    error InvalidInitialization();
-
+contract InitializerOZv5_Test is Test {
     /// @notice The storage slot of the `initialized` flag in the `Initializable` contract from OZ v5.
     /// keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.Initializable")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant INITIALIZABLE_STORAGE = 0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
@@ -19,7 +17,6 @@ contract InitializerOZv5_Test is CommonTest {
     /// @notice Contains the address of an `Initializable` contract and the calldata
     ///         used to initialize it.
     struct InitializeableContract {
-        string name;
         address target;
         bytes initCalldata;
     }
@@ -28,18 +25,13 @@ contract InitializerOZv5_Test is CommonTest {
     ///         used to initialize them.
     InitializeableContract[] contracts;
 
-    function setUp() public override {
-        super.enableInterop();
-        super.enableAltDA();
-        super.setUp();
-
+    function setUp() public {
         // Initialize the `contracts` array with the addresses of the contracts to test and the
         // calldata used to initialize them
 
         // OptimismSuperchainERC20
         contracts.push(
             InitializeableContract({
-                name: "OptimismSuperchainERC20",
                 target: address(
                     DeployUtils.create1({
                         _name: "OptimismSuperchainERC20",
@@ -69,16 +61,12 @@ contract InitializerOZv5_Test is CommonTest {
             // Assert that the contract is already initialized.
             bytes32 slotVal = vm.load(_contract.target, INITIALIZABLE_STORAGE);
             uint64 initialized = uint64(uint256(slotVal));
-            assertTrue(
-                // Either 1 for initialized or type(uint64).max for initializer disabled.
-                initialized == 1 || initialized == type(uint64).max,
-                "Initializable: contract is not initialized"
-            );
+            assertEq(initialized, type(uint64).max);
 
             // Then, attempt to re-initialize the contract. This should fail.
             (bool success, bytes memory returnData) = _contract.target.call(_contract.initCalldata);
             assertFalse(success);
-            assertEq(bytes4(returnData), InvalidInitialization.selector);
+            assertEq(bytes4(returnData), Initializable.InvalidInitialization.selector);
         }
     }
 }


### PR DESCRIPTION
- ~~`testFuzz_systemConfigDeposit_succeeds` is failing when high-fuzzing due to too many assumes~~
- [x] Undo (all?) changes over `test/vendor/InitializableOZv5.t.sol`
- [ ] Define if some action is needed in the code for the comment:  
  **_Checking if the new gas consumption breaks anything on the base gas defined on the L1CDM_**
  
- [x] Remove Portal already authorized check
- [x] Rename PAO
- [x] Remove lockbox already authorized check?
- [ ] Fix `just test-upgrade` fail
