### PR TITLE
refactor: update relay cost calculation

### DIFF
--- a/packages/contracts-bedrock/src/L2/GasTank.sol
+++ b/packages/contracts-bedrock/src/L2/GasTank.sol
@@ -197,8 +197,38 @@ contract GasTank is IGasTank {
     /// @param _numHashes The number of destination hashes relayed
     /// @return overhead_ The gas cost to emit the event in wei
     function _relayOverhead(uint256 _numHashes) internal view returns (uint256 overhead_) {
-        uint256 memoryExpansionGas = (418 * _numHashes) + ((_numHashes * _numHashes) >> 9);
-        overhead_ = _cost(34_245 + memoryExpansionGas, block.basefee);
+        // Hex
+        // uint256 memoryExpansionGas = (420 * _numHashes) + (_numHashes * _numHashes) / 512;
+        // overhead_ = _cost(35_000 + memoryExpansionGas);
+        // overhead_ = _cost(
+        //     35_000 // base + calldata + base log + buffer
+        //         + (420 * _numHashes) // log data w adj
+        //         + (_numHashes * _numHashes) / 512 // memory expansion
+        // );
+
+        // Hex Adjusted
+        // overhead_ = _cost(
+        //     35_000 // base + calldata + base log + buffer
+        //         + (400 * _numHashes) // log data w adj
+        //         + (_numHashes * _numHashes) / 512 // memory expansion
+        // );
+
+        // Hex 2
+        uint256 memoryExpansionGas = ((_numHashes * _numHashes) >> 9);
+        overhead_ = _cost(
+            34_245 // base + calldata + base log + buffer
+                + (418 * _numHashes) // log data w adj
+                + memoryExpansionGas // memory expansion
+        );
+
+        // Baseline
+        // uint256 extraWords = (_numHashes * 32 + 31) / 32;
+        // overhead_ = _cost(
+        //     28_744 // base + calldata + base log
+        //         // + initialGas - gasleft() // execution
+        //         + 256 * _numHashes // log data
+        //         + 3 * extraWords + (extraWords ** 2) / 512
+        // ); // memory expansion
     }
 
     /// @notice Calculates the cost of gas used in wei

--- a/packages/contracts-bedrock/src/L2/GasTank.sol
+++ b/packages/contracts-bedrock/src/L2/GasTank.sol
@@ -229,6 +229,27 @@ contract GasTank is IGasTank {
         //         + 256 * _numHashes // log data
         //         + 3 * extraWords + (extraWords ** 2) / 512
         // ); // memory expansion
+
+        // // With memory expansion term
+        // uint256 dataBytes = 96 + 32 * _numHashes;
+        // uint256 prevBytes;
+        // assembly {
+        //     prevBytes := mload(0x40)
+        // }
+        // uint256 prevWords = prevBytes >> 5; // /32
+        // uint256 newWords = (prevBytes + dataBytes + 31) >> 5; // ceil((prev+data)/32)
+        // uint256 gMem = 3 * (newWords - prevWords) // linear component
+        //     + ((newWords * newWords) - (prevWords * prevWords)) >> 9; // quadratic (/512)
+
+        // uint256 gLog = 1500 // 1500 = 375 + 3*375 (LOG3)
+        //     + 13 * dataBytes // 8 (per-byte cost for the data payload)
+        //     + gMem; // memory expansion
+
+        // overhead_ = _cost(
+        //     182_200 // base tx + buffer (35k, 50k, 150k, 350k, 200k, 190k, 180k, 185k, 183k, )
+        //         + gLog,
+        //     block.basefee
+        // );
     }
 
     /// @notice Calculates the cost of gas used in wei


### PR DESCRIPTION
Closes OPT-878

Calculating the proper formula onchain to predict the total cost of the relay function is essential for relayers to be properly compensated for their service. This cost must be emitted before execution ends which means calculating it before the event is logged. 

The exact formula the EVM uses to calculate gas usage for the `relayMessage` function is not clear so we are implementing an approximate solution instead. However, poor estimations risks either the relay losing money (resulting in messages not being relayed) or the user overpaying. Additionally the gas usage depends on the number of nested messages that are relayed which isn't known until after execution.

The ideal formula would give a slight profit to relayers but current formulas yield variable over/underpayment depending on how many nested messages are emitted. There are also differences between gas usage using Foundry unit tests and using Supersim to simulate crosschain interactions. Here are some formulas and their predicted costs vs actual costs using Hex's [Supersim script](https://github.com/defi-wonderland/optimism/pull/424#issue-3160691087).