### PR TITLE
fix: add call to set necessary configs on L2

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -102,6 +102,7 @@ interface IOPContractsManager {
         Roles roles;
         uint32 basefeeScalar;
         uint32 blobBasefeeScalar;
+        bytes feeVaultConfigs;
         uint256 l2ChainId;
         // The correct type is OutputRoot memory but OP Deployer does not yet support structs.
         bytes startingAnchorRoot;

--- a/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
+++ b/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
@@ -27,6 +27,13 @@ interface ISystemConfig {
         address feeVaultAdmin;
     }
 
+    struct FeeVaultConfigs {
+        Types.FeeVaultConfig baseFeeVaultConfig;
+        Types.FeeVaultConfig sequencerFeeVaultConfig;
+        Types.FeeVaultConfig l1FeeVaultConfig;
+        Types.FeeVaultConfig operatorFeeVaultConfig;
+    }
+
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
     event Initialized(uint8 version);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
@@ -62,6 +69,7 @@ interface ISystemConfig {
         IResourceMetering.ResourceConfig memory _config,
         address _batchInbox,
         Addresses memory _addresses,
+        FeeVaultConfigs memory _feeVaultConfigs,
         uint256 _l2ChainId
     )
         external;
@@ -87,13 +95,7 @@ interface ISystemConfig {
     function setGasLimit(uint64 _gasLimit) external;
     function setOperatorFeeScalars(uint32 _operatorFeeScalar, uint64 _operatorFeeConstant) external;
     function setUnsafeBlockSigner(address _unsafeBlockSigner) external;
-    function setFeeVaultConfig(
-        Types.ConfigType _type,
-        address _recipient,
-        uint256 _min,
-        Types.WithdrawalNetwork _network
-    )
-        external;
+    function setFeeVaultConfig(Types.ConfigType _type, Types.FeeVaultConfig memory _config) external;
     function setEIP1559Params(uint32 _denominator, uint32 _elasticity) external;
     function startBlock() external view returns (uint256 startBlock_);
     function transferOwnership(address newOwner) external; // nosemgrep

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -25,6 +25,7 @@ import {
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
+import { Types as LibTypes } from "src/libraries/Types.sol";
 import { Types } from "scripts/libraries/Types.sol";
 import { Duration } from "src/dispute/lib/LibUDT.sol";
 import { StorageSlot, ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
@@ -519,6 +520,28 @@ contract Deploy is Deployer {
                         optimismPortal: artifacts.mustGetAddress("OptimismPortalProxy"),
                         optimismMintableERC20Factory: artifacts.mustGetAddress("L1OptimismMintableERC20FactoryProxy")
                     }),
+                    ISystemConfig.FeeVaultConfigs({
+                        baseFeeVaultConfig: LibTypes.FeeVaultConfig({
+                            recipient: cfg.baseFeeVaultRecipient(),
+                            min: cfg.baseFeeVaultMinimumWithdrawalAmount(),
+                            withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.baseFeeVaultWithdrawalNetwork())
+                        }),
+                        sequencerFeeVaultConfig: LibTypes.FeeVaultConfig({
+                            recipient: cfg.sequencerFeeVaultRecipient(),
+                            min: cfg.sequencerFeeVaultMinimumWithdrawalAmount(),
+                            withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.sequencerFeeVaultWithdrawalNetwork())
+                        }),
+                        l1FeeVaultConfig: LibTypes.FeeVaultConfig({
+                            recipient: cfg.l1FeeVaultRecipient(),
+                            min: cfg.l1FeeVaultMinimumWithdrawalAmount(),
+                            withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.l1FeeVaultWithdrawalNetwork())
+                        }),
+                        operatorFeeVaultConfig: LibTypes.FeeVaultConfig({
+                            recipient: cfg.operatorFeeVaultRecipient(),
+                            min: cfg.operatorFeeVaultMinimumWithdrawalAmount(),
+                            withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.operatorFeeVaultWithdrawalNetwork())
+                        })
+                    }),
                     cfg.l2ChainID()
                 )
             )
@@ -953,6 +976,30 @@ contract Deploy is Deployer {
                 challenger: cfg.l2OutputOracleChallenger(),
                 feeVaultAdmin: cfg.systemConfigFeeVaultAdmin()
             }),
+            feeVaultConfigs: abi.encode(
+                ISystemConfig.FeeVaultConfigs({
+                    baseFeeVaultConfig: LibTypes.FeeVaultConfig({
+                        recipient: cfg.baseFeeVaultRecipient(),
+                        min: cfg.baseFeeVaultMinimumWithdrawalAmount(),
+                        withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.baseFeeVaultWithdrawalNetwork())
+                    }),
+                    sequencerFeeVaultConfig: LibTypes.FeeVaultConfig({
+                        recipient: cfg.sequencerFeeVaultRecipient(),
+                        min: cfg.sequencerFeeVaultMinimumWithdrawalAmount(),
+                        withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.sequencerFeeVaultWithdrawalNetwork())
+                    }),
+                    l1FeeVaultConfig: LibTypes.FeeVaultConfig({
+                        recipient: cfg.l1FeeVaultRecipient(),
+                        min: cfg.l1FeeVaultMinimumWithdrawalAmount(),
+                        withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.l1FeeVaultWithdrawalNetwork())
+                    }),
+                    operatorFeeVaultConfig: LibTypes.FeeVaultConfig({
+                        recipient: cfg.operatorFeeVaultRecipient(),
+                        min: cfg.operatorFeeVaultMinimumWithdrawalAmount(),
+                        withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.operatorFeeVaultWithdrawalNetwork())
+                    })
+                })
+            ),
             basefeeScalar: cfg.basefeeScalar(),
             blobBasefeeScalar: cfg.blobbasefeeScalar(),
             l2ChainId: cfg.l2ChainID(),

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -523,22 +523,22 @@ contract Deploy is Deployer {
                     ISystemConfig.FeeVaultConfigs({
                         baseFeeVaultConfig: LibTypes.FeeVaultConfig({
                             recipient: cfg.baseFeeVaultRecipient(),
-                            min: cfg.baseFeeVaultMinimumWithdrawalAmount(),
+                            minWithdrawalAmount: cfg.baseFeeVaultMinimumWithdrawalAmount(),
                             withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.baseFeeVaultWithdrawalNetwork())
                         }),
                         sequencerFeeVaultConfig: LibTypes.FeeVaultConfig({
                             recipient: cfg.sequencerFeeVaultRecipient(),
-                            min: cfg.sequencerFeeVaultMinimumWithdrawalAmount(),
+                            minWithdrawalAmount: cfg.sequencerFeeVaultMinimumWithdrawalAmount(),
                             withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.sequencerFeeVaultWithdrawalNetwork())
                         }),
                         l1FeeVaultConfig: LibTypes.FeeVaultConfig({
                             recipient: cfg.l1FeeVaultRecipient(),
-                            min: cfg.l1FeeVaultMinimumWithdrawalAmount(),
+                            minWithdrawalAmount: cfg.l1FeeVaultMinimumWithdrawalAmount(),
                             withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.l1FeeVaultWithdrawalNetwork())
                         }),
                         operatorFeeVaultConfig: LibTypes.FeeVaultConfig({
                             recipient: cfg.operatorFeeVaultRecipient(),
-                            min: cfg.operatorFeeVaultMinimumWithdrawalAmount(),
+                            minWithdrawalAmount: cfg.operatorFeeVaultMinimumWithdrawalAmount(),
                             withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.operatorFeeVaultWithdrawalNetwork())
                         })
                     }),
@@ -980,22 +980,22 @@ contract Deploy is Deployer {
                 ISystemConfig.FeeVaultConfigs({
                     baseFeeVaultConfig: LibTypes.FeeVaultConfig({
                         recipient: cfg.baseFeeVaultRecipient(),
-                        min: cfg.baseFeeVaultMinimumWithdrawalAmount(),
+                        minWithdrawalAmount: cfg.baseFeeVaultMinimumWithdrawalAmount(),
                         withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.baseFeeVaultWithdrawalNetwork())
                     }),
                     sequencerFeeVaultConfig: LibTypes.FeeVaultConfig({
                         recipient: cfg.sequencerFeeVaultRecipient(),
-                        min: cfg.sequencerFeeVaultMinimumWithdrawalAmount(),
+                        minWithdrawalAmount: cfg.sequencerFeeVaultMinimumWithdrawalAmount(),
                         withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.sequencerFeeVaultWithdrawalNetwork())
                     }),
                     l1FeeVaultConfig: LibTypes.FeeVaultConfig({
                         recipient: cfg.l1FeeVaultRecipient(),
-                        min: cfg.l1FeeVaultMinimumWithdrawalAmount(),
+                        minWithdrawalAmount: cfg.l1FeeVaultMinimumWithdrawalAmount(),
                         withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.l1FeeVaultWithdrawalNetwork())
                     }),
                     operatorFeeVaultConfig: LibTypes.FeeVaultConfig({
                         recipient: cfg.operatorFeeVaultRecipient(),
-                        min: cfg.operatorFeeVaultMinimumWithdrawalAmount(),
+                        minWithdrawalAmount: cfg.operatorFeeVaultMinimumWithdrawalAmount(),
                         withdrawalNetwork: LibTypes.WithdrawalNetwork(cfg.operatorFeeVaultWithdrawalNetwork())
                     })
                 })

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -47,6 +47,7 @@ contract DeployOPChainInput is BaseDeployIO {
     // TODO Add fault proofs inputs in a future PR.
     uint32 internal _basefeeScalar;
     uint32 internal _blobBaseFeeScalar;
+    bytes internal _feeVaultConfigs;
     uint256 internal _l2ChainId;
     IOPContractsManager internal _opcm;
     string internal _saltMixer;
@@ -122,6 +123,11 @@ contract DeployOPChainInput is BaseDeployIO {
         else revert("DeployOPChainInput: unknown selector");
     }
 
+    function set(bytes4 _sel, bytes memory _value) public {
+        if (_sel == this.feeVaultConfigs.selector) _feeVaultConfigs = _value;
+        else revert("DeployOPChainInput: unknown selector");
+    }
+
     function opChainProxyAdminOwner() public view returns (address) {
         require(_opChainProxyAdminOwner != address(0), "DeployOPChainInput: not set");
         return _opChainProxyAdminOwner;
@@ -165,6 +171,11 @@ contract DeployOPChainInput is BaseDeployIO {
     function blobBaseFeeScalar() public view returns (uint32) {
         require(_blobBaseFeeScalar != 0, "DeployOPChainInput: not set");
         return _blobBaseFeeScalar;
+    }
+
+    function feeVaultConfigs() public view returns (bytes memory) {
+        require(_feeVaultConfigs.length != 0, "DeployOPChainInput: not set");
+        return _feeVaultConfigs;
     }
 
     function l2ChainId() public view returns (uint256) {
@@ -384,6 +395,7 @@ contract DeployOPChain is Script {
             roles: roles,
             basefeeScalar: _doi.basefeeScalar(),
             blobBasefeeScalar: _doi.blobBaseFeeScalar(),
+            feeVaultConfigs: _doi.feeVaultConfigs(),
             l2ChainId: _doi.l2ChainId(),
             startingAnchorRoot: _doi.startingAnchorRoot(),
             saltMixer: _doi.saltMixer(),

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
@@ -279,6 +279,11 @@
             "type": "uint32"
           },
           {
+            "internalType": "bytes",
+            "name": "feeVaultConfigs",
+            "type": "bytes"
+          },
+          {
             "internalType": "uint256",
             "name": "l2ChainId",
             "type": "uint256"

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerDeployer.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerDeployer.json
@@ -172,6 +172,11 @@
             "type": "uint32"
           },
           {
+            "internalType": "bytes",
+            "name": "feeVaultConfigs",
+            "type": "bytes"
+          },
+          {
             "internalType": "uint256",
             "name": "l2ChainId",
             "type": "uint256"

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
@@ -420,7 +420,7 @@
               },
               {
                 "internalType": "uint256",
-                "name": "min",
+                "name": "minWithdrawalAmount",
                 "type": "uint256"
               },
               {
@@ -442,7 +442,7 @@
               },
               {
                 "internalType": "uint256",
-                "name": "min",
+                "name": "minWithdrawalAmount",
                 "type": "uint256"
               },
               {
@@ -464,7 +464,7 @@
               },
               {
                 "internalType": "uint256",
-                "name": "min",
+                "name": "minWithdrawalAmount",
                 "type": "uint256"
               },
               {
@@ -486,7 +486,7 @@
               },
               {
                 "internalType": "uint256",
-                "name": "min",
+                "name": "minWithdrawalAmount",
                 "type": "uint256"
               },
               {
@@ -783,7 +783,7 @@
           },
           {
             "internalType": "uint256",
-            "name": "min",
+            "name": "minWithdrawalAmount",
             "type": "uint256"
           },
           {

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
@@ -410,6 +410,101 @@
         "type": "tuple"
       },
       {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "min",
+                "type": "uint256"
+              },
+              {
+                "internalType": "enum Types.WithdrawalNetwork",
+                "name": "withdrawalNetwork",
+                "type": "uint8"
+              }
+            ],
+            "internalType": "struct Types.FeeVaultConfig",
+            "name": "baseFeeVaultConfig",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "min",
+                "type": "uint256"
+              },
+              {
+                "internalType": "enum Types.WithdrawalNetwork",
+                "name": "withdrawalNetwork",
+                "type": "uint8"
+              }
+            ],
+            "internalType": "struct Types.FeeVaultConfig",
+            "name": "sequencerFeeVaultConfig",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "min",
+                "type": "uint256"
+              },
+              {
+                "internalType": "enum Types.WithdrawalNetwork",
+                "name": "withdrawalNetwork",
+                "type": "uint8"
+              }
+            ],
+            "internalType": "struct Types.FeeVaultConfig",
+            "name": "l1FeeVaultConfig",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "min",
+                "type": "uint256"
+              },
+              {
+                "internalType": "enum Types.WithdrawalNetwork",
+                "name": "withdrawalNetwork",
+                "type": "uint8"
+              }
+            ],
+            "internalType": "struct Types.FeeVaultConfig",
+            "name": "operatorFeeVaultConfig",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct SystemConfig.FeeVaultConfigs",
+        "name": "_feeVaultConfigs",
+        "type": "tuple"
+      },
+      {
         "internalType": "uint256",
         "name": "_l2ChainId",
         "type": "uint256"
@@ -680,19 +775,26 @@
         "type": "uint8"
       },
       {
-        "internalType": "address",
-        "name": "_recipient",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_min",
-        "type": "uint256"
-      },
-      {
-        "internalType": "enum Types.WithdrawalNetwork",
-        "name": "_network",
-        "type": "uint8"
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "min",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum Types.WithdrawalNetwork",
+            "name": "withdrawalNetwork",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct Types.FeeVaultConfig",
+        "name": "_config",
+        "type": "tuple"
       }
     ],
     "name": "setFeeVaultConfig",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -41,7 +41,7 @@
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
     "initCodeHash": "0x577d832b7e2f7f75bed5d6640bca2f03492bbc26816c06bcf71bc9e05d7ad0aa",
-    "sourceCodeHash": "0x41f37d648b447b0e3f9497cbd6e623f6d5e22fcbfc6f496d8ebb1a0ccc681335"
+    "sourceCodeHash": "0xe8d1565b675efdc21e0d326a973997e51591fee4a6d4da53592ed023f403526f"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x5cd051d29314c81baa81e684b419ea90cb9dda59418c8695940f3fc505161655",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xe52e857ef20c4475761ec707de57b9f3a9f3fec648f58039c92c92a20819d986"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x0b4e1a5538776a77533542dd22d297e62e719033ede485314f56df10aed3af4c",
-    "sourceCodeHash": "0x9ecc16aef0036dc573ce5071912a0ef4dd3fbd0ec76bb53ba5c85319858fec7c"
+    "initCodeHash": "0xb8283af7e2cf217fedba2bde71adf55904c1418652e5612b12929d16f6538a87",
+    "sourceCodeHash": "0x7c3a140c45192b3782f31e5f53626465149e34c2d211c8cc84248ea45929aa8e"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0xc8980137343fd0721803935044bd46be89449100ebdcc1b9beec5dea31229240",
@@ -40,8 +40,8 @@
     "sourceCodeHash": "0xe3f5ce9c26d70ca09d9db171827091630ac25ea56ff0e73114e2658c923eadf1"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0xf42c6f75fd8e500ffa94dc91a862e1b21a321aa1ce5dba3f929320670bbd3372",
-    "sourceCodeHash": "0x86defec9b6fde0960ecddd914f17f769e98264c9a6849800012813f6fbeb4343"
+    "initCodeHash": "0x577d832b7e2f7f75bed5d6640bca2f03492bbc26816c06bcf71bc9e05d7ad0aa",
+    "sourceCodeHash": "0x41f37d648b447b0e3f9497cbd6e623f6d5e22fcbfc6f496d8ebb1a0ccc681335"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x5cd051d29314c81baa81e684b419ea90cb9dda59418c8695940f3fc505161655",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1096,6 +1096,7 @@ contract OPContractsManagerDeployer is OPContractsManagerBase {
                 referenceResourceConfig,
                 chainIdToBatchInboxAddress(_input.l2ChainId),
                 opChainAddrs,
+                abi.decode(_input.feeVaultConfigs, (ISystemConfig.FeeVaultConfigs)),
                 _input.l2ChainId
             )
         );
@@ -1192,6 +1193,7 @@ contract OPContractsManager is ISemver {
         Roles roles;
         uint32 basefeeScalar;
         uint32 blobBasefeeScalar;
+        bytes feeVaultConfigs;
         uint256 l2ChainId;
         // The correct type is Proposal memory but OP Deployer does not yet support structs.
         bytes startingAnchorRoot;

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -56,6 +56,14 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
         address feeVaultAdmin;
     }
 
+    /// @notice Struct representing the configuration of all the fee vaults.
+    struct FeeVaultConfigs {
+        Types.FeeVaultConfig baseFeeVaultConfig;
+        Types.FeeVaultConfig sequencerFeeVaultConfig;
+        Types.FeeVaultConfig l1FeeVaultConfig;
+        Types.FeeVaultConfig operatorFeeVaultConfig;
+    }
+
     /// @notice Version identifier, used for upgrades.
     uint256 public constant VERSION = 0;
 
@@ -186,6 +194,7 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
         IResourceMetering.ResourceConfig memory _config,
         address _batchInbox,
         SystemConfig.Addresses memory _addresses,
+        FeeVaultConfigs memory _feeVaultConfigs,
         uint256 _l2ChainId
     )
         public
@@ -203,15 +212,29 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
         // Note: FEE_VAULT_ADMIN_SLOT is initialized here and cannot be changed later.
         Storage.setAddress(FEE_VAULT_ADMIN_SLOT, _roles.feeVaultAdmin);
         Storage.setAddress(BATCH_INBOX_SLOT, _batchInbox);
-        Storage.setAddress(L1_CROSS_DOMAIN_MESSENGER_SLOT, _addresses.l1CrossDomainMessenger);
-        Storage.setAddress(L1_ERC_721_BRIDGE_SLOT, _addresses.l1ERC721Bridge);
-        Storage.setAddress(L1_STANDARD_BRIDGE_SLOT, _addresses.l1StandardBridge);
         Storage.setAddress(OPTIMISM_PORTAL_SLOT, _addresses.optimismPortal);
         Storage.setAddress(OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT, _addresses.optimismMintableERC20Factory);
 
+        _setResourceConfig(_config);
+
+        // Set the L1 addresses on OptimismPortal
+        _setAddress(
+            L1_CROSS_DOMAIN_MESSENGER_SLOT,
+            _addresses.l1CrossDomainMessenger,
+            Types.ConfigType.L1_CROSS_DOMAIN_MESSENGER_ADDRESS
+        );
+        _setAddress(L1_ERC_721_BRIDGE_SLOT, _addresses.l1ERC721Bridge, Types.ConfigType.L1_ERC_721_BRIDGE_ADDRESS);
+        _setAddress(L1_STANDARD_BRIDGE_SLOT, _addresses.l1StandardBridge, Types.ConfigType.L1_STANDARD_BRIDGE_ADDRESS);
+
         _setStartBlock();
 
-        _setResourceConfig(_config);
+        // Set the fee vault configs.
+        _setFeeVaultConfig(Types.ConfigType.BASE_FEE_VAULT_CONFIG, _feeVaultConfigs.baseFeeVaultConfig);
+        _setFeeVaultConfig(Types.ConfigType.SEQUENCER_FEE_VAULT_CONFIG, _feeVaultConfigs.sequencerFeeVaultConfig);
+        _setFeeVaultConfig(Types.ConfigType.L1_FEE_VAULT_CONFIG, _feeVaultConfigs.l1FeeVaultConfig);
+        _setFeeVaultConfig(Types.ConfigType.OPERATOR_FEE_VAULT_CONFIG, _feeVaultConfigs.operatorFeeVaultConfig);
+
+        _setRemoteChainId();
 
         l2ChainId = _l2ChainId;
     }
@@ -312,34 +335,16 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
 
     /// @notice Setter for the FeeVault predeploy configuration.
     /// @param _type The FeeVault type.
-    /// @param _recipient Address that should receive the funds.
-    /// @param _min Minimum withdrawal amount allowed to be processed.
-    /// @param _network The network in which the fees should be withdrawn to.
-    function setFeeVaultConfig(
-        Types.ConfigType _type,
-        address _recipient,
-        uint256 _min,
-        Types.WithdrawalNetwork _network
-    )
-        external
-    {
+    /// @param _config The FeeVault config.
+    function setFeeVaultConfig(Types.ConfigType _type, Types.FeeVaultConfig memory _config) external {
         require(msg.sender == feeVaultAdmin(), "SystemConfig: caller is not the fee admin");
-        _setFeeVaultConfig(_type, _recipient, _min, _network);
+        _setFeeVaultConfig(_type, _config);
     }
 
     /// @notice Internal function for setting the FeeVault config by type.
     /// @param _type The FeeVault type
-    /// @param _recipient Address that should receive the funds.
-    /// @param _min Minimum withdrawal amount allowed to be processed.
-    /// @param _network The network in which the fees should be withdrawn to.
-    function _setFeeVaultConfig(
-        Types.ConfigType _type,
-        address _recipient,
-        uint256 _min,
-        Types.WithdrawalNetwork _network
-    )
-        internal
-    {
+    /// @param _config The FeeVault config.
+    function _setFeeVaultConfig(Types.ConfigType _type, Types.FeeVaultConfig memory _config) internal {
         require(
             _type == Types.ConfigType.BASE_FEE_VAULT_CONFIG || _type == Types.ConfigType.L1_FEE_VAULT_CONFIG
                 || _type == Types.ConfigType.SEQUENCER_FEE_VAULT_CONFIG
@@ -348,7 +353,7 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
         );
         IOptimismPortal2(payable(optimismPortal())).setConfig({
             _type: _type,
-            _value: abi.encode(Encoding.encodeFeeVaultConfig(_recipient, _min, _network))
+            _value: abi.encode(Encoding.encodeFeeVaultConfig(_config.recipient, _config.min, _config.withdrawalNetwork))
         });
     }
 
@@ -522,5 +527,24 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
         );
 
         _resourceConfig = _config;
+    }
+
+    /// @notice Internal setter for L1 system addresses that need to be legible from within L2.
+    /// @param _slot The local storage slot that the address should be stored in.
+    /// @param _addr The address of the L1 based system address.
+    /// @param _type The ConfigType that represents what the address is.
+    function _setAddress(bytes32 _slot, address _addr, Types.ConfigType _type) internal {
+        Storage.setAddress(_slot, _addr);
+        IOptimismPortal2(payable(optimismPortal())).setConfig({ _type: _type, _value: abi.encode(_addr) });
+    }
+
+    /// @notice Internal setter for the base chain's chain id. This allows for the
+    ///         base chain's chain id to be legible from within the parent chain.
+    ///         In the case of an L2, this would be the L1 chain id.
+    function _setRemoteChainId() internal {
+        IOptimismPortal2(payable(optimismPortal())).setConfig({
+            _type: Types.ConfigType.REMOTE_CHAIN_ID,
+            _value: abi.encode(block.chainid)
+        });
     }
 }

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -353,7 +353,9 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
         );
         IOptimismPortal2(payable(optimismPortal())).setConfig({
             _type: _type,
-            _value: abi.encode(Encoding.encodeFeeVaultConfig(_config.recipient, _config.min, _config.withdrawalNetwork))
+            _value: abi.encode(
+                Encoding.encodeFeeVaultConfig(_config.recipient, _config.minWithdrawalAmount, _config.withdrawalNetwork)
+            )
         });
     }
 

--- a/packages/contracts-bedrock/src/libraries/Types.sol
+++ b/packages/contracts-bedrock/src/libraries/Types.sol
@@ -132,13 +132,14 @@ library Types {
         RESOLVED
     }
 
-    /// @notice Struct representing the configuration of a fee vault.
-    /// @custom:field recipient Address that should receive the funds.
-    /// @custom:field min Minimum withdrawal amount allowed to be processed.
-    /// @custom:field withdrawalNetwork The network in which the fees should be withdrawn to.
+    /// @notice Configuration parameters for fee vault withdrawals.
+    /// @custom:field recipient The address that will receive withdrawn fees.
+    /// @custom:field minWithdrawalAmount The minimum amount of fees (in wei) that must accumulate before a withdrawal
+    ///               can be initiated.
+    /// @custom:field withdrawalNetwork Specifies which network (L1 or L2) the fees should be withdrawn to.
     struct FeeVaultConfig {
         address recipient;
-        uint256 min;
+        uint256 minWithdrawalAmount;
         Types.WithdrawalNetwork withdrawalNetwork;
     }
 }

--- a/packages/contracts-bedrock/src/libraries/Types.sol
+++ b/packages/contracts-bedrock/src/libraries/Types.sol
@@ -131,4 +131,14 @@ library Types {
         CHUGSPLASH,
         RESOLVED
     }
+
+    /// @notice Struct representing the configuration of a fee vault.
+    /// @custom:field recipient Address that should receive the funds.
+    /// @custom:field min Minimum withdrawal amount allowed to be processed.
+    /// @custom:field withdrawalNetwork The network in which the fees should be withdrawn to.
+    struct FeeVaultConfig {
+        address recipient;
+        uint256 min;
+        Types.WithdrawalNetwork withdrawalNetwork;
+    }
 }

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -18,7 +18,7 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { Blueprint } from "src/libraries/Blueprint.sol";
 import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
 import { Bytes } from "src/libraries/Bytes.sol";
-
+import { Types } from "src/libraries/Types.sol";
 // Interfaces
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
@@ -114,6 +114,7 @@ contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase {
         doi.set(doi.feeVaultAdmin.selector, feeVaultAdmin);
         doi.set(doi.basefeeScalar.selector, basefeeScalar);
         doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
+        doi.set(doi.feeVaultConfigs.selector, feeVaultConfigs);
         doi.set(doi.l2ChainId.selector, l2ChainId);
         doi.set(doi.opcm.selector, address(opcm));
         doi.set(doi.gasLimit.selector, gasLimit);
@@ -145,6 +146,7 @@ contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase {
             }),
             basefeeScalar: _doi.basefeeScalar(),
             blobBasefeeScalar: _doi.blobBaseFeeScalar(),
+            feeVaultConfigs: _doi.feeVaultConfigs(),
             l2ChainId: _doi.l2ChainId(),
             startingAnchorRoot: _doi.startingAnchorRoot(),
             saltMixer: _doi.saltMixer(),
@@ -1027,6 +1029,30 @@ contract OPContractsManager_AddGameType_Test is Test {
                         l2SequenceNumber: 0
                     })
                 ),
+                feeVaultConfigs: abi.encode(
+                    ISystemConfig.FeeVaultConfigs({
+                        baseFeeVaultConfig: Types.FeeVaultConfig({
+                            recipient: address(0),
+                            min: 0,
+                            withdrawalNetwork: Types.WithdrawalNetwork.L1
+                        }),
+                        sequencerFeeVaultConfig: Types.FeeVaultConfig({
+                            recipient: address(0),
+                            min: 0,
+                            withdrawalNetwork: Types.WithdrawalNetwork.L1
+                        }),
+                        l1FeeVaultConfig: Types.FeeVaultConfig({
+                            recipient: address(0),
+                            min: 0,
+                            withdrawalNetwork: Types.WithdrawalNetwork.L1
+                        }),
+                        operatorFeeVaultConfig: Types.FeeVaultConfig({
+                            recipient: address(0),
+                            min: 0,
+                            withdrawalNetwork: Types.WithdrawalNetwork.L1
+                        })
+                    })
+                ),
                 l2ChainId: 100,
                 saltMixer: "hello",
                 gasLimit: 30_000_000,
@@ -1382,6 +1408,30 @@ contract OPContractsManager_UpdatePrestate_Test is Test {
                     Proposal({
                         root: Hash.wrap(0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef),
                         l2SequenceNumber: 0
+                    })
+                ),
+                feeVaultConfigs: abi.encode(
+                    ISystemConfig.FeeVaultConfigs({
+                        baseFeeVaultConfig: Types.FeeVaultConfig({
+                            recipient: address(0),
+                            min: 0,
+                            withdrawalNetwork: Types.WithdrawalNetwork.L1
+                        }),
+                        sequencerFeeVaultConfig: Types.FeeVaultConfig({
+                            recipient: address(0),
+                            min: 0,
+                            withdrawalNetwork: Types.WithdrawalNetwork.L1
+                        }),
+                        l1FeeVaultConfig: Types.FeeVaultConfig({
+                            recipient: address(0),
+                            min: 0,
+                            withdrawalNetwork: Types.WithdrawalNetwork.L1
+                        }),
+                        operatorFeeVaultConfig: Types.FeeVaultConfig({
+                            recipient: address(0),
+                            min: 0,
+                            withdrawalNetwork: Types.WithdrawalNetwork.L1
+                        })
                     })
                 ),
                 l2ChainId: 100,

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -1033,22 +1033,22 @@ contract OPContractsManager_AddGameType_Test is Test {
                     ISystemConfig.FeeVaultConfigs({
                         baseFeeVaultConfig: Types.FeeVaultConfig({
                             recipient: address(0),
-                            min: 0,
+                            minWithdrawalAmount: 0,
                             withdrawalNetwork: Types.WithdrawalNetwork.L1
                         }),
                         sequencerFeeVaultConfig: Types.FeeVaultConfig({
                             recipient: address(0),
-                            min: 0,
+                            minWithdrawalAmount: 0,
                             withdrawalNetwork: Types.WithdrawalNetwork.L1
                         }),
                         l1FeeVaultConfig: Types.FeeVaultConfig({
                             recipient: address(0),
-                            min: 0,
+                            minWithdrawalAmount: 0,
                             withdrawalNetwork: Types.WithdrawalNetwork.L1
                         }),
                         operatorFeeVaultConfig: Types.FeeVaultConfig({
                             recipient: address(0),
-                            min: 0,
+                            minWithdrawalAmount: 0,
                             withdrawalNetwork: Types.WithdrawalNetwork.L1
                         })
                     })
@@ -1414,22 +1414,22 @@ contract OPContractsManager_UpdatePrestate_Test is Test {
                     ISystemConfig.FeeVaultConfigs({
                         baseFeeVaultConfig: Types.FeeVaultConfig({
                             recipient: address(0),
-                            min: 0,
+                            minWithdrawalAmount: 0,
                             withdrawalNetwork: Types.WithdrawalNetwork.L1
                         }),
                         sequencerFeeVaultConfig: Types.FeeVaultConfig({
                             recipient: address(0),
-                            min: 0,
+                            minWithdrawalAmount: 0,
                             withdrawalNetwork: Types.WithdrawalNetwork.L1
                         }),
                         l1FeeVaultConfig: Types.FeeVaultConfig({
                             recipient: address(0),
-                            min: 0,
+                            minWithdrawalAmount: 0,
                             withdrawalNetwork: Types.WithdrawalNetwork.L1
                         }),
                         operatorFeeVaultConfig: Types.FeeVaultConfig({
                             recipient: address(0),
-                            min: 0,
+                            minWithdrawalAmount: 0,
                             withdrawalNetwork: Types.WithdrawalNetwork.L1
                         })
                     })

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -37,6 +37,9 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
 contract OptimismPortal2_Test is CommonTest {
+    // Account for the gas used by the SystemConfig.setConfig calls during initialization.
+    uint256 public constant SET_CONFIG_GAS = 1600_000;
+
     address depositor;
 
     function setUp() public virtual override {
@@ -278,7 +281,7 @@ contract OptimismPortal2_Test is CommonTest {
             bound(
                 _gasLimit,
                 optimismPortal2.minimumGasLimit(uint64(_data.length)),
-                systemConfig.resourceConfig().maxResourceLimit
+                systemConfig.resourceConfig().maxResourceLimit - SET_CONFIG_GAS
             )
         );
         if (_isCreation) _to = address(0);
@@ -336,7 +339,7 @@ contract OptimismPortal2_Test is CommonTest {
             bound(
                 _gasLimit,
                 optimismPortal2.minimumGasLimit(uint64(_data.length)),
-                systemConfig.resourceConfig().maxResourceLimit
+                systemConfig.resourceConfig().maxResourceLimit - SET_CONFIG_GAS
             )
         );
         if (_isCreation) _to = address(0);
@@ -390,7 +393,7 @@ contract OptimismPortal2_Test is CommonTest {
             bound(
                 _gasLimit,
                 optimismPortal2.minimumGasLimit(uint64(_data.length)),
-                systemConfig.resourceConfig().maxResourceLimit
+                systemConfig.resourceConfig().maxResourceLimit - SET_CONFIG_GAS
             )
         );
         if (_isCreation) _to = address(0);
@@ -2250,6 +2253,8 @@ contract OptimismPortal2_FinalizeWithdrawal_Test is CommonTest {
 }
 
 contract OptimismPortal2_Upgradeable_Test is CommonTest {
+    uint64 internal constant SYSTEM_DEPOSIT_GAS_LIMIT = 200_000;
+
     function setUp() public override {
         super.setUp();
     }
@@ -2261,7 +2266,8 @@ contract OptimismPortal2_Upgradeable_Test is CommonTest {
         IResourceMetering.ResourceConfig memory rcfg = systemConfig.resourceConfig();
 
         assertEq(prevBaseFee, rcfg.minimumBaseFee);
-        assertEq(prevBoughtGas, 0);
+        // On SystemConfig deployment, we call setConfig for each fee vault, the L1 addresses, and the remote chain id.
+        assertEq(prevBoughtGas, SYSTEM_DEPOSIT_GAS_LIMIT * 8);
         assertEq(prevBlockNum, block.number);
     }
 

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -17,6 +17,7 @@ import { Bytes } from "src/libraries/Bytes.sol";
 // Interfaces
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 
 contract SystemConfig_Init is CommonTest {
     event ConfigUpdate(uint256 indexed version, ISystemConfig.UpdateType indexed updateType, bytes data);
@@ -147,6 +148,28 @@ contract SystemConfig_Initialize_Test is SystemConfig_Init {
                 optimismPortal: address(optimismPortal2),
                 optimismMintableERC20Factory: address(0)
             }),
+            _feeVaultConfigs: ISystemConfig.FeeVaultConfigs({
+                baseFeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                }),
+                sequencerFeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                }),
+                l1FeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                }),
+                operatorFeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                })
+            }),
             _l2ChainId: 1234
         });
 
@@ -202,6 +225,28 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0)
             }),
+            _feeVaultConfigs: ISystemConfig.FeeVaultConfigs({
+                baseFeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                }),
+                sequencerFeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                }),
+                l1FeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                }),
+                operatorFeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                })
+            }),
             _l2ChainId: 1234
         });
     }
@@ -212,6 +257,13 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
         vm.store(address(systemConfig), bytes32(0), bytes32(0));
         // Set slot startBlock to zero
         vm.store(address(systemConfig), systemConfig.START_BLOCK_SLOT(), bytes32(uint256(0)));
+
+        // Mock the call to setConfig on OptimismPortal2 for each fee vault, the L1 addresses, and the remote chain id.
+        vm.mockCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes(""));
+        vm.expectCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), 8);
+
+        Types.FeeVaultConfig memory feeVaultConfig =
+            Types.FeeVaultConfig({ recipient: address(0), min: 0, withdrawalNetwork: Types.WithdrawalNetwork.L1 });
 
         // Initialize and check that StartBlock updates to current block number
         vm.prank(systemConfig.owner());
@@ -228,8 +280,14 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 l1CrossDomainMessenger: address(0),
                 l1ERC721Bridge: address(0),
                 l1StandardBridge: address(0),
-                optimismPortal: address(0),
+                optimismPortal: address(optimismPortal2),
                 optimismMintableERC20Factory: address(0)
+            }),
+            _feeVaultConfigs: ISystemConfig.FeeVaultConfigs({
+                baseFeeVaultConfig: feeVaultConfig,
+                sequencerFeeVaultConfig: feeVaultConfig,
+                l1FeeVaultConfig: feeVaultConfig,
+                operatorFeeVaultConfig: feeVaultConfig
             }),
             _l2ChainId: 1234
         });
@@ -242,6 +300,10 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
         vm.store(address(systemConfig), bytes32(0), bytes32(0));
         // Set slot startBlock to non-zero value 1
         vm.store(address(systemConfig), systemConfig.START_BLOCK_SLOT(), bytes32(uint256(1)));
+
+        // Mock the call to setConfig on OptimismPortal2 for each fee vault, the L1 addresses, and the remote chain id.
+        vm.mockCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes(""));
+        vm.expectCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), 8);
 
         // Initialize and check that StartBlock doesn't update
         vm.prank(systemConfig.owner());
@@ -258,8 +320,30 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 l1CrossDomainMessenger: address(0),
                 l1ERC721Bridge: address(0),
                 l1StandardBridge: address(0),
-                optimismPortal: address(0),
+                optimismPortal: address(optimismPortal2),
                 optimismMintableERC20Factory: address(0)
+            }),
+            _feeVaultConfigs: ISystemConfig.FeeVaultConfigs({
+                baseFeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                }),
+                sequencerFeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                }),
+                l1FeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                }),
+                operatorFeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                })
             }),
             _l2ChainId: 1234
         });
@@ -286,7 +370,7 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
             minimumBaseFee: 2 gwei,
             maximumBaseFee: 1 gwei
         });
-        _initializeWithResourceConfig(config, "SystemConfig: min base fee must be less than max base");
+        _initializeWithResourceConfig(config, 0, "SystemConfig: min base fee must be less than max base");
     }
 
     /// @dev Tests that `setResourceConfig` reverts if the baseFeeMaxChangeDenominator
@@ -300,7 +384,7 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
             minimumBaseFee: 1 gwei,
             maximumBaseFee: 2 gwei
         });
-        _initializeWithResourceConfig(config, "SystemConfig: denominator must be larger than 1");
+        _initializeWithResourceConfig(config, 0, "SystemConfig: denominator must be larger than 1");
     }
 
     /// @dev Tests that `setResourceConfig` reverts if the gas limit is too low.
@@ -315,7 +399,7 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
             minimumBaseFee: 1 gwei,
             maximumBaseFee: 2 gwei
         });
-        _initializeWithResourceConfig(config, "SystemConfig: gas limit too low");
+        _initializeWithResourceConfig(config, 0, "SystemConfig: gas limit too low");
     }
 
     /// @dev Tests that `setResourceConfig` reverts if the gas limit is too low.
@@ -328,7 +412,7 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
             minimumBaseFee: 1 gwei,
             maximumBaseFee: 2 gwei
         });
-        _initializeWithResourceConfig(config, "SystemConfig: elasticity multiplier cannot be 0");
+        _initializeWithResourceConfig(config, 0, "SystemConfig: elasticity multiplier cannot be 0");
     }
 
     /// @dev Tests that `setResourceConfig` reverts if the elasticity multiplier
@@ -342,13 +426,14 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
             minimumBaseFee: 1 gwei,
             maximumBaseFee: 2 gwei
         });
-        _initializeWithResourceConfig(config, "SystemConfig: precision loss with target resource limit");
+        _initializeWithResourceConfig(config, 0, "SystemConfig: precision loss with target resource limit");
     }
 
-    /// @dev Helper to initialize the system config with a resource config and default values, and expect a revert
-    ///      with the given message.
+    /// @dev Helper to initialize the system config with a resource config, expected number of calls to OptimismPortal2,
+    ///      and default values, and expect a revert with the given message.
     function _initializeWithResourceConfig(
         IResourceMetering.ResourceConfig memory config,
+        uint64 _expectedCallsToOptimismPortal2,
         string memory revertMessage
     )
         internal
@@ -357,6 +442,14 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
         vm.store(address(systemConfig), bytes32(0), bytes32(0));
         // Fetch the current gas limit
         uint64 gasLimit = systemConfig.gasLimit();
+
+        // Mock the call to setConfig on OptimismPortal2 for each fee vault, the L1 addresses, and the remote chain id.
+        vm.mockCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes(""));
+        vm.expectCall(
+            address(optimismPortal2),
+            abi.encodeWithSelector(IOptimismPortal2.setConfig.selector),
+            _expectedCallsToOptimismPortal2
+        );
 
         vm.expectRevert(bytes(revertMessage));
         systemConfig.initialize({
@@ -375,8 +468,41 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0)
             }),
+            _feeVaultConfigs: ISystemConfig.FeeVaultConfigs({
+                baseFeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                }),
+                sequencerFeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                }),
+                l1FeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                }),
+                operatorFeeVaultConfig: Types.FeeVaultConfig({
+                    recipient: address(0),
+                    min: 0,
+                    withdrawalNetwork: Types.WithdrawalNetwork.L1
+                })
+            }),
             _l2ChainId: 1234
         });
+    }
+
+    /// @dev Helper to initialize the system config with a resource config and default values, and expect a revert
+    ///      with the given message.
+    function _initializeWithResourceConfig(
+        IResourceMetering.ResourceConfig memory config,
+        string memory revertMessage
+    )
+        internal
+    {
+        _initializeWithResourceConfig(config, 8, revertMessage);
     }
 }
 
@@ -488,7 +614,8 @@ contract SystemConfig_Setters_TestFail is SystemConfig_Init {
         vm.expectRevert("SystemConfig: caller is not the fee admin");
         vm.prank(_caller);
         systemConfig.setFeeVaultConfig(
-            Types.ConfigType.BASE_FEE_VAULT_CONFIG, address(0x20), 0, Types.WithdrawalNetwork.L1
+            Types.ConfigType.BASE_FEE_VAULT_CONFIG,
+            Types.FeeVaultConfig({ recipient: address(0x20), min: 0, withdrawalNetwork: Types.WithdrawalNetwork.L1 })
         );
     }
 }
@@ -601,7 +728,9 @@ contract SystemConfig_Setters_Test is SystemConfig_Init {
         vm.mockCall(address(optimismPortal2), data, abi.encode(true));
 
         vm.prank(systemConfig.feeVaultAdmin());
-        systemConfig.setFeeVaultConfig(configType, _recipient, _min, network);
+        systemConfig.setFeeVaultConfig(
+            configType, Types.FeeVaultConfig({ recipient: _recipient, min: _min, withdrawalNetwork: network })
+        );
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -151,22 +151,22 @@ contract SystemConfig_Initialize_Test is SystemConfig_Init {
             _feeVaultConfigs: ISystemConfig.FeeVaultConfigs({
                 baseFeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 }),
                 sequencerFeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 }),
                 l1FeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 }),
                 operatorFeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 })
             }),
@@ -228,22 +228,22 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
             _feeVaultConfigs: ISystemConfig.FeeVaultConfigs({
                 baseFeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 }),
                 sequencerFeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 }),
                 l1FeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 }),
                 operatorFeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 })
             }),
@@ -262,8 +262,11 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
         vm.mockCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes(""));
         vm.expectCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), 8);
 
-        Types.FeeVaultConfig memory feeVaultConfig =
-            Types.FeeVaultConfig({ recipient: address(0), min: 0, withdrawalNetwork: Types.WithdrawalNetwork.L1 });
+        Types.FeeVaultConfig memory feeVaultConfig = Types.FeeVaultConfig({
+            recipient: address(0),
+            minWithdrawalAmount: 0,
+            withdrawalNetwork: Types.WithdrawalNetwork.L1
+        });
 
         // Initialize and check that StartBlock updates to current block number
         vm.prank(systemConfig.owner());
@@ -326,22 +329,22 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
             _feeVaultConfigs: ISystemConfig.FeeVaultConfigs({
                 baseFeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 }),
                 sequencerFeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 }),
                 l1FeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 }),
                 operatorFeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 })
             }),
@@ -471,22 +474,22 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
             _feeVaultConfigs: ISystemConfig.FeeVaultConfigs({
                 baseFeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 }),
                 sequencerFeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 }),
                 l1FeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 }),
                 operatorFeeVaultConfig: Types.FeeVaultConfig({
                     recipient: address(0),
-                    min: 0,
+                    minWithdrawalAmount: 0,
                     withdrawalNetwork: Types.WithdrawalNetwork.L1
                 })
             }),
@@ -615,7 +618,11 @@ contract SystemConfig_Setters_TestFail is SystemConfig_Init {
         vm.prank(_caller);
         systemConfig.setFeeVaultConfig(
             Types.ConfigType.BASE_FEE_VAULT_CONFIG,
-            Types.FeeVaultConfig({ recipient: address(0x20), min: 0, withdrawalNetwork: Types.WithdrawalNetwork.L1 })
+            Types.FeeVaultConfig({
+                recipient: address(0x20),
+                minWithdrawalAmount: 0,
+                withdrawalNetwork: Types.WithdrawalNetwork.L1
+            })
         );
     }
 }
@@ -729,7 +736,8 @@ contract SystemConfig_Setters_Test is SystemConfig_Init {
 
         vm.prank(systemConfig.feeVaultAdmin());
         systemConfig.setFeeVaultConfig(
-            configType, Types.FeeVaultConfig({ recipient: _recipient, min: _min, withdrawalNetwork: network })
+            configType,
+            Types.FeeVaultConfig({ recipient: _recipient, minWithdrawalAmount: _min, withdrawalNetwork: network })
         );
     }
 }

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -259,8 +259,10 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
         vm.store(address(systemConfig), systemConfig.START_BLOCK_SLOT(), bytes32(uint256(0)));
 
         // Mock the call to setConfig on OptimismPortal2 for each fee vault, the L1 addresses, and the remote chain id.
-        vm.mockCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes(""));
-        vm.expectCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), 8);
+        vm.mockCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes("")); // nosemgrep:
+            // sol-style-use-abi-encodecall
+        vm.expectCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), 8); // nosemgrep:
+            // sol-style-use-abi-encodecall
 
         Types.FeeVaultConfig memory feeVaultConfig = Types.FeeVaultConfig({
             recipient: address(0),
@@ -305,8 +307,8 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
         vm.store(address(systemConfig), systemConfig.START_BLOCK_SLOT(), bytes32(uint256(1)));
 
         // Mock the call to setConfig on OptimismPortal2 for each fee vault, the L1 addresses, and the remote chain id.
-        vm.mockCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes(""));
-        vm.expectCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), 8);
+        vm.mockCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes("")); // nosemgrep: sol-style-use-abi-encodecall
+        vm.expectCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), 8); // nosemgrep: sol-style-use-abi-encodecall
 
         // Initialize and check that StartBlock doesn't update
         vm.prank(systemConfig.owner());
@@ -447,12 +449,8 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
         uint64 gasLimit = systemConfig.gasLimit();
 
         // Mock the call to setConfig on OptimismPortal2 for each fee vault, the L1 addresses, and the remote chain id.
-        vm.mockCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes(""));
-        vm.expectCall(
-            address(optimismPortal2),
-            abi.encodeWithSelector(IOptimismPortal2.setConfig.selector),
-            _expectedCallsToOptimismPortal2
-        );
+        vm.mockCall(address(optimismPortal2), abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes("")); // nosemgrep: sol-style-use-abi-encodecall
+        vm.expectCall(address(optimismPortal2),abi.encodeWithSelector(IOptimismPortal2.setConfig.selector),_expectedCallsToOptimismPortal2); // nosemgrep: sol-style-use-abi-encodecall
 
         vm.expectRevert(bytes(revertMessage));
         systemConfig.initialize({

--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -198,7 +198,6 @@ contract L1BlockEcotone_Test is L1BlockTest {
     }
 }
 
-/// TODO: FIX THIS AFTER SYNC
 contract L1BlockSetConfig_Test is L1BlockTest {
     /// @dev Tests that `setConfig` reverts if sender address is not the depositor account.
     function test_setConfig_isDepositor_reverts(

--- a/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -56,22 +56,22 @@ contract SystemConfig_GasLimitBoundaries_Invariant is Test {
                     ISystemConfig.FeeVaultConfigs({
                         baseFeeVaultConfig: Types.FeeVaultConfig({
                             recipient: address(0),
-                            min: 0,
+                            minWithdrawalAmount: 0,
                             withdrawalNetwork: Types.WithdrawalNetwork.L1
                         }),
                         sequencerFeeVaultConfig: Types.FeeVaultConfig({
                             recipient: address(0),
-                            min: 0,
+                            minWithdrawalAmount: 0,
                             withdrawalNetwork: Types.WithdrawalNetwork.L1
                         }),
                         l1FeeVaultConfig: Types.FeeVaultConfig({
                             recipient: address(0),
-                            min: 0,
+                            minWithdrawalAmount: 0,
                             withdrawalNetwork: Types.WithdrawalNetwork.L1
                         }),
                         operatorFeeVaultConfig: Types.FeeVaultConfig({
                             recipient: address(0),
-                            min: 0,
+                            minWithdrawalAmount: 0,
                             withdrawalNetwork: Types.WithdrawalNetwork.L1
                         })
                     }),

--- a/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -29,8 +29,10 @@ contract SystemConfig_GasLimitBoundaries_Invariant is Test {
 
         // Mock the call to setConfig on OptimismPortal2 for each fee vault, the L1 addresses, and the remote chain id.
         vm.etch(optimismPortal2, bytes("123"));
-        vm.mockCall(optimismPortal2, abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes(""));
-        vm.expectCall(optimismPortal2, abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), 8);
+        vm.mockCall(optimismPortal2, abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes("")); // nosemgrep:
+            // sol-style-use-abi-encodecall
+        vm.expectCall(optimismPortal2, abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), 8); // nosemgrep:
+            // sol-style-use-abi-encodecall
 
         vm.prank(msg.sender);
         proxy.upgradeToAndCall(

--- a/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -6,9 +6,12 @@ import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Types } from "src/libraries/Types.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 
 contract SystemConfig_GasLimitBoundaries_Invariant is Test {
     ISystemConfig public config;
+    address public optimismPortal2 = makeAddr("OptimismPortal2");
 
     function setUp() external {
         IProxy proxy = IProxy(
@@ -23,6 +26,11 @@ contract SystemConfig_GasLimitBoundaries_Invariant is Test {
                 _args: DeployUtils.encodeConstructor(abi.encodeCall(ISystemConfig.__constructor__, ()))
             })
         );
+
+        // Mock the call to setConfig on OptimismPortal2 for each fee vault, the L1 addresses, and the remote chain id.
+        vm.etch(optimismPortal2, bytes("123"));
+        vm.mockCall(optimismPortal2, abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), bytes(""));
+        vm.expectCall(optimismPortal2, abi.encodeWithSelector(IOptimismPortal2.setConfig.selector), 8);
 
         vm.prank(msg.sender);
         proxy.upgradeToAndCall(
@@ -42,8 +50,30 @@ contract SystemConfig_GasLimitBoundaries_Invariant is Test {
                         l1CrossDomainMessenger: address(0),
                         l1ERC721Bridge: address(0),
                         l1StandardBridge: address(0),
-                        optimismPortal: address(0),
+                        optimismPortal: optimismPortal2,
                         optimismMintableERC20Factory: address(0)
+                    }),
+                    ISystemConfig.FeeVaultConfigs({
+                        baseFeeVaultConfig: Types.FeeVaultConfig({
+                            recipient: address(0),
+                            min: 0,
+                            withdrawalNetwork: Types.WithdrawalNetwork.L1
+                        }),
+                        sequencerFeeVaultConfig: Types.FeeVaultConfig({
+                            recipient: address(0),
+                            min: 0,
+                            withdrawalNetwork: Types.WithdrawalNetwork.L1
+                        }),
+                        l1FeeVaultConfig: Types.FeeVaultConfig({
+                            recipient: address(0),
+                            min: 0,
+                            withdrawalNetwork: Types.WithdrawalNetwork.L1
+                        }),
+                        operatorFeeVaultConfig: Types.FeeVaultConfig({
+                            recipient: address(0),
+                            min: 0,
+                            withdrawalNetwork: Types.WithdrawalNetwork.L1
+                        })
                     }),
                     1234 // _l2ChainId
                 )

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -50,22 +50,22 @@ contract DeployOPChainInput_Test is Test {
         ISystemConfig.FeeVaultConfigs({
             baseFeeVaultConfig: Types.FeeVaultConfig({
                 recipient: address(0),
-                min: 0,
+                minWithdrawalAmount: 0,
                 withdrawalNetwork: Types.WithdrawalNetwork.L1
             }),
             sequencerFeeVaultConfig: Types.FeeVaultConfig({
                 recipient: address(0),
-                min: 0,
+                minWithdrawalAmount: 0,
                 withdrawalNetwork: Types.WithdrawalNetwork.L1
             }),
             l1FeeVaultConfig: Types.FeeVaultConfig({
                 recipient: address(0),
-                min: 0,
+                minWithdrawalAmount: 0,
                 withdrawalNetwork: Types.WithdrawalNetwork.L1
             }),
             operatorFeeVaultConfig: Types.FeeVaultConfig({
                 recipient: address(0),
-                min: 0,
+                minWithdrawalAmount: 0,
                 withdrawalNetwork: Types.WithdrawalNetwork.L1
             })
         })
@@ -373,22 +373,22 @@ contract DeployOPChain_TestBase is Test {
         ISystemConfig.FeeVaultConfigs({
             baseFeeVaultConfig: Types.FeeVaultConfig({
                 recipient: address(0),
-                min: 0,
+                minWithdrawalAmount: 0,
                 withdrawalNetwork: Types.WithdrawalNetwork.L1
             }),
             sequencerFeeVaultConfig: Types.FeeVaultConfig({
                 recipient: address(0),
-                min: 0,
+                minWithdrawalAmount: 0,
                 withdrawalNetwork: Types.WithdrawalNetwork.L1
             }),
             l1FeeVaultConfig: Types.FeeVaultConfig({
                 recipient: address(0),
-                min: 0,
+                minWithdrawalAmount: 0,
                 withdrawalNetwork: Types.WithdrawalNetwork.L1
             }),
             operatorFeeVaultConfig: Types.FeeVaultConfig({
                 recipient: address(0),
-                min: 0,
+                minWithdrawalAmount: 0,
                 withdrawalNetwork: Types.WithdrawalNetwork.L1
             })
         })

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -25,6 +25,8 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions, ProtocolVersion } from "interfaces/L1/IProtocolVersions.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { Types } from "src/libraries/Types.sol";
 
 import { Claim, Duration, GameType, GameTypes, Hash, Proposal } from "src/dispute/lib/Types.sol";
 
@@ -44,6 +46,30 @@ contract DeployOPChainInput_Test is Test {
     uint32 blobBaseFeeScalar = 200;
     uint256 l2ChainId = 300;
     string saltMixer = "saltMixer";
+    bytes feeVaultConfigs = abi.encode(
+        ISystemConfig.FeeVaultConfigs({
+            baseFeeVaultConfig: Types.FeeVaultConfig({
+                recipient: address(0),
+                min: 0,
+                withdrawalNetwork: Types.WithdrawalNetwork.L1
+            }),
+            sequencerFeeVaultConfig: Types.FeeVaultConfig({
+                recipient: address(0),
+                min: 0,
+                withdrawalNetwork: Types.WithdrawalNetwork.L1
+            }),
+            l1FeeVaultConfig: Types.FeeVaultConfig({
+                recipient: address(0),
+                min: 0,
+                withdrawalNetwork: Types.WithdrawalNetwork.L1
+            }),
+            operatorFeeVaultConfig: Types.FeeVaultConfig({
+                recipient: address(0),
+                min: 0,
+                withdrawalNetwork: Types.WithdrawalNetwork.L1
+            })
+        })
+    );
 
     function setUp() public {
         doi = new DeployOPChainInput();
@@ -59,6 +85,7 @@ contract DeployOPChainInput_Test is Test {
         doi.set(doi.challenger.selector, challenger);
         doi.set(doi.basefeeScalar.selector, basefeeScalar);
         doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
+        doi.set(doi.feeVaultConfigs.selector, feeVaultConfigs);
         doi.set(doi.l2ChainId.selector, l2ChainId);
         doi.set(doi.allowCustomDisputeParameters.selector, true);
         doi.set(doi.opcm.selector, opcm);
@@ -342,6 +369,30 @@ contract DeployOPChain_TestBase is Test {
     uint256 disputeSplitDepth = 30;
     uint64 disputeClockExtension = Duration.unwrap(Duration.wrap(3 hours));
     uint64 disputeMaxClockDuration = Duration.unwrap(Duration.wrap(3.5 days));
+    bytes feeVaultConfigs = abi.encode(
+        ISystemConfig.FeeVaultConfigs({
+            baseFeeVaultConfig: Types.FeeVaultConfig({
+                recipient: address(0),
+                min: 0,
+                withdrawalNetwork: Types.WithdrawalNetwork.L1
+            }),
+            sequencerFeeVaultConfig: Types.FeeVaultConfig({
+                recipient: address(0),
+                min: 0,
+                withdrawalNetwork: Types.WithdrawalNetwork.L1
+            }),
+            l1FeeVaultConfig: Types.FeeVaultConfig({
+                recipient: address(0),
+                min: 0,
+                withdrawalNetwork: Types.WithdrawalNetwork.L1
+            }),
+            operatorFeeVaultConfig: Types.FeeVaultConfig({
+                recipient: address(0),
+                min: 0,
+                withdrawalNetwork: Types.WithdrawalNetwork.L1
+            })
+        })
+    );
 
     function setUp() public virtual {
         // Configure and deploy Superchain contracts
@@ -422,6 +473,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         doi.set(doi.challenger.selector, challenger);
         doi.set(doi.basefeeScalar.selector, basefeeScalar);
         doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
+        doi.set(doi.feeVaultConfigs.selector, feeVaultConfigs);
         doi.set(doi.l2ChainId.selector, l2ChainId);
         doi.set(doi.opcm.selector, address(opcm));
         doi.set(doi.saltMixer.selector, saltMixer);
@@ -517,6 +569,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         doi.set(doi.challenger.selector, challenger);
         doi.set(doi.basefeeScalar.selector, basefeeScalar);
         doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
+        doi.set(doi.feeVaultConfigs.selector, feeVaultConfigs);
         doi.set(doi.l2ChainId.selector, l2ChainId);
         doi.set(doi.opcm.selector, address(opcm));
         doi.set(doi.saltMixer.selector, saltMixer);

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -9,6 +9,7 @@ import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
 import { Process } from "scripts/libraries/Process.sol";
 
 // Libraries
+import { Types } from "src/libraries/Types.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 import { GameType, Hash, Proposal } from "src/dispute/lib/Types.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
@@ -169,6 +170,28 @@ contract Initializer_Test is CommonTest {
                             optimismPortal: address(0),
                             optimismMintableERC20Factory: address(0)
                         }),
+                        ISystemConfig.FeeVaultConfigs({
+                            baseFeeVaultConfig: Types.FeeVaultConfig({
+                                recipient: address(0),
+                                min: 0,
+                                withdrawalNetwork: Types.WithdrawalNetwork.L1
+                            }),
+                            sequencerFeeVaultConfig: Types.FeeVaultConfig({
+                                recipient: address(0),
+                                min: 0,
+                                withdrawalNetwork: Types.WithdrawalNetwork.L1
+                            }),
+                            l1FeeVaultConfig: Types.FeeVaultConfig({
+                                recipient: address(0),
+                                min: 0,
+                                withdrawalNetwork: Types.WithdrawalNetwork.L1
+                            }),
+                            operatorFeeVaultConfig: Types.FeeVaultConfig({
+                                recipient: address(0),
+                                min: 0,
+                                withdrawalNetwork: Types.WithdrawalNetwork.L1
+                            })
+                        }),
                         0
                     )
                 )
@@ -203,6 +226,28 @@ contract Initializer_Test is CommonTest {
                             l1StandardBridge: address(0),
                             optimismPortal: address(0),
                             optimismMintableERC20Factory: address(0)
+                        }),
+                        ISystemConfig.FeeVaultConfigs({
+                            baseFeeVaultConfig: Types.FeeVaultConfig({
+                                recipient: address(0),
+                                min: 0,
+                                withdrawalNetwork: Types.WithdrawalNetwork.L1
+                            }),
+                            sequencerFeeVaultConfig: Types.FeeVaultConfig({
+                                recipient: address(0),
+                                min: 0,
+                                withdrawalNetwork: Types.WithdrawalNetwork.L1
+                            }),
+                            l1FeeVaultConfig: Types.FeeVaultConfig({
+                                recipient: address(0),
+                                min: 0,
+                                withdrawalNetwork: Types.WithdrawalNetwork.L1
+                            }),
+                            operatorFeeVaultConfig: Types.FeeVaultConfig({
+                                recipient: address(0),
+                                min: 0,
+                                withdrawalNetwork: Types.WithdrawalNetwork.L1
+                            })
                         }),
                         0
                     )

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -173,22 +173,22 @@ contract Initializer_Test is CommonTest {
                         ISystemConfig.FeeVaultConfigs({
                             baseFeeVaultConfig: Types.FeeVaultConfig({
                                 recipient: address(0),
-                                min: 0,
+                                minWithdrawalAmount: 0,
                                 withdrawalNetwork: Types.WithdrawalNetwork.L1
                             }),
                             sequencerFeeVaultConfig: Types.FeeVaultConfig({
                                 recipient: address(0),
-                                min: 0,
+                                minWithdrawalAmount: 0,
                                 withdrawalNetwork: Types.WithdrawalNetwork.L1
                             }),
                             l1FeeVaultConfig: Types.FeeVaultConfig({
                                 recipient: address(0),
-                                min: 0,
+                                minWithdrawalAmount: 0,
                                 withdrawalNetwork: Types.WithdrawalNetwork.L1
                             }),
                             operatorFeeVaultConfig: Types.FeeVaultConfig({
                                 recipient: address(0),
-                                min: 0,
+                                minWithdrawalAmount: 0,
                                 withdrawalNetwork: Types.WithdrawalNetwork.L1
                             })
                         }),
@@ -230,22 +230,22 @@ contract Initializer_Test is CommonTest {
                         ISystemConfig.FeeVaultConfigs({
                             baseFeeVaultConfig: Types.FeeVaultConfig({
                                 recipient: address(0),
-                                min: 0,
+                                minWithdrawalAmount: 0,
                                 withdrawalNetwork: Types.WithdrawalNetwork.L1
                             }),
                             sequencerFeeVaultConfig: Types.FeeVaultConfig({
                                 recipient: address(0),
-                                min: 0,
+                                minWithdrawalAmount: 0,
                                 withdrawalNetwork: Types.WithdrawalNetwork.L1
                             }),
                             l1FeeVaultConfig: Types.FeeVaultConfig({
                                 recipient: address(0),
-                                min: 0,
+                                minWithdrawalAmount: 0,
                                 withdrawalNetwork: Types.WithdrawalNetwork.L1
                             }),
                             operatorFeeVaultConfig: Types.FeeVaultConfig({
                                 recipient: address(0),
-                                min: 0,
+                                minWithdrawalAmount: 0,
                                 withdrawalNetwork: Types.WithdrawalNetwork.L1
                             })
                         }),


### PR DESCRIPTION
Updates SystemConfig to properly call OptimismPortal.setConfig for fee vault configuration, remote chain id and L1 addresses, updates related test assertions.