### PR TITLE
feat: move to vote

### DIFF
--- a/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
+++ b/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
@@ -29,6 +29,7 @@ interface IProposalValidator is ISemver {
     error ProposalValidator_InvalidUpgradeProposalType();
     error ProposalValidator_InvalidVotingCycle();
     error ProposalValidator_ProposalIdMismatch();
+    error ProposalValidator_InvalidProposer();
 
     event ProposalSubmitted(
         bytes32 indexed proposalHash,

--- a/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
+++ b/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
@@ -182,8 +182,6 @@ interface IProposalValidator is ISemver {
 
     function distributionThreshold() external view returns (uint256);
 
-    function OPTIMISTIC_MODULE_PERCENT_DIVISOR() external view returns (uint256);
-
     function VOTING_TOKEN() external view returns (IGovernanceToken);
 
     function GOVERNOR() external view returns (IOptimismGovernor);

--- a/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
+++ b/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
@@ -74,7 +74,7 @@ interface IProposalValidator is ISemver {
     struct ProposalData {
         address proposer;
         ProposalType proposalType;
-        bool inVoting;
+        bool movedToVote;
         mapping(address => bool) delegateApprovals;
         uint256 approvalCount;
         uint256 votingCycle;

--- a/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
+++ b/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
@@ -13,6 +13,7 @@ interface IProposalValidator is ISemver {
     error ProposalValidator_InsufficientApprovals();
     error ProposalValidator_ProposalAlreadyApproved();
     error ProposalValidator_ProposalAlreadySubmitted();
+    error ProposalValidator_ProposalAlreadyMovedToVote();
     error ProposalValidator_InvalidAttestation();
     error ProposalValidator_VotingCycleAlreadySet();
     error ProposalValidator_ProposalDoesNotExist();
@@ -24,8 +25,10 @@ interface IProposalValidator is ISemver {
     error ProposalValidator_AttestationRevoked();
     error ProposalValidator_InvalidAttestationSchema();
     error ProposalValidator_InvalidCriteriaValue();
-    error ProposalValidator_InvalidUpgradeProposalType();
     error ProposalValidator_InvalidAgainstThreshold();
+    error ProposalValidator_InvalidUpgradeProposalType();
+    error ProposalValidator_InvalidVotingCycle();
+    error ProposalValidator_ProposalIdMismatch();
 
     struct ProposalData {
         address proposer;
@@ -33,11 +36,19 @@ interface IProposalValidator is ISemver {
         bool inVoting;
         mapping(address => bool) delegateApprovals;
         uint256 approvalCount;
+        uint256 votingCycle;
     }
 
     struct ProposalTypeData {
         uint256 requiredApprovals;
         uint8 proposalVotingModule;
+    }
+
+    struct VotingCycleData {
+        uint256 startingBlock;
+        uint256 duration;
+        uint256 votingCycleDistributionLimit;
+        uint256 movedToVoteTokenCount;
     }
 
     enum ProposalType {
@@ -91,13 +102,6 @@ interface IProposalValidator is ISemver {
 
     function approveProposal(bytes32 _proposalHash, bytes32 _attestationUid) external;
 
-    function moveToVote(
-        address[] memory _targets,
-        uint256[] memory _values,
-        bytes[] memory _calldatas,
-        string memory _description
-    ) external returns (uint256 governorProposalId_);
-
     function setDistributionThreshold(uint256 _distributionThreshold) external;
 
     function setProposalTypeData(
@@ -116,7 +120,8 @@ interface IProposalValidator is ISemver {
         uint128 _criteriaValue,
         string[] memory _optionDescriptions,
         string memory _proposalDescription,
-        bytes32 _attestationUid
+        bytes32 _attestationUid,
+        uint256 _votingCycle
     ) external returns (bytes32 proposalHash_);
 
     function submitFundingProposal(
@@ -125,13 +130,35 @@ interface IProposalValidator is ISemver {
         address[] memory _optionsRecipients,
         uint256[] memory _optionsAmounts,
         string memory _description,
-        ProposalType _proposalType
+        ProposalType _proposalType,
+        uint256 _votingCycle
     ) external returns (bytes32 proposalHash_);
 
     function submitUpgradeProposal(
         uint248 _againstThreshold,
         string memory _proposalDescription,
         bytes32 _attestationUid,
+        ProposalType _proposalType,
+        uint256 _votingCycle
+    ) external returns (bytes32 proposalHash_);
+
+    function moveToVoteProtocolOrGovernorUpgradeProposal(
+        uint248 _againstThreshold,
+        string memory _proposalDescription
+    ) external returns (bytes32 proposalHash_);
+
+    function moveToVoteCouncilMemberElectionsProposal(
+        uint128 _criteriaValue,
+        string[] memory _optionsDescriptions,
+        string memory _proposalDescription
+    ) external returns (bytes32 proposalHash_);
+
+    function moveToVoteFundingProposal(
+        uint128 _criteriaValue,
+        string[] memory _optionsDescriptions,
+        address[] memory _optionsRecipients,
+        uint256[] memory _optionsAmounts,
+        string memory _description,
         ProposalType _proposalType
     ) external returns (bytes32 proposalHash_);
 
@@ -174,7 +201,8 @@ interface IProposalValidator is ISemver {
     function votingCycles(uint256) external view returns (
         uint256 startingBlock,
         uint256 duration,
-        uint256 votingCycleDistributionLimit
+        uint256 votingCycleDistributionLimit,
+        uint256 movedToVoteTokenCount
     );
 
     function __constructor__(

--- a/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
+++ b/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
@@ -10,6 +10,7 @@ import { IProposalTypesConfigurator } from './IProposalTypesConfigurator.sol';
 /// @title IProposalValidator
 /// @notice Interface for the ProposalValidator contract.
 interface IProposalValidator is ISemver {
+    error ReinitializableBase_ZeroInitVersion();
     error ProposalValidator_InsufficientApprovals();
     error ProposalValidator_ProposalAlreadyApproved();
     error ProposalValidator_ProposalAlreadySubmitted();
@@ -18,7 +19,6 @@ interface IProposalValidator is ISemver {
     error ProposalValidator_VotingCycleAlreadySet();
     error ProposalValidator_ProposalDoesNotExist();
     error ProposalValidator_ProposalTypesDataLengthMismatch();
-    error ReinitializableBase_ZeroInitVersion();
     error ProposalValidator_InvalidFundingProposalType();
     error ProposalValidator_ExceedsDistributionThreshold();
     error ProposalValidator_InvalidOptionsLength();
@@ -29,35 +29,6 @@ interface IProposalValidator is ISemver {
     error ProposalValidator_InvalidUpgradeProposalType();
     error ProposalValidator_InvalidVotingCycle();
     error ProposalValidator_ProposalIdMismatch();
-
-    struct ProposalData {
-        address proposer;
-        ProposalType proposalType;
-        bool inVoting;
-        mapping(address => bool) delegateApprovals;
-        uint256 approvalCount;
-        uint256 votingCycle;
-    }
-
-    struct ProposalTypeData {
-        uint256 requiredApprovals;
-        uint8 proposalVotingModule;
-    }
-
-    struct VotingCycleData {
-        uint256 startingBlock;
-        uint256 duration;
-        uint256 votingCycleDistributionLimit;
-        uint256 movedToVoteTokenCount;
-    }
-
-    enum ProposalType {
-        ProtocolOrGovernorUpgrade,
-        MaintenanceUpgrade,
-        CouncilMemberElections,
-        GovernanceFund,
-        CouncilBudget
-    }
 
     event ProposalSubmitted(
         bytes32 indexed proposalHash,
@@ -100,21 +71,42 @@ interface IProposalValidator is ISemver {
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-    function approveProposal(bytes32 _proposalHash, bytes32 _attestationUid) external;
+    struct ProposalData {
+        address proposer;
+        ProposalType proposalType;
+        bool inVoting;
+        mapping(address => bool) delegateApprovals;
+        uint256 approvalCount;
+        uint256 votingCycle;
+    }
 
-    function setDistributionThreshold(uint256 _distributionThreshold) external;
+    struct ProposalTypeData {
+        uint256 requiredApprovals;
+        uint8 proposalVotingModule;
+    }
 
-    function setProposalTypeData(
+    struct VotingCycleData {
+        uint256 startingBlock;
+        uint256 duration;
+        uint256 votingCycleDistributionLimit;
+        uint256 movedToVoteTokenCount;
+    }
+
+    enum ProposalType {
+        ProtocolOrGovernorUpgrade,
+        MaintenanceUpgrade,
+        CouncilMemberElections,
+        GovernanceFund,
+        CouncilBudget
+    }
+
+    function submitUpgradeProposal(
+        uint248 _againstThreshold,
+        string memory _proposalDescription,
+        bytes32 _attestationUid,
         ProposalType _proposalType,
-        ProposalTypeData memory _proposalTypeData
-    ) external;
-
-    function setVotingCycleData(
-        uint256 _cycleNumber,
-        uint256 _startBlock,
-        uint256 _duration,
-        uint256 _votingCycleDistributionLimit
-    ) external;
+        uint256 _votingCycle
+    ) external returns (bytes32 proposalHash_);
 
     function submitCouncilMemberElectionsProposal(
         uint128 _criteriaValue,
@@ -134,13 +126,9 @@ interface IProposalValidator is ISemver {
         uint256 _votingCycle
     ) external returns (bytes32 proposalHash_);
 
-    function submitUpgradeProposal(
-        uint248 _againstThreshold,
-        string memory _proposalDescription,
-        bytes32 _attestationUid,
-        ProposalType _proposalType,
-        uint256 _votingCycle
-    ) external returns (bytes32 proposalHash_);
+    function approveProposal(bytes32 _proposalHash, bytes32 _attestationUid) external;
+
+    function canApproveProposal(bytes32 _attestationUid, address _delegate) external view returns (bool canApprove_);
 
     function moveToVoteProtocolOrGovernorUpgradeProposal(
         uint248 _againstThreshold,
@@ -162,6 +150,20 @@ interface IProposalValidator is ISemver {
         ProposalType _proposalType
     ) external returns (bytes32 proposalHash_);
 
+    function setVotingCycleData(
+        uint256 _cycleNumber,
+        uint256 _startBlock,
+        uint256 _duration,
+        uint256 _votingCycleDistributionLimit
+    ) external;
+
+    function setDistributionThreshold(uint256 _distributionThreshold) external;
+
+    function setProposalTypeData(
+        ProposalType _proposalType,
+        ProposalTypeData memory _proposalTypeData
+    ) external;
+
     function initialize(
         address _owner,
         IProposalTypesConfigurator _proposalTypesConfigurator,
@@ -178,8 +180,6 @@ interface IProposalValidator is ISemver {
 
     function transferOwnership(address newOwner) external;
 
-    function canApproveProposal(bytes32 _attestationUid, address _delegate) external view returns (bool canApprove_);
-
     function distributionThreshold() external view returns (uint256);
 
     function VOTING_TOKEN() external view returns (IGovernanceToken);
@@ -193,6 +193,8 @@ interface IProposalValidator is ISemver {
     function APPROVED_PROPOSER_ATTESTATION_SCHEMA_UID() external view returns (bytes32);
 
     function TOP_DELEGATES_ATTESTATION_SCHEMA_UID() external view returns (bytes32);
+
+    function OPTIMISTIC_MODULE_PERCENT_DIVISOR() external view returns (uint256);
 
     function proposalTypesConfigurator() external view returns (IProposalTypesConfigurator);
 

--- a/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
+++ b/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
@@ -30,6 +30,7 @@ interface IProposalValidator is ISemver {
     error ProposalValidator_InvalidVotingCycle();
     error ProposalValidator_ProposalIdMismatch();
     error ProposalValidator_InvalidProposer();
+    error ProposalValidator_InvalidProposal();
 
     event ProposalSubmitted(
         bytes32 indexed proposalHash,

--- a/packages/contracts-bedrock/snapshots/abi/ProposalValidator.json
+++ b/packages/contracts-bedrock/snapshots/abi/ProposalValidator.json
@@ -226,32 +226,95 @@
   {
     "inputs": [
       {
+        "internalType": "uint128",
+        "name": "_criteriaValue",
+        "type": "uint128"
+      },
+      {
+        "internalType": "string[]",
+        "name": "_optionsDescriptions",
+        "type": "string[]"
+      },
+      {
+        "internalType": "string",
+        "name": "_proposalDescription",
+        "type": "string"
+      }
+    ],
+    "name": "moveToVoteCouncilMemberElectionsProposal",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "proposalHash_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "_criteriaValue",
+        "type": "uint128"
+      },
+      {
+        "internalType": "string[]",
+        "name": "_optionsDescriptions",
+        "type": "string[]"
+      },
+      {
         "internalType": "address[]",
-        "name": "_targets",
+        "name": "_optionsRecipients",
         "type": "address[]"
       },
       {
         "internalType": "uint256[]",
-        "name": "_values",
+        "name": "_optionsAmounts",
         "type": "uint256[]"
-      },
-      {
-        "internalType": "bytes[]",
-        "name": "_calldatas",
-        "type": "bytes[]"
       },
       {
         "internalType": "string",
         "name": "_description",
         "type": "string"
+      },
+      {
+        "internalType": "enum ProposalValidator.ProposalType",
+        "name": "_proposalType",
+        "type": "uint8"
       }
     ],
-    "name": "moveToVote",
+    "name": "moveToVoteFundingProposal",
     "outputs": [
       {
-        "internalType": "uint256",
-        "name": "governorProposalId_",
-        "type": "uint256"
+        "internalType": "bytes32",
+        "name": "proposalHash_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint248",
+        "name": "_againstThreshold",
+        "type": "uint248"
+      },
+      {
+        "internalType": "string",
+        "name": "_proposalDescription",
+        "type": "string"
+      }
+    ],
+    "name": "moveToVoteProtocolOrGovernorUpgradeProposal",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "proposalHash_",
+        "type": "bytes32"
       }
     ],
     "stateMutability": "nonpayable",
@@ -406,6 +469,11 @@
         "internalType": "bytes32",
         "name": "_attestationUid",
         "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_votingCycle",
+        "type": "uint256"
       }
     ],
     "name": "submitCouncilMemberElectionsProposal",
@@ -450,6 +518,11 @@
         "internalType": "enum ProposalValidator.ProposalType",
         "name": "_proposalType",
         "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_votingCycle",
+        "type": "uint256"
       }
     ],
     "name": "submitFundingProposal",
@@ -484,6 +557,11 @@
         "internalType": "enum ProposalValidator.ProposalType",
         "name": "_proposalType",
         "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_votingCycle",
+        "type": "uint256"
       }
     ],
     "name": "submitUpgradeProposal",
@@ -546,6 +624,11 @@
       {
         "internalType": "uint256",
         "name": "votingCycleDistributionLimit",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "movedToVoteTokenCount",
         "type": "uint256"
       }
     ],
@@ -793,7 +876,17 @@
   },
   {
     "inputs": [],
+    "name": "ProposalValidator_InvalidVotingCycle",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "ProposalValidator_ProposalAlreadyApproved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProposalValidator_ProposalAlreadyMovedToVote",
     "type": "error"
   },
   {
@@ -804,6 +897,11 @@
   {
     "inputs": [],
     "name": "ProposalValidator_ProposalDoesNotExist",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProposalValidator_ProposalIdMismatch",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/src/governance/ProposalValidator.sol
+++ b/packages/contracts-bedrock/src/governance/ProposalValidator.sol
@@ -91,6 +91,9 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @notice Thrown when the caller is not the proposer.
     error ProposalValidator_InvalidProposer();
 
+    /// @notice Thrown when the proposal is invalid trying to move to vote.
+    error ProposalValidator_InvalidProposal();
+
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -613,11 +616,12 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         ProposalData storage proposal = _proposals[proposalHash_];
 
-        // Proposal must exist and the proposer must be the caller
+        // Proposal must exist and be valid
         if (proposal.proposer == address(0) || proposal.proposalType != proposalType) {
-            revert ProposalValidator_ProposalDoesNotExist();
+            revert ProposalValidator_InvalidProposal();
         }
 
+        // Check if the caller is the proposer
         if (proposal.proposer != _msgSender()) {
             revert ProposalValidator_InvalidProposer();
         }
@@ -684,11 +688,12 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         ProposalData storage proposal = _proposals[proposalHash_];
 
-        // Proposal must exist and the proposer must be the caller
+        // Proposal must exist and be valid
         if (proposal.proposer == address(0) || proposal.proposalType != proposalType) {
-            revert ProposalValidator_ProposalDoesNotExist();
+            revert ProposalValidator_InvalidProposal();
         }
 
+        // Check if the caller is the proposer
         if (proposal.proposer != _msgSender()) {
             revert ProposalValidator_InvalidProposer();
         }
@@ -783,7 +788,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         // Proposal must exist
         if (proposal.proposer == address(0) || proposal.proposalType != _proposalType) {
-            revert ProposalValidator_ProposalDoesNotExist();
+            revert ProposalValidator_InvalidProposal();
         }
 
         // Check if proposal has enough approvals

--- a/packages/contracts-bedrock/src/governance/ProposalValidator.sol
+++ b/packages/contracts-bedrock/src/governance/ProposalValidator.sol
@@ -142,14 +142,14 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @notice Struct for storing proposal information.
     /// @param proposer The address that submitted the proposal.
     /// @param proposalType Type of the proposal from the ProposalType enum.
-    /// @param inVoting Whether the proposal has been moved to the voting phase.
+    /// @param movedToVote Whether the proposal has been proposed to the Governor for voting.
     /// @param delegateApprovals Mapping of delegate addresses to their approval status.
     /// @param approvalCount Number of approvals received so far.
     /// @param votingCycle The voting cycle number the proposal is targetted for.
     struct ProposalData {
         address proposer;
         ProposalType proposalType;
-        bool inVoting;
+        bool movedToVote;
         mapping(address => bool) delegateApprovals;
         uint256 approvalCount;
         uint256 votingCycle;
@@ -374,7 +374,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         // MaintenanceUpgrade proposals move directly to voting (atomic operation)
         if (_proposalType == ProposalType.MaintenanceUpgrade) {
-            proposal.inVoting = true;
+            proposal.movedToVote = true;
 
             GOVERNOR.proposeWithModule(
                 VotingModule(votingModule), proposalVotingModuleData, _proposalDescription, uint8(_proposalType)
@@ -615,11 +615,11 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         }
 
         // Check if proposal is already in voting
-        if (proposal.inVoting) {
+        if (proposal.movedToVote) {
             revert ProposalValidator_ProposalAlreadyMovedToVote();
         }
 
-        proposal.inVoting = true;
+        proposal.movedToVote = true;
 
         // Propose with module on the Governor
         uint256 proposalId = GOVERNOR.proposeWithModule(
@@ -687,7 +687,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         }
 
         // Check if proposal is already in voting
-        if (proposal.inVoting) {
+        if (proposal.movedToVote) {
             revert ProposalValidator_ProposalAlreadyMovedToVote();
         }
 
@@ -701,7 +701,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
             revert ProposalValidator_InvalidVotingCycle();
         }
 
-        proposal.inVoting = true;
+        proposal.movedToVote = true;
 
         // Propose with module on the Governor
         uint256 proposalId = GOVERNOR.proposeWithModule(
@@ -780,7 +780,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         }
 
         // Check if proposal is already in voting
-        if (proposal.inVoting) {
+        if (proposal.movedToVote) {
             revert ProposalValidator_ProposalAlreadyMovedToVote();
         }
 
@@ -800,7 +800,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         }
 
         // Move proposal to vote
-        proposal.inVoting = true;
+        proposal.movedToVote = true;
         votingCycles[proposal.votingCycle].movedToVoteTokenCount += totalBudget;
 
         // Propose with module on the Governor

--- a/packages/contracts-bedrock/src/governance/ProposalValidator.sol
+++ b/packages/contracts-bedrock/src/governance/ProposalValidator.sol
@@ -88,6 +88,9 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @notice Thrown when the proposalId returned by the Governor is not the same as the proposalHash.
     error ProposalValidator_ProposalIdMismatch();
 
+    /// @notice Thrown when the caller is not the proposer.
+    error ProposalValidator_InvalidProposer();
+
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -599,6 +602,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         bytes memory proposalVotingModuleData = abi.encode(settings);
 
         // Get the module address from the configurator
+        ProposalType proposalType = ProposalType.ProtocolOrGovernorUpgrade;
         address votingModule = proposalTypesConfigurator.proposalTypes(
             proposalTypesData[ProposalType.ProtocolOrGovernorUpgrade].proposalVotingModule
         ).module;
@@ -610,8 +614,12 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         ProposalData storage proposal = _proposals[proposalHash_];
 
         // Proposal must exist and the proposer must be the caller
-        if (proposal.proposer != _msgSender() || proposal.proposalType != ProposalType.ProtocolOrGovernorUpgrade) {
+        if (proposal.proposer == address(0) || proposal.proposalType != proposalType) {
             revert ProposalValidator_ProposalDoesNotExist();
+        }
+
+        if (proposal.proposer != _msgSender()) {
+            revert ProposalValidator_InvalidProposer();
         }
 
         // Check if proposal is already in voting
@@ -626,7 +634,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
             VotingModule(votingModule),
             proposalVotingModuleData,
             _proposalDescription,
-            uint8(ProposalType.ProtocolOrGovernorUpgrade)
+            uint8(proposalType)
         );
 
         // Make sure the proposalId is the same as the proposalHash
@@ -677,8 +685,12 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         ProposalData storage proposal = _proposals[proposalHash_];
 
         // Proposal must exist and the proposer must be the caller
-        if (proposal.proposer != _msgSender() || proposal.proposalType != proposalType) {
+        if (proposal.proposer == address(0) || proposal.proposalType != proposalType) {
             revert ProposalValidator_ProposalDoesNotExist();
+        }
+
+        if (proposal.proposer != _msgSender()) {
+            revert ProposalValidator_InvalidProposer();
         }
 
         // Check if proposal has enough approvals

--- a/packages/contracts-bedrock/src/governance/ProposalValidator.sol
+++ b/packages/contracts-bedrock/src/governance/ProposalValidator.sol
@@ -626,6 +626,11 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
             revert ProposalValidator_InvalidProposer();
         }
 
+        // Check if proposal has enough approvals
+        if (proposal.approvalCount < proposalTypesData[proposalType].requiredApprovals) {
+            revert ProposalValidator_InsufficientApprovals();
+        }
+
         // Check if proposal is already in voting
         if (proposal.movedToVote) {
             revert ProposalValidator_ProposalAlreadyMovedToVote();

--- a/packages/contracts-bedrock/src/governance/ProposalValidator.sol
+++ b/packages/contracts-bedrock/src/governance/ProposalValidator.sol
@@ -932,7 +932,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @param _recipients An address for each option to transfer funds to (empty for non-funding proposals).
     /// @param _amounts The amount to transfer for each option (empty for non-funding proposals).
     /// @return options_ The built proposal options.
-    /// @return totalBudget The total budget amount (sum of all amounts, 0 for non-funding proposals).
+    /// @return totalBudget_ The total budget amount (sum of all amounts, 0 for non-funding proposals).
     function _buildApprovalModuleOptions(
         string[] memory _optionDescriptions,
         address[] memory _recipients,

--- a/packages/contracts-bedrock/src/governance/ProposalValidator.sol
+++ b/packages/contracts-bedrock/src/governance/ProposalValidator.sol
@@ -89,6 +89,53 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     error ProposalValidator_ProposalIdMismatch();
 
     /*//////////////////////////////////////////////////////////////
+                                 EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Emitted when a new proposal is submitted.
+    /// @param proposalHash The hash of the submitted proposal.
+    /// @param proposer The address that submitted the proposal.
+    /// @param description Description of the proposal.
+    /// @param proposalType Type of the proposal.
+    event ProposalSubmitted(
+        bytes32 indexed proposalHash, address indexed proposer, string description, ProposalType proposalType
+    );
+
+    /// @notice Emitted when a delegate approves a proposal.
+    /// @param proposalHash The hash of the approved proposal.
+    /// @param approver The address of the delegate who approved the proposal.
+    event ProposalApproved(bytes32 indexed proposalHash, address indexed approver);
+
+    /// @notice Emitted when a proposal is moved to the voting phase in the governor contract.
+    /// @param proposalHash The hash of the proposal moved to vote.
+    /// @param executor The address that executed the move to vote.
+    event ProposalMovedToVote(bytes32 indexed proposalHash, address indexed executor);
+
+    /// @notice Emitted when the voting cycle data is set.
+    /// @param cycleNumber The number of the voting cycle.
+    /// @param startBlock The block number of the starting block of the voting cycle.
+    /// @param duration The duration of the voting cycle.
+    /// @param votingCycleDistributionLimit The max amount of tokens that can be distributed during the voting cycle.
+    event VotingCycleDataSet(
+        uint256 cycleNumber, uint256 startBlock, uint256 duration, uint256 votingCycleDistributionLimit
+    );
+
+    /// @notice Emitted when the distribution threshold is set.
+    /// @param newDistributionThreshold The new distribution threshold.
+    event DistributionThresholdSet(uint256 newDistributionThreshold);
+
+    /// @notice Emitted when the proposal type data is set.
+    /// @param proposalType The type of proposal.
+    /// @param requiredApprovals The required number of approvals.
+    /// @param proposalVotingModule The proposal type ID.
+    event ProposalTypeDataSet(ProposalType proposalType, uint256 requiredApprovals, uint8 proposalVotingModule);
+
+    /// @notice Emitted with ProposalSubmitted event.
+    /// @param proposalHash The hash of the submitted proposal.
+    /// @param encodedVotingModuleData The encoded voting module data.
+    event ProposalVotingModuleData(bytes32 indexed proposalHash, bytes encodedVotingModuleData);
+
+    /*//////////////////////////////////////////////////////////////
                                  STRUCTS
     //////////////////////////////////////////////////////////////*/
 
@@ -156,53 +203,8 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     uint256 public constant OPTIMISTIC_MODULE_PERCENT_DIVISOR = 10_000;
 
     /*//////////////////////////////////////////////////////////////
-                                 EVENTS
+                                 STATE VARIABLES
     //////////////////////////////////////////////////////////////*/
-
-    /// @notice Emitted when a new proposal is submitted.
-    /// @param proposalHash The hash of the submitted proposal.
-    /// @param proposer The address that submitted the proposal.
-    /// @param description Description of the proposal.
-    /// @param proposalType Type of the proposal.
-    event ProposalSubmitted(
-        bytes32 indexed proposalHash, address indexed proposer, string description, ProposalType proposalType
-    );
-
-    /// @notice Emitted when a delegate approves a proposal.
-    /// @param proposalHash The hash of the approved proposal.
-    /// @param approver The address of the delegate who approved the proposal.
-    event ProposalApproved(bytes32 indexed proposalHash, address indexed approver);
-
-    /// @notice Emitted when a proposal is moved to the voting phase in the governor contract.
-    /// @param proposalHash The hash of the proposal moved to vote.
-    /// @param executor The address that executed the move to vote.
-    event ProposalMovedToVote(bytes32 indexed proposalHash, address indexed executor);
-
-    /// @notice Emitted when the voting cycle data is set.
-    /// @param cycleNumber The number of the voting cycle.
-    /// @param startBlock The block number of the starting block of the voting cycle.
-    /// @param duration The duration of the voting cycle.
-    /// @param votingCycleDistributionLimit The max amount of tokens that can be distributed during the voting cycle.
-    event VotingCycleDataSet(
-        uint256 cycleNumber, uint256 startBlock, uint256 duration, uint256 votingCycleDistributionLimit
-    );
-
-    /// @notice Emitted when the distribution threshold is set.
-    /// @param newDistributionThreshold The new distribution threshold.
-    event DistributionThresholdSet(uint256 newDistributionThreshold);
-
-    /// @notice Emitted when the proposal type data is set.
-    /// @param proposalType The type of proposal.
-    /// @param requiredApprovals The required number of approvals.
-    /// @param proposalVotingModule The proposal type ID.
-    event ProposalTypeDataSet(ProposalType proposalType, uint256 requiredApprovals, uint8 proposalVotingModule);
-
-    /// @notice Emitted with ProposalSubmitted event.
-    /// @param proposalHash The hash of the submitted proposal.
-    /// @param encodedVotingModuleData The encoded voting module data.
-    event ProposalVotingModuleData(bytes32 indexed proposalHash, bytes encodedVotingModuleData);
-
-    event Test(string text);
 
     /// @notice The schema UID for attestations in the Ethereum Attestation Service for checking if the caller
     ///         is an approved proposer.
@@ -542,62 +544,6 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         emit ProposalSubmitted(proposalHash_, msg.sender, _description, _proposalType);
         emit ProposalVotingModuleData(proposalHash_, proposalVotingModuleData);
-    }
-
-    /// @notice Internal function to build proposal options with optional execution data.
-    /// @param _optionDescriptions The strings of the different options that can be voted.
-    /// @param _recipients An address for each option to transfer funds to (empty for non-funding proposals).
-    /// @param _amounts The amount to transfer for each option (empty for non-funding proposals).
-    /// @return options_ The built proposal options.
-    /// @return totalBudget The total budget amount (sum of all amounts, 0 for non-funding proposals).
-    function _buildApprovalModuleOptions(
-        string[] memory _optionDescriptions,
-        address[] memory _recipients,
-        uint256[] memory _amounts
-    )
-        internal
-        view
-        returns (ProposalOption[] memory options_, uint256 totalBudget)
-    {
-        uint256 optionsLength = _optionDescriptions.length;
-        options_ = new ProposalOption[](optionsLength);
-
-        for (uint256 i = 0; i < optionsLength; i++) {
-            address[] memory targets;
-            uint256[] memory values;
-            bytes[] memory calldatas;
-            uint256 budgetTokensSpent;
-
-            // Check if this is a funding proposal (has recipients and amounts)
-            if (_recipients.length > 0 && _amounts.length > 0) {
-                // Validate amount doesn't exceed distribution threshold
-                if (_amounts[i] > distributionThreshold) {
-                    revert ProposalValidator_ExceedsDistributionThreshold();
-                }
-                targets = new address[](1);
-                values = new uint256[](1);
-                calldatas = new bytes[](1);
-
-                targets[0] = Predeploys.GOVERNANCE_TOKEN;
-                calldatas[0] = abi.encodeCall(IERC20.transfer, (_recipients[i], _amounts[i]));
-                budgetTokensSpent = _amounts[i];
-                totalBudget += _amounts[i];
-            } else {
-                // Non-funding proposals have no execution data
-                targets = new address[](0);
-                values = new uint256[](0);
-                calldatas = new bytes[](0);
-                budgetTokensSpent = 0;
-            }
-
-            options_[i] = ProposalOption({
-                budgetTokensSpent: budgetTokensSpent,
-                targets: targets,
-                values: values,
-                calldatas: calldatas,
-                description: _optionDescriptions[i]
-            });
-        }
     }
 
     /// @notice Approves a proposal before being moved for voting.
@@ -962,6 +908,62 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         }
 
         canApprove_ = true;
+    }
+
+    /// @notice Internal function to build proposal options with optional execution data.
+    /// @param _optionDescriptions The strings of the different options that can be voted.
+    /// @param _recipients An address for each option to transfer funds to (empty for non-funding proposals).
+    /// @param _amounts The amount to transfer for each option (empty for non-funding proposals).
+    /// @return options_ The built proposal options.
+    /// @return totalBudget The total budget amount (sum of all amounts, 0 for non-funding proposals).
+    function _buildApprovalModuleOptions(
+        string[] memory _optionDescriptions,
+        address[] memory _recipients,
+        uint256[] memory _amounts
+    )
+        internal
+        view
+        returns (ProposalOption[] memory options_, uint256 totalBudget)
+    {
+        uint256 optionsLength = _optionDescriptions.length;
+        options_ = new ProposalOption[](optionsLength);
+
+        for (uint256 i = 0; i < optionsLength; i++) {
+            address[] memory targets;
+            uint256[] memory values;
+            bytes[] memory calldatas;
+            uint256 budgetTokensSpent;
+
+            // Check if this is a funding proposal (has recipients and amounts)
+            if (_recipients.length > 0 && _amounts.length > 0) {
+                // Validate amount doesn't exceed distribution threshold
+                if (_amounts[i] > distributionThreshold) {
+                    revert ProposalValidator_ExceedsDistributionThreshold();
+                }
+                targets = new address[](1);
+                values = new uint256[](1);
+                calldatas = new bytes[](1);
+
+                targets[0] = Predeploys.GOVERNANCE_TOKEN;
+                calldatas[0] = abi.encodeCall(IERC20.transfer, (_recipients[i], _amounts[i]));
+                budgetTokensSpent = _amounts[i];
+                totalBudget += _amounts[i];
+            } else {
+                // Non-funding proposals have no execution data
+                targets = new address[](0);
+                values = new uint256[](0);
+                calldatas = new bytes[](0);
+                budgetTokensSpent = 0;
+            }
+
+            options_[i] = ProposalOption({
+                budgetTokensSpent: budgetTokensSpent,
+                targets: targets,
+                values: values,
+                calldatas: calldatas,
+                description: _optionDescriptions[i]
+            });
+        }
     }
 
     /// @notice Calculate `proposalId` hashing similarly to `hashProposal` but based on `module` and `proposalData`.

--- a/packages/contracts-bedrock/src/governance/ProposalValidator.sol
+++ b/packages/contracts-bedrock/src/governance/ProposalValidator.sol
@@ -394,22 +394,8 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
             revert ProposalValidator_InvalidCriteriaValue();
         }
 
-        ProposalOption[] memory options = new ProposalOption[](optionsLength);
-
-        // Build proposal options without any execution calls (elections don't execute operations)
-        for (uint256 i = 0; i < optionsLength; i++) {
-            address[] memory targets = new address[](0);
-            uint256[] memory values = new uint256[](0);
-            bytes[] memory calldatas = new bytes[](0);
-
-            options[i] = ProposalOption({
-                budgetTokensSpent: 0, // No tokens spent for elections
-                targets: targets,
-                values: values,
-                calldatas: calldatas,
-                description: _optionDescriptions[i]
-            });
-        }
+        // Build proposal options (elections don't execute operations)
+        (ProposalOption[] memory options,) = _buildApprovalModuleOptions(_optionDescriptions, new address[](0), new uint256[](0));
 
         // Configure approval voting settings with TopChoices criteria
         ApprovalProposalSettings memory settings = ApprovalProposalSettings({
@@ -491,32 +477,8 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
             revert ProposalValidator_InvalidOptionsLength();
         }
 
-        ProposalOption[] memory options = new ProposalOption[](optionsLength);
-        uint256 totalBudget = 0;
-
-        // Check amounts, build options, and calculate total budget in single loop
-        for (uint256 i = 0; i < optionsLength; i++) {
-            if (_optionsAmounts[i] > distributionThreshold) {
-                revert ProposalValidator_ExceedsDistributionThreshold();
-            }
-
-            address[] memory targets = new address[](1);
-            uint256[] memory values = new uint256[](1);
-            bytes[] memory calldatas = new bytes[](1);
-
-            targets[0] = Predeploys.GOVERNANCE_TOKEN;
-            calldatas[0] = abi.encodeCall(IERC20.transfer, (_optionsRecipients[i], _optionsAmounts[i]));
-
-            options[i] = ProposalOption({
-                budgetTokensSpent: _optionsAmounts[i],
-                targets: targets,
-                values: values,
-                calldatas: calldatas,
-                description: _optionsDescriptions[i]
-            });
-
-            totalBudget += _optionsAmounts[i];
-        }
+        // Build proposal options with funding execution data
+        (ProposalOption[] memory options, uint256 totalBudget) = _buildApprovalModuleOptions(_optionsDescriptions, _optionsRecipients, _optionsAmounts);
 
         // Configure approval voting settings
         ApprovalProposalSettings memory settings = ApprovalProposalSettings({
@@ -556,6 +518,65 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         emit ProposalVotingModuleData(proposalHash_, proposalVotingModuleData);
     }
 
+    /// @notice Internal function to build proposal options with optional execution data.
+    /// @param _optionDescriptions The strings of the different options that can be voted.
+    /// @param _recipients An address for each option to transfer funds to (empty for non-funding proposals).
+    /// @param _amounts The amount to transfer for each option (empty for non-funding proposals).
+    /// @return options_ The built proposal options.
+    /// @return totalBudget The total budget amount (sum of all amounts, 0 for non-funding proposals).
+    function _buildApprovalModuleOptions(
+        string[] memory _optionDescriptions,
+        address[] memory _recipients,
+        uint256[] memory _amounts
+    )
+        internal
+        view
+        returns (ProposalOption[] memory options_, uint256 totalBudget)
+    {
+        uint256 optionsLength = _optionDescriptions.length;
+        options_ = new ProposalOption[](optionsLength);
+        totalBudget = 0;
+
+        for (uint256 i = 0; i < optionsLength; i++) {
+            address[] memory targets;
+            uint256[] memory values;
+            bytes[] memory calldatas;
+            uint256 budgetTokensSpent;
+
+            // Check if this is a funding proposal (has recipients and amounts)
+            if (_recipients.length > 0 && _amounts.length > 0) {
+                // Validate amount doesn't exceed distribution threshold
+                if (_amounts[i] > distributionThreshold) {
+                    revert ProposalValidator_ExceedsDistributionThreshold();
+                }
+
+                targets = new address[](1);
+                values = new uint256[](1);
+                calldatas = new bytes[](1);
+
+                targets[0] = Predeploys.GOVERNANCE_TOKEN;
+                calldatas[0] = abi.encodeCall(IERC20.transfer, (_recipients[i], _amounts[i]));
+                budgetTokensSpent = _amounts[i];
+            } else {
+                // Non-funding proposals have no execution data
+                targets = new address[](0);
+                values = new uint256[](0);
+                calldatas = new bytes[](0);
+                budgetTokensSpent = 0;
+            }
+
+            options_[i] = ProposalOption({
+                budgetTokensSpent: budgetTokensSpent,
+                targets: targets,
+                values: values,
+                calldatas: calldatas,
+                description: _optionDescriptions[i]
+            });
+
+            totalBudget += _amounts[i];
+        }
+    }
+
     /// @notice Approves a proposal before being moved for voting.
     /// @dev This function should only be called by the top delegates.
     /// @param _proposalHash The hash of the proposal to approve
@@ -581,47 +602,6 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         proposal.approvalCount++;
 
         emit ProposalApproved(_proposalHash, _delegate);
-    }
-
-    /// @notice Move a proposal to voting phase after sufficient delegate approvals
-    /// @param _targets Target addresses for proposal calls
-    /// @param _values ETH values for proposal calls
-    /// @param _calldatas Function data for proposal calls
-    /// @param _description Description of the proposal
-    /// @return governorProposalId_ The proposal ID in the governor contract
-    function moveToVote(
-        address[] memory _targets,
-        uint256[] memory _values,
-        bytes[] memory _calldatas,
-        string memory _description
-    )
-        external
-        returns (uint256 governorProposalId_)
-    {
-        // Verify that the provided data matches the proposalHash
-        bytes32 _proposalHash = bytes32(0); // TODO: Implement hashProposalWithModule
-
-        ProposalData storage proposal = _proposals[_proposalHash];
-
-        if (proposal.proposer == address(0)) {
-            revert ProposalValidator_ProposalDoesNotExist();
-        }
-
-        ProposalTypeData memory proposalTypeData = proposalTypesData[proposal.proposalType];
-        if (proposal.approvalCount < proposalTypeData.requiredApprovals) {
-            revert ProposalValidator_InsufficientApprovals();
-        }
-
-        if (proposal.inVoting) {
-            revert ProposalValidator_ProposalAlreadySubmitted();
-        }
-
-        proposal.inVoting = true;
-
-        governorProposalId_ =
-            GOVERNOR.propose(_targets, _values, _calldatas, _description, uint8(proposal.proposalType));
-
-        emit ProposalMovedToVote(_proposalHash, msg.sender);
     }
 
     /// @notice Checks if a delegate can approve a proposal.

--- a/packages/contracts-bedrock/src/governance/ProposalValidator.sol
+++ b/packages/contracts-bedrock/src/governance/ProposalValidator.sol
@@ -693,8 +693,11 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         // Check if the voting cycle is valid
         VotingCycleData memory votingCycleData = votingCycles[proposal.votingCycle];
-        // TODO: is +1 days correct?
-        if (votingCycleData.startingBlock > block.number || votingCycleData.startingBlock + 1 days < block.number) {
+        // TODO: is + duration correct?
+        if (
+            votingCycleData.startingBlock > block.number
+                || votingCycleData.startingBlock + votingCycleData.duration < block.number
+        ) {
             revert ProposalValidator_InvalidVotingCycle();
         }
 
@@ -783,8 +786,11 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         // Check if proposal can be moved to vote
         VotingCycleData memory votingCycleData = votingCycles[proposal.votingCycle];
-        // TODO: is +1 days correct?
-        if (votingCycleData.startingBlock > block.number || votingCycleData.startingBlock + 1 days < block.number) {
+        // TODO: is + duration correct?
+        if (
+            votingCycleData.startingBlock > block.number
+                || votingCycleData.startingBlock + votingCycleData.duration < block.number
+        ) {
             revert ProposalValidator_InvalidVotingCycle();
         }
 

--- a/packages/contracts-bedrock/src/governance/ProposalValidator.sol
+++ b/packages/contracts-bedrock/src/governance/ProposalValidator.sol
@@ -940,7 +940,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     )
         internal
         view
-        returns (ProposalOption[] memory options_, uint256 totalBudget)
+        returns (ProposalOption[] memory options_, uint256 totalBudget_)
     {
         uint256 optionsLength = _optionDescriptions.length;
         options_ = new ProposalOption[](optionsLength);
@@ -964,7 +964,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
                 targets[0] = Predeploys.GOVERNANCE_TOKEN;
                 calldatas[0] = abi.encodeCall(IERC20.transfer, (_recipients[i], _amounts[i]));
                 budgetTokensSpent = _amounts[i];
-                totalBudget += _amounts[i];
+                totalBudget_ += _amounts[i];
             } else {
                 // Non-funding proposals have no execution data
                 targets = new address[](0);

--- a/packages/contracts-bedrock/src/governance/ProposalValidator.sol
+++ b/packages/contracts-bedrock/src/governance/ProposalValidator.sol
@@ -43,6 +43,9 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @notice Thrown when attempting to move a proposal to vote that is already in voting.
     error ProposalValidator_ProposalAlreadySubmitted();
 
+    /// @notice Thrown when attempting to move a proposal to vote that is already in voting.
+    error ProposalValidator_ProposalAlreadyMovedToVote();
+
     /// @notice Thrown when an invalid attestation is provided for a proposal.
     error ProposalValidator_InvalidAttestation();
 
@@ -79,6 +82,12 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @notice Thrown when an invalid proposal type is provided for upgrade proposals.
     error ProposalValidator_InvalidUpgradeProposalType();
 
+    /// @notice Thrown when the trying to move a proposal to vote outside of the accepted voting cycle.
+    error ProposalValidator_InvalidVotingCycle();
+
+    /// @notice Thrown when the proposalId returned by the Governor is not the same as the proposalHash.
+    error ProposalValidator_ProposalIdMismatch();
+
     /*//////////////////////////////////////////////////////////////
                                  STRUCTS
     //////////////////////////////////////////////////////////////*/
@@ -89,12 +98,14 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @param inVoting Whether the proposal has been moved to the voting phase.
     /// @param delegateApprovals Mapping of delegate addresses to their approval status.
     /// @param approvalCount Number of approvals received so far.
+    /// @param votingCycle The voting cycle number the proposal is targetted for.
     struct ProposalData {
         address proposer;
         ProposalType proposalType;
         bool inVoting;
         mapping(address => bool) delegateApprovals;
         uint256 approvalCount;
+        uint256 votingCycle;
     }
 
     /// @notice Struct for storing explicit data for each proposal type.
@@ -110,10 +121,12 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @param startingBlock The block number of the starting block of the voting cycle.
     /// @param duration The duration of the voting cycle.
     /// @param votingCycleDistributionLimit The max amount of tokens that can be distributed in a proposal.
+    /// @param movedToVoteTokenCount The total amount of tokens to possibly be distributed in the voting cycle.
     struct VotingCycleData {
         uint256 startingBlock;
         uint256 duration;
         uint256 votingCycleDistributionLimit;
+        uint256 movedToVoteTokenCount;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -188,6 +201,8 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @param proposalHash The hash of the submitted proposal.
     /// @param encodedVotingModuleData The encoded voting module data.
     event ProposalVotingModuleData(bytes32 indexed proposalHash, bytes encodedVotingModuleData);
+
+    event Test(string text);
 
     /// @notice The schema UID for attestations in the Ethereum Attestation Service for checking if the caller
     ///         is an approved proposer.
@@ -292,12 +307,14 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @param _proposalDescription Description of the proposal.
     /// @param _attestationUid The UID of the attestation for the approved proposer.
     /// @param _proposalType The type of proposal (ProtocolOrGovernorUpgrade or MaintenanceUpgrade).
+    /// @param _votingCycle The voting cycle number the proposal is targetted for.
     /// @return proposalHash_ The hash of the submitted proposal.
     function submitUpgradeProposal(
         uint248 _againstThreshold,
         string memory _proposalDescription,
         bytes32 _attestationUid,
-        ProposalType _proposalType
+        ProposalType _proposalType,
+        uint256 _votingCycle
     )
         external
         returns (bytes32 proposalHash_)
@@ -348,6 +365,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         // Store proposal metadata
         proposal.proposer = msg.sender;
         proposal.proposalType = _proposalType;
+        proposal.votingCycle = _votingCycle;
 
         emit ProposalSubmitted(proposalHash_, msg.sender, _proposalDescription, _proposalType);
         emit ProposalVotingModuleData(proposalHash_, proposalVotingModuleData);
@@ -370,12 +388,14 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @param _optionDescriptions The strings of the different options that can be voted.
     /// @param _proposalDescription Description of the proposal.
     /// @param _attestationUid The UID of the attestation for the approved proposer.
+    /// @param _votingCycle The voting cycle number the proposal is targetted for.
     /// @return proposalHash_ The hash of the submitted proposal.
     function submitCouncilMemberElectionsProposal(
         uint128 _criteriaValue,
         string[] memory _optionDescriptions,
         string memory _proposalDescription,
-        bytes32 _attestationUid
+        bytes32 _attestationUid,
+        uint256 _votingCycle
     )
         external
         returns (bytes32 proposalHash_)
@@ -395,7 +415,8 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         }
 
         // Build proposal options (elections don't execute operations)
-        (ProposalOption[] memory options,) = _buildApprovalModuleOptions(_optionDescriptions, new address[](0), new uint256[](0));
+        (ProposalOption[] memory options,) =
+            _buildApprovalModuleOptions(_optionDescriptions, new address[](0), new uint256[](0));
 
         // Configure approval voting settings with TopChoices criteria
         ApprovalProposalSettings memory settings = ApprovalProposalSettings({
@@ -432,6 +453,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         // Store proposal metadata
         proposal.proposer = msg.sender;
         proposal.proposalType = ProposalType.CouncilMemberElections;
+        proposal.votingCycle = _votingCycle;
 
         emit ProposalSubmitted(proposalHash_, msg.sender, _proposalDescription, ProposalType.CouncilMemberElections);
         emit ProposalVotingModuleData(proposalHash_, proposalVotingModuleData);
@@ -449,6 +471,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @param _optionsAmounts The amount to transfer for each option in case the option passes the voting.
     /// @param _description Description of the proposal.
     /// @param _proposalType The type of proposal (must be GovernanceFund or CouncilBudget).
+    /// @param _votingCycle The voting cycle number the proposal is targetted for.
     /// @return proposalHash_ The hash of the submitted proposal.
     function submitFundingProposal(
         uint128 _criteriaValue,
@@ -456,7 +479,8 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         address[] memory _optionsRecipients,
         uint256[] memory _optionsAmounts,
         string memory _description,
-        ProposalType _proposalType
+        ProposalType _proposalType,
+        uint256 _votingCycle
     )
         external
         returns (bytes32 proposalHash_)
@@ -478,7 +502,8 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         }
 
         // Build proposal options with funding execution data
-        (ProposalOption[] memory options, uint256 totalBudget) = _buildApprovalModuleOptions(_optionsDescriptions, _optionsRecipients, _optionsAmounts);
+        (ProposalOption[] memory options, uint256 totalBudget) =
+            _buildApprovalModuleOptions(_optionsDescriptions, _optionsRecipients, _optionsAmounts);
 
         // Configure approval voting settings
         ApprovalProposalSettings memory settings = ApprovalProposalSettings({
@@ -513,6 +538,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         // Store proposal metadata
         proposal.proposer = msg.sender;
         proposal.proposalType = _proposalType;
+        proposal.votingCycle = _votingCycle;
 
         emit ProposalSubmitted(proposalHash_, msg.sender, _description, _proposalType);
         emit ProposalVotingModuleData(proposalHash_, proposalVotingModuleData);
@@ -535,7 +561,6 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     {
         uint256 optionsLength = _optionDescriptions.length;
         options_ = new ProposalOption[](optionsLength);
-        totalBudget = 0;
 
         for (uint256 i = 0; i < optionsLength; i++) {
             address[] memory targets;
@@ -549,7 +574,6 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
                 if (_amounts[i] > distributionThreshold) {
                     revert ProposalValidator_ExceedsDistributionThreshold();
                 }
-
                 targets = new address[](1);
                 values = new uint256[](1);
                 calldatas = new bytes[](1);
@@ -557,6 +581,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
                 targets[0] = Predeploys.GOVERNANCE_TOKEN;
                 calldatas[0] = abi.encodeCall(IERC20.transfer, (_recipients[i], _amounts[i]));
                 budgetTokensSpent = _amounts[i];
+                totalBudget += _amounts[i];
             } else {
                 // Non-funding proposals have no execution data
                 targets = new address[](0);
@@ -572,8 +597,6 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
                 calldatas: calldatas,
                 description: _optionDescriptions[i]
             });
-
-            totalBudget += _amounts[i];
         }
     }
 
@@ -610,6 +633,235 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @return canApprove_ True if the delegate can approve the proposal, false otherwise.
     function canApproveProposal(bytes32 _attestationUid, address _delegate) external view returns (bool canApprove_) {
         canApprove_ = _validateTopDelegateAttestation(_attestationUid, _delegate);
+    }
+
+    /// @notice Moves a Protocol or Governor Upgrade proposal to vote by proposing it on the Governor.
+    /// @param _againstThreshold The threshold for the proposal to be against the total supply.
+    /// @param _proposalDescription Description of the proposal.
+    /// @return proposalHash_ The hash of the submitted proposal.
+    function moveToVoteProtocolOrGovernorUpgradeProposal(
+        uint248 _againstThreshold,
+        string memory _proposalDescription
+    )
+        external
+        returns (bytes32 proposalHash_)
+    {
+        // Configure optimistic proposal settings
+        OptimisticProposalSettings memory settings =
+            OptimisticProposalSettings({ againstThreshold: _againstThreshold, isRelativeToVotableSupply: true });
+
+        bytes memory proposalVotingModuleData = abi.encode(settings);
+
+        // Get the module address from the configurator
+        address votingModule = proposalTypesConfigurator.proposalTypes(
+            proposalTypesData[ProposalType.ProtocolOrGovernorUpgrade].proposalVotingModule
+        ).module;
+
+        // Generate unique proposal hash
+        proposalHash_ =
+            _hashProposalWithModule(votingModule, proposalVotingModuleData, keccak256(bytes(_proposalDescription)));
+
+        ProposalData storage proposal = _proposals[proposalHash_];
+
+        // Proposal must exist and the proposer must be the caller
+        if (proposal.proposer != _msgSender() || proposal.proposalType != ProposalType.ProtocolOrGovernorUpgrade) {
+            revert ProposalValidator_ProposalDoesNotExist();
+        }
+
+        // Check if proposal is already in voting
+        if (proposal.inVoting) {
+            revert ProposalValidator_ProposalAlreadyMovedToVote();
+        }
+
+        proposal.inVoting = true;
+
+        // Propose with module on the Governor
+        uint256 proposalId = GOVERNOR.proposeWithModule(
+            VotingModule(votingModule),
+            proposalVotingModuleData,
+            _proposalDescription,
+            uint8(ProposalType.ProtocolOrGovernorUpgrade)
+        );
+
+        // Make sure the proposalId is the same as the proposalHash
+        if (proposalId != uint256(proposalHash_)) {
+            revert ProposalValidator_ProposalIdMismatch();
+        }
+
+        emit ProposalMovedToVote(proposalHash_, _msgSender());
+    }
+
+    /// @notice Moves a council member elections proposal to vote by proposing it on the Governor.
+    /// @param _criteriaValue The number of top choices that can pass the voting.
+    /// @param _optionsDescriptions The strings of the different options that can be voted.
+    /// @param _proposalDescription Description of the proposal.
+    /// @return proposalHash_ The hash of the submitted proposal.
+    function moveToVoteCouncilMemberElectionsProposal(
+        uint128 _criteriaValue,
+        string[] memory _optionsDescriptions,
+        string memory _proposalDescription
+    )
+        external
+        returns (bytes32 proposalHash_)
+    {
+        // Configure approval module options
+        (ProposalOption[] memory options,) =
+            _buildApprovalModuleOptions(_optionsDescriptions, new address[](0), new uint256[](0));
+
+        // Configure approval module settings
+        ApprovalProposalSettings memory settings = ApprovalProposalSettings({
+            maxApprovals: uint8(_optionsDescriptions.length),
+            criteria: uint8(PassingCriteria.TopChoices),
+            budgetToken: address(0),
+            criteriaValue: _criteriaValue,
+            budgetAmount: 0
+        });
+
+        bytes memory proposalVotingModuleData = abi.encode(options, settings);
+
+        // Get the module address from the configurator
+        ProposalType proposalType = ProposalType.CouncilMemberElections;
+        address votingModule =
+            proposalTypesConfigurator.proposalTypes(proposalTypesData[proposalType].proposalVotingModule).module;
+
+        // Generate unique proposal hash
+        proposalHash_ =
+            _hashProposalWithModule(votingModule, proposalVotingModuleData, keccak256(bytes(_proposalDescription)));
+
+        ProposalData storage proposal = _proposals[proposalHash_];
+
+        // Proposal must exist and the proposer must be the caller
+        if (proposal.proposer != _msgSender() || proposal.proposalType != proposalType) {
+            revert ProposalValidator_ProposalDoesNotExist();
+        }
+
+        // Check if proposal has enough approvals
+        if (proposal.approvalCount < proposalTypesData[proposalType].requiredApprovals) {
+            revert ProposalValidator_InsufficientApprovals();
+        }
+
+        // Check if proposal is already in voting
+        if (proposal.inVoting) {
+            revert ProposalValidator_ProposalAlreadyMovedToVote();
+        }
+
+        // Check if the voting cycle is valid
+        VotingCycleData memory votingCycleData = votingCycles[proposal.votingCycle];
+        // TODO: is +1 days correct?
+        if (votingCycleData.startingBlock > block.number || votingCycleData.startingBlock + 1 days < block.number) {
+            revert ProposalValidator_InvalidVotingCycle();
+        }
+
+        proposal.inVoting = true;
+
+        // Propose with module on the Governor
+        uint256 proposalId = GOVERNOR.proposeWithModule(
+            VotingModule(votingModule), proposalVotingModuleData, _proposalDescription, uint8(proposalType)
+        );
+
+        // Make sure the proposalId is the same as the proposalHash
+        if (proposalId != uint256(proposalHash_)) {
+            revert ProposalValidator_ProposalIdMismatch();
+        }
+
+        emit ProposalMovedToVote(proposalHash_, _msgSender());
+    }
+
+    /// @notice Moves a funding proposal to vote by proposing it on the Governor.
+    /// @dev For UI integration: Frontend interfaces should present this as a percentage input to users (e.g., "25%"),
+    /// then convert to the absolute vote count by calculating: (percentage / 100) * total_votable_supply.
+    /// Direct contract callers must provide the absolute number of votes required for passage.
+    /// @param _criteriaValue The absolute number of votes required for the proposal to pass. This represents the
+    /// threshold that must be met or exceeded for any option to be considered successful.
+    /// @param _optionsDescriptions The strings of the different options that can be voted.
+    /// @param _optionsRecipients An address for each option to transfer funds to in case the option passes the voting.
+    /// @param _optionsAmounts The amount to transfer for each option in case the option passes the voting.
+    /// @param _description Description of the proposal.
+    /// @param _proposalType The type of proposal (must be GovernanceFund or CouncilBudget).
+    /// @return proposalHash_ The hash of the submitted proposal.
+    function moveToVoteFundingProposal(
+        uint128 _criteriaValue,
+        string[] memory _optionsDescriptions,
+        address[] memory _optionsRecipients,
+        uint256[] memory _optionsAmounts,
+        string memory _description,
+        ProposalType _proposalType
+    )
+        external
+        returns (bytes32 proposalHash_)
+    {
+        uint256 optionsLength = _optionsDescriptions.length;
+        // Only funding proposal types can use this function
+        if (_proposalType != ProposalType.GovernanceFund && _proposalType != ProposalType.CouncilBudget) {
+            revert ProposalValidator_InvalidFundingProposalType();
+        }
+
+        // Configure approval module options
+        (ProposalOption[] memory options, uint256 totalBudget) =
+            _buildApprovalModuleOptions(_optionsDescriptions, _optionsRecipients, _optionsAmounts);
+
+        // Configure approval module settings
+        ApprovalProposalSettings memory settings = ApprovalProposalSettings({
+            maxApprovals: uint8(optionsLength),
+            criteria: uint8(PassingCriteria.Threshold),
+            budgetToken: Predeploys.GOVERNANCE_TOKEN,
+            criteriaValue: _criteriaValue,
+            budgetAmount: uint128(totalBudget)
+        });
+
+        bytes memory proposalVotingModuleData = abi.encode(options, settings);
+
+        // Get the module address from the configurator
+        address votingModule =
+            proposalTypesConfigurator.proposalTypes(proposalTypesData[_proposalType].proposalVotingModule).module;
+
+        // Generate unique proposal hash
+        proposalHash_ = _hashProposalWithModule(votingModule, proposalVotingModuleData, keccak256(bytes(_description)));
+
+        ProposalData storage proposal = _proposals[proposalHash_];
+
+        // Proposal must exist
+        if (proposal.proposer == address(0) || proposal.proposalType != _proposalType) {
+            revert ProposalValidator_ProposalDoesNotExist();
+        }
+
+        // Check if proposal has enough approvals
+        if (proposal.approvalCount < proposalTypesData[_proposalType].requiredApprovals) {
+            revert ProposalValidator_InsufficientApprovals();
+        }
+
+        // Check if proposal is already in voting
+        if (proposal.inVoting) {
+            revert ProposalValidator_ProposalAlreadyMovedToVote();
+        }
+
+        // Check if proposal can be moved to vote
+        VotingCycleData memory votingCycleData = votingCycles[proposal.votingCycle];
+        // TODO: is +1 days correct?
+        if (votingCycleData.startingBlock > block.number || votingCycleData.startingBlock + 1 days < block.number) {
+            revert ProposalValidator_InvalidVotingCycle();
+        }
+
+        // Check if total budget is within the voting cycle distribution limit
+        if (votingCycleData.movedToVoteTokenCount + totalBudget > votingCycleData.votingCycleDistributionLimit) {
+            revert ProposalValidator_ExceedsDistributionThreshold();
+        }
+
+        // Move proposal to vote
+        proposal.inVoting = true;
+        votingCycles[proposal.votingCycle].movedToVoteTokenCount += totalBudget;
+
+        // Propose with module on the Governor
+        uint256 proposalId = GOVERNOR.proposeWithModule(
+            VotingModule(votingModule), proposalVotingModuleData, _description, uint8(_proposalType)
+        );
+
+        // Make sure the proposalId is the same as the proposalHash
+        if (proposalId != uint256(proposalHash_)) {
+            revert ProposalValidator_ProposalIdMismatch();
+        }
+
+        emit ProposalMovedToVote(proposalHash_, _msgSender());
     }
 
     /// @notice Sets the data of a voting cycle.
@@ -749,7 +1001,8 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         votingCycles[_cycleNumber] = VotingCycleData({
             startingBlock: _startBlock,
             duration: _duration,
-            votingCycleDistributionLimit: _votingCycleDistributionLimit
+            votingCycleDistributionLimit: _votingCycleDistributionLimit,
+            movedToVoteTokenCount: 0
         });
         emit VotingCycleDataSet(_cycleNumber, _startBlock, _duration, _votingCycleDistributionLimit);
     }

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -1599,23 +1599,23 @@ contract ProposalValidator_MoveToVoteFundingProposal_TestFail is ProposalValidat
 /// @title ProposalValidator_CanApproveProposal_Test
 /// @notice Tests for the canApproveProposal function
 contract ProposalValidator_CanApproveProposal_Test is ProposalValidator_Init {
-    function test_canApproveProposal_returnsTrue_succeeds() public {
+    function test_canApproveProposal_returnTrue_succeeds() public {
         // Attestation already created in setUp
         bool canApprove = validator.canApproveProposal(topDelegateAttestation_A, topDelegate_A);
         assertTrue(canApprove);
     }
 
-    function test_canApproveProposal_returnsFalse_succeeds(bytes32 _attestationUid, address _delegate) public {
+    function test_canApproveProposal_returnFalse_succeeds(bytes32 attestationUid, address delegate) public {
         // Ensure the attestation uid is not one of the top delegates
         vm.assume(
-            _attestationUid != topDelegateAttestation_A && _attestationUid != topDelegateAttestation_B
-                && _attestationUid != topDelegateAttestation_C && _attestationUid != topDelegateAttestation_D
+            attestationUid != topDelegateAttestation_A && attestationUid != topDelegateAttestation_B
+                && attestationUid != topDelegateAttestation_C && attestationUid != topDelegateAttestation_D
         );
 
         bool canApprove;
         // Expect the invalid attestation error to be reverted
-        vm.expectRevert(ProposalValidator.ProposalValidator_InvalidAttestationSchema.selector);
-        try validator.canApproveProposal(_attestationUid, _delegate) returns (bool result_) {
+        vm.expectRevert(IProposalValidator.ProposalValidator_InvalidAttestation.selector);
+        try validator.canApproveProposal(attestationUid, delegate) returns (bool result_) {
             canApprove = result_;
         } catch {
             canApprove = false;

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -944,7 +944,7 @@ contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_TestFail 
         validator.moveToVoteProtocolOrGovernorUpgradeProposal(againstThreshold, proposalDescription);
     }
 
-    function test_moveToVoteProtocolOrGovernorUpgradeProposal_proposalDoesNotExist_reverts(
+    function test_moveToVoteProtocolOrGovernorUpgradeProposal_invalidProposal_reverts(
         uint248 _againstThreshold
     )
         public
@@ -955,7 +955,7 @@ contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_TestFail 
         // Mock the proposal types configurator call
         _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
 
-        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalDoesNotExist.selector);
+        vm.expectRevert(IProposalValidator.ProposalValidator_InvalidProposal.selector);
         vm.prank(approvedProposer);
         validator.moveToVoteProtocolOrGovernorUpgradeProposal(_againstThreshold, proposalDescription);
     }
@@ -1082,14 +1082,14 @@ contract ProposalValidator_MoveToVoteCouncilMemberElectionsProposal_TestFail is 
         validator.moveToVoteCouncilMemberElectionsProposal(criteriaValue, optionsDescriptions, proposalDescription);
     }
 
-    function test_moveToVoteCouncilMemberElectionsProposal_proposalDoesNotExist_reverts() public {
+    function test_moveToVoteCouncilMemberElectionsProposal_invalidProposal_reverts() public {
         // This will generate a different proposal hash which will make the proposal type wrong
         uint128 _criteriaValue = 2; // we use 2 since it is the max based on the created proposal in setUp
 
         // Mock the proposal types configurator call
         _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
 
-        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalDoesNotExist.selector);
+        vm.expectRevert(IProposalValidator.ProposalValidator_InvalidProposal.selector);
         vm.prank(approvedProposer);
         validator.moveToVoteCouncilMemberElectionsProposal(_criteriaValue, optionsDescriptions, proposalDescription);
     }
@@ -1333,7 +1333,7 @@ contract ProposalValidator_MoveToVoteFundingProposal_TestFail is ProposalValidat
         );
     }
 
-    function test_moveToVoteFundingProposal_proposalDoesNotExist_reverts(
+    function test_moveToVoteFundingProposal_invalidProposal_reverts(
         uint8 _proposalTypeValue,
         uint128 _criteriaValue
     )
@@ -1357,14 +1357,14 @@ contract ProposalValidator_MoveToVoteFundingProposal_TestFail is ProposalValidat
         // Mock the proposal types configurator call
         _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
 
-        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalDoesNotExist.selector);
+        vm.expectRevert(IProposalValidator.ProposalValidator_InvalidProposal.selector);
         vm.prank(approvedProposer);
         validator.moveToVoteFundingProposal(
             _criteriaValue, optionsDescriptions, optionsRecipients, optionsAmounts, proposalDescription, proposalType
         );
     }
 
-    function test_moveToVoteFundingProposal_proposalDoesNotExistWrongProposalType_reverts(
+    function test_moveToVoteFundingProposal_invalidProposalWrongProposalType_reverts(
         uint8 _wrongProposalTypeValue,
         uint8 _validProposalTypeValue
     )
@@ -1391,7 +1391,7 @@ contract ProposalValidator_MoveToVoteFundingProposal_TestFail is ProposalValidat
         // Mock the proposal types configurator call
         _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
 
-        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalDoesNotExist.selector);
+        vm.expectRevert(IProposalValidator.ProposalValidator_InvalidProposal.selector);
         vm.prank(approvedProposer);
         validator.moveToVoteFundingProposal(
             criteriaValue,

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -73,10 +73,17 @@ contract ProposalValidatorForTest is ProposalValidator {
     function getProposalData(bytes32 _proposalHash)
         public
         view
-        returns (address proposer_, ProposalType proposalType_, bool inVoting_, uint256 approvalCount_)
+        returns (
+            address proposer_,
+            ProposalType proposalType_,
+            bool inVoting_,
+            uint256 approvalCount_,
+            uint256 votingCycle_
+        )
     {
         ProposalData storage proposal = _proposals[_proposalHash];
-        return (proposal.proposer, proposal.proposalType, proposal.inVoting, proposal.approvalCount);
+        return
+            (proposal.proposer, proposal.proposalType, proposal.inVoting, proposal.approvalCount, proposal.votingCycle);
     }
 
     function setProposalData(
@@ -571,7 +578,7 @@ contract ProposalValidator_ApproveProposal_Test is ProposalValidator_Init {
         // Check that the proposal data has been updated
         assertTrue(validator.hasDelegateApproved(_proposalHash, topDelegate_A));
 
-        (,,, uint256 approvalCount) = validator.getProposalData(_proposalHash);
+        (,,, uint256 approvalCount,) = validator.getProposalData(_proposalHash);
         assertEq(approvalCount, 1);
     }
 }
@@ -879,12 +886,17 @@ contract ProposalValidator_Setters_Test is ProposalValidator_Init {
         vm.prank(owner);
         validator.setVotingCycleData(cycleNumber, startBlock, duration, distributionLimit);
 
-        (uint256 actualStartBlock, uint256 actualDuration, uint256 actualDistributionLimit) =
-            validator.votingCycles(cycleNumber);
+        (
+            uint256 actualStartBlock,
+            uint256 actualDuration,
+            uint256 actualDistributionLimit,
+            uint256 actualMovedToVoteTokenCount
+        ) = validator.votingCycles(cycleNumber);
 
         assertEq(actualStartBlock, startBlock);
         assertEq(actualDuration, duration);
         assertEq(actualDistributionLimit, distributionLimit);
+        assertEq(actualMovedToVoteTokenCount, 0);
     }
 
     function test_setVotingCycleData_notOwner_reverts() public {
@@ -1064,8 +1076,9 @@ contract ProposalValidator_SubmitFundingProposal_Test is ProposalValidator_Init 
         _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
 
         vm.prank(proposer);
-        bytes32 proposalHash =
-            validator.submitFundingProposal(criteriaValue, descriptions, recipients, amounts, description, proposalType);
+        bytes32 proposalHash = validator.submitFundingProposal(
+            criteriaValue, descriptions, recipients, amounts, description, proposalType, CYCLE_NUMBER
+        );
 
         assertEq(proposalHash, expectedHash);
 
@@ -1074,13 +1087,15 @@ contract ProposalValidator_SubmitFundingProposal_Test is ProposalValidator_Init 
             address storedProposer,
             ProposalValidator.ProposalType storedProposalType,
             bool inVoting,
-            uint256 approvalCount
+            uint256 approvalCount,
+            uint256 votingCycle
         ) = validator.getProposalData(proposalHash);
 
         assertEq(storedProposer, proposer, "Proposer should match input");
         assertEq(uint8(storedProposalType), uint8(proposalType), "Proposal type should match input");
         assertFalse(inVoting, "Proposal should not be in voting yet");
         assertEq(approvalCount, 0, "Approval count should be 0");
+        assertEq(votingCycle, CYCLE_NUMBER, "Voting cycle should match input");
     }
 }
 
@@ -1107,7 +1122,7 @@ contract ProposalValidator_SubmitFundingProposal_TestFail is ProposalValidator_I
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidFundingProposalType.selector);
         vm.prank(user);
         validator.submitFundingProposal(
-            FUNDING_CRITERIA_VALUE, descriptions, recipients, amounts, description, proposalType
+            FUNDING_CRITERIA_VALUE, descriptions, recipients, amounts, description, proposalType, CYCLE_NUMBER
         );
     }
 
@@ -1140,7 +1155,8 @@ contract ProposalValidator_SubmitFundingProposal_TestFail is ProposalValidator_I
             matchingRecipients,
             matchingAmounts,
             description,
-            proposalType
+            proposalType,
+            CYCLE_NUMBER
         );
     }
 
@@ -1173,7 +1189,8 @@ contract ProposalValidator_SubmitFundingProposal_TestFail is ProposalValidator_I
             mismatchedRecipients,
             matchingAmounts,
             description,
-            proposalType
+            proposalType,
+            CYCLE_NUMBER
         );
     }
 
@@ -1206,7 +1223,8 @@ contract ProposalValidator_SubmitFundingProposal_TestFail is ProposalValidator_I
             matchingRecipients,
             mismatchedAmounts,
             description,
-            proposalType
+            proposalType,
+            CYCLE_NUMBER
         );
     }
 
@@ -1231,7 +1249,7 @@ contract ProposalValidator_SubmitFundingProposal_TestFail is ProposalValidator_I
         vm.expectRevert(ProposalValidator.ProposalValidator_ExceedsDistributionThreshold.selector);
         vm.prank(user);
         validator.submitFundingProposal(
-            FUNDING_CRITERIA_VALUE, descriptions, recipients, amounts, description, proposalType
+            FUNDING_CRITERIA_VALUE, descriptions, recipients, amounts, description, proposalType, CYCLE_NUMBER
         );
     }
 
@@ -1261,7 +1279,7 @@ contract ProposalValidator_SubmitFundingProposal_TestFail is ProposalValidator_I
         // Submit first proposal
         vm.prank(user);
         validator.submitFundingProposal(
-            FUNDING_CRITERIA_VALUE, descriptions, recipients, amounts, description, proposalType
+            FUNDING_CRITERIA_VALUE, descriptions, recipients, amounts, description, proposalType, CYCLE_NUMBER
         );
 
         // Attempt to submit identical proposal
@@ -1271,7 +1289,7 @@ contract ProposalValidator_SubmitFundingProposal_TestFail is ProposalValidator_I
 
         vm.prank(user);
         validator.submitFundingProposal(
-            FUNDING_CRITERIA_VALUE, descriptions, recipients, amounts, description, proposalType
+            FUNDING_CRITERIA_VALUE, descriptions, recipients, amounts, description, proposalType, CYCLE_NUMBER
         );
     }
 
@@ -1302,7 +1320,7 @@ contract ProposalValidator_SubmitFundingProposal_TestFail is ProposalValidator_I
 
         vm.prank(user);
         validator.submitFundingProposal(
-            FUNDING_CRITERIA_VALUE, descriptions, recipients, amounts, description, proposalType
+            FUNDING_CRITERIA_VALUE, descriptions, recipients, amounts, description, proposalType, CYCLE_NUMBER
         );
     }
 
@@ -1317,7 +1335,13 @@ contract ProposalValidator_SubmitFundingProposal_TestFail is ProposalValidator_I
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidOptionsLength.selector);
         vm.prank(user);
         validator.submitFundingProposal(
-            FUNDING_CRITERIA_VALUE, emptyDescriptions, emptyRecipients, emptyAmounts, description, proposalType
+            FUNDING_CRITERIA_VALUE,
+            emptyDescriptions,
+            emptyRecipients,
+            emptyAmounts,
+            description,
+            proposalType,
+            CYCLE_NUMBER
         );
     }
 
@@ -1339,7 +1363,13 @@ contract ProposalValidator_SubmitFundingProposal_TestFail is ProposalValidator_I
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidOptionsLength.selector);
         vm.prank(user);
         validator.submitFundingProposal(
-            FUNDING_CRITERIA_VALUE, tooManyDescriptions, tooManyRecipients, tooManyAmounts, description, proposalType
+            FUNDING_CRITERIA_VALUE,
+            tooManyDescriptions,
+            tooManyRecipients,
+            tooManyAmounts,
+            description,
+            proposalType,
+            CYCLE_NUMBER
         );
     }
 }
@@ -1388,10 +1418,12 @@ contract ProposalValidator_Initialize_Test is ProposalValidator_Init {
         assertEq(validator.owner(), owner);
 
         // Verify voting cycle data
-        (uint256 startBlock, uint256 duration, uint256 distributionLimit) = validator.votingCycles(CYCLE_NUMBER);
+        (uint256 startBlock, uint256 duration, uint256 distributionLimit, uint256 movedToVoteTokenCount) =
+            validator.votingCycles(CYCLE_NUMBER);
         assertEq(startBlock, START_BLOCK);
         assertEq(duration, DURATION);
         assertEq(distributionLimit, DISTRIBUTION_LIMIT);
+        assertEq(movedToVoteTokenCount, 0);
 
         // Verify proposal type data
         for (uint256 i = 0; i < proposalTypes.length; i++) {
@@ -1504,14 +1536,19 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_Test is Proposal
 
         vm.prank(topDelegate_A);
         bytes32 proposalHash = validator.submitCouncilMemberElectionsProposal(
-            criteriaValue, optionDescriptions, proposalDescription, attestationUid
+            criteriaValue, optionDescriptions, proposalDescription, attestationUid, CYCLE_NUMBER
         );
 
         assertEq(proposalHash, expectedHash);
 
         // Verify proposal data was stored correctly
-        (address proposer, ProposalValidator.ProposalType proposalType, bool inVoting, uint256 approvalCount) =
-            validator.getProposalData(proposalHash);
+        (
+            address proposer,
+            ProposalValidator.ProposalType proposalType,
+            bool inVoting,
+            uint256 approvalCount,
+            uint256 votingCycle
+        ) = validator.getProposalData(proposalHash);
 
         assertEq(proposer, topDelegate_A, "Proposer should be topDelegate_A");
         assertEq(
@@ -1521,6 +1558,7 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_Test is Proposal
         );
         assertFalse(inVoting, "Proposal should not be in voting yet");
         assertEq(approvalCount, 0, "Approval count should be 0");
+        assertEq(votingCycle, CYCLE_NUMBER, "Voting cycle should match input");
     }
 }
 
@@ -1556,7 +1594,7 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_TestFail is Prop
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidAttestation.selector);
         vm.prank(topDelegate_A);
         validator.submitCouncilMemberElectionsProposal(
-            criteriaValue, optionDescriptions, proposalDescription, fuzzedAttestationUid
+            criteriaValue, optionDescriptions, proposalDescription, fuzzedAttestationUid, CYCLE_NUMBER
         );
     }
 
@@ -1567,7 +1605,7 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_TestFail is Prop
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidAttestation.selector);
         vm.prank(fuzzedProposer); // Different from attested topDelegate_A
         validator.submitCouncilMemberElectionsProposal(
-            criteriaValue, optionDescriptions, proposalDescription, attestationUid
+            criteriaValue, optionDescriptions, proposalDescription, attestationUid, CYCLE_NUMBER
         );
     }
 
@@ -1576,7 +1614,9 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_TestFail is Prop
 
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidOptionsLength.selector);
         vm.prank(topDelegate_A);
-        validator.submitCouncilMemberElectionsProposal(criteriaValue, emptyOptions, proposalDescription, attestationUid);
+        validator.submitCouncilMemberElectionsProposal(
+            criteriaValue, emptyOptions, proposalDescription, attestationUid, CYCLE_NUMBER
+        );
     }
 
     function test_submitCouncilMemberElectionsProposal_duplicateProposal_reverts() public {
@@ -1598,7 +1638,7 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_TestFail is Prop
         // Submit first proposal
         vm.prank(topDelegate_A);
         validator.submitCouncilMemberElectionsProposal(
-            criteriaValue, optionDescriptions, proposalDescription, attestationUid
+            criteriaValue, optionDescriptions, proposalDescription, attestationUid, CYCLE_NUMBER
         );
 
         // Create new attestation for second attempt
@@ -1612,7 +1652,7 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_TestFail is Prop
 
         vm.prank(topDelegate_B);
         validator.submitCouncilMemberElectionsProposal(
-            criteriaValue, optionDescriptions, proposalDescription, secondAttestation
+            criteriaValue, optionDescriptions, proposalDescription, secondAttestation, CYCLE_NUMBER
         );
     }
 
@@ -1636,7 +1676,7 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_TestFail is Prop
 
         vm.prank(topDelegate_A);
         validator.submitCouncilMemberElectionsProposal(
-            criteriaValue, optionDescriptions, proposalDescription, attestationUid
+            criteriaValue, optionDescriptions, proposalDescription, attestationUid, CYCLE_NUMBER
         );
     }
 
@@ -1664,7 +1704,7 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_TestFail is Prop
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidAttestation.selector);
         vm.prank(topDelegate_A);
         validator.submitCouncilMemberElectionsProposal(
-            criteriaValue, optionDescriptions, proposalDescription, invalidAttestation
+            criteriaValue, optionDescriptions, proposalDescription, invalidAttestation, CYCLE_NUMBER
         );
     }
 
@@ -1679,7 +1719,7 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_TestFail is Prop
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidCriteriaValue.selector);
         vm.prank(topDelegate_A);
         validator.submitCouncilMemberElectionsProposal(
-            invalidCriteriaValue, optionDescriptions, proposalDescription, attestationUid
+            invalidCriteriaValue, optionDescriptions, proposalDescription, attestationUid, CYCLE_NUMBER
         );
     }
 }
@@ -1750,8 +1790,9 @@ contract ProposalValidator_SubmitUpgradeProposal_Test is ProposalValidator_Init 
         emit ProposalMovedToVote(expectedHash, proposer);
 
         vm.prank(proposer);
-        bytes32 proposalHash =
-            validator.submitUpgradeProposal(againstThreshold, proposalDescription, attestationUid, proposalType);
+        bytes32 proposalHash = validator.submitUpgradeProposal(
+            againstThreshold, proposalDescription, attestationUid, proposalType, CYCLE_NUMBER
+        );
 
         assertEq(proposalHash, expectedHash);
 
@@ -1760,13 +1801,15 @@ contract ProposalValidator_SubmitUpgradeProposal_Test is ProposalValidator_Init 
             address storedProposer,
             ProposalValidator.ProposalType storedProposalType,
             bool inVoting,
-            uint256 approvalCount
+            uint256 approvalCount,
+            uint256 votingCycle
         ) = validator.getProposalData(proposalHash);
 
         assertEq(storedProposer, proposer, "Proposer should match input");
         assertEq(uint8(storedProposalType), uint8(proposalType), "Proposal type should match input");
         assertTrue(inVoting, "MaintenanceUpgrade should be in voting immediately");
         assertEq(approvalCount, 0, "Approval count should be 0");
+        assertEq(votingCycle, CYCLE_NUMBER, "Voting cycle should match input");
     }
 
     function testFuzz_submitUpgradeProposal_protocolOrGovernorUpgrade_succeeds(
@@ -1809,8 +1852,9 @@ contract ProposalValidator_SubmitUpgradeProposal_Test is ProposalValidator_Init 
         emit ProposalVotingModuleData(expectedHash, votingModuleData);
 
         vm.prank(proposer);
-        bytes32 proposalHash =
-            validator.submitUpgradeProposal(againstThreshold, proposalDescription, attestationUid, proposalType);
+        bytes32 proposalHash = validator.submitUpgradeProposal(
+            againstThreshold, proposalDescription, attestationUid, proposalType, CYCLE_NUMBER
+        );
 
         assertEq(proposalHash, expectedHash);
 
@@ -1819,13 +1863,15 @@ contract ProposalValidator_SubmitUpgradeProposal_Test is ProposalValidator_Init 
             address storedProposer,
             ProposalValidator.ProposalType storedProposalType,
             bool inVoting,
-            uint256 approvalCount
+            uint256 approvalCount,
+            uint256 votingCycle
         ) = validator.getProposalData(proposalHash);
 
         assertEq(storedProposer, proposer, "Proposer should match input");
         assertEq(uint8(storedProposalType), uint8(proposalType), "Proposal type should match input");
         assertFalse(inVoting, "ProtocolOrGovernorUpgrade should not be in voting yet");
         assertEq(approvalCount, 0, "Approval count should be 0");
+        assertEq(votingCycle, CYCLE_NUMBER, "Voting cycle should match input");
     }
 }
 
@@ -1852,7 +1898,9 @@ contract ProposalValidator_SubmitUpgradeProposal_TestFail is ProposalValidator_I
 
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidUpgradeProposalType.selector);
         vm.prank(topDelegate_A);
-        validator.submitUpgradeProposal(againstThreshold, proposalDescription, attestationUid, proposalType);
+        validator.submitUpgradeProposal(
+            againstThreshold, proposalDescription, attestationUid, proposalType, CYCLE_NUMBER
+        );
     }
 
     function testFuzz_submitUpgradeProposal_invalidAttestation_reverts(bytes32 fuzzedAttestationUid) public {
@@ -1864,7 +1912,9 @@ contract ProposalValidator_SubmitUpgradeProposal_TestFail is ProposalValidator_I
 
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidAttestation.selector);
         vm.prank(topDelegate_A);
-        validator.submitUpgradeProposal(againstThreshold, proposalDescription, fuzzedAttestationUid, proposalType);
+        validator.submitUpgradeProposal(
+            againstThreshold, proposalDescription, fuzzedAttestationUid, proposalType, CYCLE_NUMBER
+        );
     }
 
     function testFuzz_submitUpgradeProposal_unattestedProposer_reverts(address fuzzedProposer) public {
@@ -1877,7 +1927,9 @@ contract ProposalValidator_SubmitUpgradeProposal_TestFail is ProposalValidator_I
         // Try to submit with different address than attested
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidAttestation.selector);
         vm.prank(fuzzedProposer); // Different from attested topDelegate_A
-        validator.submitUpgradeProposal(againstThreshold, proposalDescription, attestationUid, proposalType);
+        validator.submitUpgradeProposal(
+            againstThreshold, proposalDescription, attestationUid, proposalType, CYCLE_NUMBER
+        );
     }
 
     function test_submitUpgradeProposal_zeroAgainstThreshold_reverts() public {
@@ -1887,7 +1939,7 @@ contract ProposalValidator_SubmitUpgradeProposal_TestFail is ProposalValidator_I
 
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidAgainstThreshold.selector);
         vm.prank(topDelegate_A);
-        validator.submitUpgradeProposal(zeroThreshold, proposalDescription, attestationUid, proposalType);
+        validator.submitUpgradeProposal(zeroThreshold, proposalDescription, attestationUid, proposalType, CYCLE_NUMBER);
     }
 
     function testFuzz_submitUpgradeProposal_exceedsMaxAgainstThreshold_reverts(uint248 excessiveThreshold) public {
@@ -1900,7 +1952,9 @@ contract ProposalValidator_SubmitUpgradeProposal_TestFail is ProposalValidator_I
 
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidAgainstThreshold.selector);
         vm.prank(topDelegate_A);
-        validator.submitUpgradeProposal(excessiveThreshold, proposalDescription, attestationUid, proposalType);
+        validator.submitUpgradeProposal(
+            excessiveThreshold, proposalDescription, attestationUid, proposalType, CYCLE_NUMBER
+        );
     }
 
     function testFuzz_submitUpgradeProposal_duplicateProposal_reverts(uint8 proposalTypeValue) public {
@@ -1940,7 +1994,9 @@ contract ProposalValidator_SubmitUpgradeProposal_TestFail is ProposalValidator_I
 
         // Submit first proposal
         vm.prank(topDelegate_A);
-        validator.submitUpgradeProposal(againstThreshold, proposalDescription, attestationUid, proposalType);
+        validator.submitUpgradeProposal(
+            againstThreshold, proposalDescription, attestationUid, proposalType, CYCLE_NUMBER
+        );
 
         // Create new attestation for second attempt
         bytes32 secondAttestation = _createApprovedProposerAttestation(topDelegate_B, proposalType);
@@ -1951,7 +2007,9 @@ contract ProposalValidator_SubmitUpgradeProposal_TestFail is ProposalValidator_I
         _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
 
         vm.prank(topDelegate_B);
-        validator.submitUpgradeProposal(againstThreshold, proposalDescription, secondAttestation, proposalType);
+        validator.submitUpgradeProposal(
+            againstThreshold, proposalDescription, secondAttestation, proposalType, CYCLE_NUMBER
+        );
     }
 
     function testFuzz_submitUpgradeProposal_proposalExistsInGovernor_reverts(uint8 proposalTypeValue) public {
@@ -1980,7 +2038,9 @@ contract ProposalValidator_SubmitUpgradeProposal_TestFail is ProposalValidator_I
         _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
 
         vm.prank(topDelegate_A);
-        validator.submitUpgradeProposal(againstThreshold, proposalDescription, attestationUid, proposalType);
+        validator.submitUpgradeProposal(
+            againstThreshold, proposalDescription, attestationUid, proposalType, CYCLE_NUMBER
+        );
     }
 
     function testFuzz_submitUpgradeProposal_attestationNotFromOwner_reverts(address fuzzedAttester) public {
@@ -2007,6 +2067,8 @@ contract ProposalValidator_SubmitUpgradeProposal_TestFail is ProposalValidator_I
 
         vm.expectRevert(ProposalValidator.ProposalValidator_InvalidAttestation.selector);
         vm.prank(topDelegate_A);
-        validator.submitUpgradeProposal(againstThreshold, proposalDescription, invalidAttestation, proposalType);
+        validator.submitUpgradeProposal(
+            againstThreshold, proposalDescription, invalidAttestation, proposalType, CYCLE_NUMBER
+        );
     }
 }

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -288,22 +288,27 @@ contract ProposalValidator_Init is CommonTest {
         proposalTypes[4] = ProposalValidator.ProposalType.CouncilBudget;
 
         ProposalValidator.ProposalTypeData[] memory proposalTypesData = new ProposalValidator.ProposalTypeData[](5);
+        // ProtocolOrGovernorUpgrade
         proposalTypesData[0] = ProposalValidator.ProposalTypeData({
             requiredApprovals: PROPOSAL_REQUIRED_APPROVALS,
             proposalVotingModule: OPTIMISTIC_VOTING_MODULE_ID
         });
+        // MaintenanceUpgrade
         proposalTypesData[1] = ProposalValidator.ProposalTypeData({
-            requiredApprovals: PROPOSAL_REQUIRED_APPROVALS,
+            requiredApprovals: 0,
             proposalVotingModule: OPTIMISTIC_VOTING_MODULE_ID
         });
+        // CouncilMemberElections
         proposalTypesData[2] = ProposalValidator.ProposalTypeData({
             requiredApprovals: PROPOSAL_REQUIRED_APPROVALS,
             proposalVotingModule: APPROVAL_VOTING_MODULE_ID
         });
+        // GovernanceFund
         proposalTypesData[3] = ProposalValidator.ProposalTypeData({
             requiredApprovals: PROPOSAL_REQUIRED_APPROVALS,
             proposalVotingModule: APPROVAL_VOTING_MODULE_ID
         });
+        // CouncilBudget
         proposalTypesData[4] = ProposalValidator.ProposalTypeData({
             requiredApprovals: PROPOSAL_REQUIRED_APPROVALS,
             proposalVotingModule: APPROVAL_VOTING_MODULE_ID

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -965,12 +965,24 @@ contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_TestFail 
         validator.moveToVoteProtocolOrGovernorUpgradeProposal(_againstThreshold, proposalDescription);
     }
 
+    function test_moveToVoteProtocolOrGovernorUpgradeProposal_insufficientApprovals_reverts() public {
+        // Set proposal data approved count to 0 since it is 1 by the approval on the setUp
+        validator.setProposalData(expectedHash, approvedProposer, proposalType, false, 0);
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_InsufficientApprovals.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteProtocolOrGovernorUpgradeProposal(againstThreshold, proposalDescription);
+    }
+
     function test_moveToVoteProtocolOrGovernorUpgradeProposal_proposalAlreadyMovedToVote_reverts() public {
         // Mock the proposal types configurator call
         _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
 
         // Set proposal data movedToVote to true
-        validator.setProposalData(expectedHash, approvedProposer, proposalType, true, 0);
+        validator.setProposalData(expectedHash, approvedProposer, proposalType, true, 1);
 
         vm.expectRevert(IProposalValidator.ProposalValidator_ProposalAlreadyMovedToVote.selector);
         vm.prank(approvedProposer);

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -119,9 +119,9 @@ contract ProposalValidator_Init is CommonTest {
     uint256 public constant CYCLE_NUMBER = 1;
     uint256 public constant START_BLOCK = 1000000;
     uint256 public constant DURATION = 100;
-    uint256 public constant DISTRIBUTION_LIMIT = 10000 ether;
+    uint256 public constant DISTRIBUTION_LIMIT = 20000 ether;
     uint256 public constant DISTRIBUTION_THRESHOLD = 10000 ether;
-    uint256 public constant PROPOSAL_REQUIRED_APPROVALS = 4;
+    uint256 public constant PROPOSAL_REQUIRED_APPROVALS = 1;
     uint256 public constant MINIMUM_VOTING_POWER = 10000 ether;
     uint256 public constant OPTIMISTIC_MODULE_PERCENT_DIVISOR = 10_000;
     uint8 public constant APPROVAL_VOTING_MODULE_ID = 1;
@@ -137,6 +137,9 @@ contract ProposalValidator_Init is CommonTest {
     bytes32 topDelegateAttestation_B;
     bytes32 topDelegateAttestation_C;
     bytes32 topDelegateAttestation_D;
+    address approvedProposer = makeAddr("approvedProposer");
+    bytes32 approvedProposerUpgradeAttestationUid;
+    bytes32 approvedProposerCouncilMemberElectionsAttestationUid;
     address approvalVotingModule;
     address optimisticVotingModule;
 
@@ -308,7 +311,7 @@ contract ProposalValidator_Init is CommonTest {
         return (proposalTypes, proposalTypesData);
     }
 
-    function _constructVotingModuleData(
+    function _constructFundingVotingModuleData(
         string[] memory descriptions,
         address[] memory recipients,
         uint256[] memory amounts,
@@ -402,6 +405,127 @@ contract ProposalValidator_Init is CommonTest {
         return abi.encode(settings);
     }
 
+    /// @notice Helper function to create a proposal for move to vote
+    function _createUpgradeProposalForMoveToVote(
+        address proposer,
+        bytes32 attestationUid,
+        uint248 againstThreshold,
+        string memory proposalDescription
+    )
+        internal
+        returns (bytes32 proposalHash_, bytes memory votingModuleData_)
+    {
+        // Calculate expected proposal hash
+        votingModuleData_ = _constructOptimisticVotingModuleData(againstThreshold);
+        proposalHash_ = validator.hashProposalWithModule(
+            optimisticVotingModule, votingModuleData_, keccak256(bytes(proposalDescription))
+        );
+
+        _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
+
+        // Mock proposalSnapshot to return 0 (proposal doesn't exist in governor)
+        _mockAndExpect(
+            address(governor),
+            abi.encodeCall(IOptimismGovernor.proposalSnapshot, (uint256(proposalHash_))),
+            abi.encode(0)
+        );
+
+        // create proposal
+        vm.prank(proposer);
+        validator.submitUpgradeProposal(
+            againstThreshold,
+            proposalDescription,
+            attestationUid,
+            ProposalValidator.ProposalType.ProtocolOrGovernorUpgrade,
+            CYCLE_NUMBER
+        );
+
+        // approve proposal
+        vm.prank(topDelegate_A);
+        validator.approveProposal(proposalHash_, topDelegateAttestation_A);
+    }
+
+    /// @notice Helper function to create a proposal for move to vote for council elections
+    function _createCouncilElectionProposalForMoveToVote(
+        address proposer,
+        bytes32 attestationUid,
+        uint128 criteriaValue,
+        string[] memory optionsDescriptions,
+        string memory proposalDescription
+    )
+        internal
+        returns (bytes32 proposalHash_, bytes memory votingModuleData_)
+    {
+        votingModuleData_ = _constructCouncilElectionVotingModuleData(optionsDescriptions, criteriaValue);
+        proposalHash_ = validator.hashProposalWithModule(
+            approvalVotingModule, votingModuleData_, keccak256(bytes(proposalDescription))
+        );
+
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        // Mock proposalSnapshot to return 0 (proposal doesn't exist in governor)
+        _mockAndExpect(
+            address(governor),
+            abi.encodeCall(IOptimismGovernor.proposalSnapshot, (uint256(proposalHash_))),
+            abi.encode(0)
+        );
+
+        // create proposal
+        vm.prank(proposer);
+        validator.submitCouncilMemberElectionsProposal(
+            criteriaValue, optionsDescriptions, proposalDescription, attestationUid, CYCLE_NUMBER
+        );
+
+        // approve proposal
+        vm.prank(topDelegate_A);
+        validator.approveProposal(proposalHash_, topDelegateAttestation_A);
+    }
+
+    /// @notice Helper function to create a proposal for move to vote for a funding proposal type
+    function _createFundingProposalForMoveToVote(
+        address proposer,
+        uint128 criteriaValue,
+        string[] memory optionsDescriptions,
+        address[] memory optionsRecipients,
+        uint256[] memory optionsAmounts,
+        string memory proposalDescription,
+        ProposalValidator.ProposalType proposalType
+    )
+        internal
+        returns (bytes32 proposalHash_, bytes memory votingModuleData_)
+    {
+        votingModuleData_ =
+            _constructFundingVotingModuleData(optionsDescriptions, optionsRecipients, optionsAmounts, criteriaValue);
+        proposalHash_ = validator.hashProposalWithModule(
+            approvalVotingModule, votingModuleData_, keccak256(bytes(proposalDescription))
+        );
+
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        // Mock proposalSnapshot to return 0 (proposal doesn't exist in governor)
+        _mockAndExpect(
+            address(governor),
+            abi.encodeCall(IOptimismGovernor.proposalSnapshot, (uint256(proposalHash_))),
+            abi.encode(0)
+        );
+
+        // create proposal
+        vm.prank(proposer);
+        validator.submitFundingProposal(
+            criteriaValue,
+            optionsDescriptions,
+            optionsRecipients,
+            optionsAmounts,
+            proposalDescription,
+            proposalType,
+            CYCLE_NUMBER
+        );
+
+        // approve proposal
+        vm.prank(topDelegate_A);
+        validator.approveProposal(proposalHash_, topDelegateAttestation_A);
+    }
+
     /// @notice Helper function to setup proposal types configurator mocks
     function _mockProposalTypesConfiguratorCall(uint8 _votingModuleId) internal {
         address moduleAddress;
@@ -488,6 +612,13 @@ contract ProposalValidator_Init is CommonTest {
         topDelegateAttestation_B = _createTopDelegateAttestation(topDelegate_B);
         topDelegateAttestation_C = _createTopDelegateAttestation(topDelegate_C);
         topDelegateAttestation_D = _createTopDelegateAttestation(topDelegate_D);
+
+        // Create approved proposer attestations
+        approvedProposerUpgradeAttestationUid = _createApprovedProposerAttestation(
+            approvedProposer, ProposalValidator.ProposalType.ProtocolOrGovernorUpgrade
+        );
+        approvedProposerCouncilMemberElectionsAttestationUid =
+            _createApprovedProposerAttestation(approvedProposer, ProposalValidator.ProposalType.CouncilMemberElections);
     }
 
     /// @notice Helper to create a valid attestation for an approved proposer
@@ -530,26 +661,6 @@ contract ProposalValidator_Init is CommonTest {
                 })
             })
         );
-    }
-
-    /// @notice Helper to create a standard proposal setup
-    function _createProposalSetup()
-        internal
-        view
-        returns (
-            address[] memory targets_,
-            uint256[] memory values_,
-            bytes[] memory calldatas_,
-            string memory description_
-        )
-    {
-        targets_ = new address[](1);
-        targets_[0] = address(0);
-        values_ = new uint256[](1);
-        values_[0] = 0;
-        calldatas_ = new bytes[](1);
-        calldatas_[0] = bytes("");
-        description_ = "Test proposal";
     }
 }
 
@@ -733,109 +844,729 @@ contract ProposalValidator_ApproveProposal_TestFail is ProposalValidator_Init {
     }
 }
 
-// /// @title ProposalValidator_MoveToVote_Test
-// /// @notice Happy path tests for moveToVote function
-// contract ProposalValidator_MoveToVote_Test is ProposalValidator_Init {
-//     address[] targets;
-//     uint256[] values;
-//     bytes[] calldatas;
-//     string description;
-//     ProposalValidator.ProposalType proposalType;
-//     uint8 proposalVotingModule;
+contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_Test is ProposalValidator_Init {
+    uint248 againstThreshold = 5000; // 50%
+    string proposalDescription = "Test proposal";
+    ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType.ProtocolOrGovernorUpgrade;
+    bytes votingModuleData;
+    bytes32 expectedHash;
 
-//     function setUp() public override {
-//         super.setUp();
+    function setUp() public override {
+        super.setUp();
 
-//         (targets, values, calldatas, description) = _createProposalSetup();
+        (expectedHash, votingModuleData) = _createUpgradeProposalForMoveToVote(
+            approvedProposer, approvedProposerUpgradeAttestationUid, againstThreshold, proposalDescription
+        );
+    }
 
-//         proposalType = ProposalValidator.ProposalType.ProtocolOrGovernorUpgrade;
-//         proposalVotingModule = 0;
-//         bytes32 attestationUid = _createApprovedProposerAttestation(topDelegate_A, proposalType);
+    function test_moveToVoteProtocolOrGovernorUpgradeProposal_succeeds() public {
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
 
-//         /* vm.prank(topDelegate_A); */
-//         proposalHash = bytes32(0); // TODO: Implement after submitFundingProposal is implemented
+        // Mock the governor.proposeWithModule call
+        _mockAndExpect(
+            address(governor),
+            abi.encodeCall(
+                IOptimismGovernor.proposeWithModule,
+                (VotingModule(optimisticVotingModule), votingModuleData, proposalDescription, uint8(proposalType))
+            ),
+            abi.encode(uint256(expectedHash))
+        );
 
-//         _approveProposal(topDelegate_A, proposalHash);
-//         _approveProposal(topDelegate_B, proposalHash);
-//         _approveProposal(topDelegate_C, proposalHash);
-//         _approveProposal(topDelegate_D, proposalHash);
-//     }
+        // Expect the ProposalMovedToVote event to be emitted
+        vm.expectEmit(address(validator));
+        emit ProposalMovedToVote(expectedHash, approvedProposer);
 
-//     function test_moveToVote_succeeds() public {
-//         _mockAndExpect(
-//             address(governor),
-//             abi.encodeCall(IOptimismGovernor.propose, (targets, values, calldatas, description,
-// proposalVotingModule)),
-//             abi.encode(1)
-//         );
+        // Move to vote
+        vm.prank(approvedProposer);
+        validator.moveToVoteProtocolOrGovernorUpgradeProposal(againstThreshold, proposalDescription);
 
-//         // Expect the ProposalMovedToVote event to be emitted
-//         vm.expectEmit(address(validator));
-//         emit ProposalMovedToVote(proposalHash, owner);
+        // Check that the proposal is in voting
+        (,, bool inVoting,,) = validator.getProposalData(expectedHash);
+        assertTrue(inVoting, "Proposal should be in voting");
+    }
+}
 
-//         vm.prank(owner);
-//         uint256 governorProposalId = validator.moveToVote(targets, values, calldatas, description);
+contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_TestFail is ProposalValidator_Init {
+    uint248 againstThreshold = 5000; // 50%
+    string proposalDescription = "Test proposal";
+    ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType.ProtocolOrGovernorUpgrade;
+    bytes votingModuleData;
+    bytes32 expectedHash;
 
-//         assertEq(governorProposalId, 1);
-//     }
-// }
+    function setUp() public override {
+        super.setUp();
 
-// /// @title ProposalValidator_MoveToVote_TestFail
-// /// @notice Sad path tests for moveToVote function
-// contract ProposalValidator_MoveToVote_TestFail is ProposalValidator_Init {
-//     address[] targets;
-//     uint256[] values;
-//     bytes[] calldatas;
-//     string description;
-//     ProposalValidator.ProposalType proposalType;
-//     uint8 proposalVotingModule;
+        (expectedHash, votingModuleData) = _createUpgradeProposalForMoveToVote(
+            approvedProposer, approvedProposerUpgradeAttestationUid, againstThreshold, proposalDescription
+        );
+    }
 
-//     function setUp() public override {
-//         super.setUp();
+    function test_moveToVoteProtocolOrGovernorUpgradeProposal_proposalDoesNotExist_wrongCaller_reverts(address _caller)
+        public
+    {
+        vm.assume(_caller != approvedProposer);
 
-//         (targets, values, calldatas, description) = _createProposalSetup();
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
 
-//         proposalType = ProposalValidator.ProposalType.ProtocolOrGovernorUpgrade;
-//         proposalVotingModule = 0;
-//         bytes32 attestationUid = _createApprovedProposerAttestation(topDelegate_A, proposalType);
+        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalDoesNotExist.selector);
+        vm.prank(_caller);
+        validator.moveToVoteProtocolOrGovernorUpgradeProposal(againstThreshold, proposalDescription);
+    }
 
-//         /* vm.prank(topDelegate_A); */
-//         proposalHash = bytes32(0); // TODO: Implement after submitFundingProposal is implemented
-//     }
+    function test_moveToVoteProtocolOrGovernorUpgradeProposal_proposalDoesNotExist_wrongProposalType_reverts(
+        uint248 _againstThreshold
+    )
+        public
+    {
+        // This will generate a different proposal hash which will make the proposal type wrong
+        vm.assume(_againstThreshold != againstThreshold);
 
-//     function test_moveToVote_insufficientApprovals_reverts() public {
-//         // Only approve with 3 delegates (need 4)
-//         _approveProposal(topDelegate_A, proposalHash);
-//         _approveProposal(topDelegate_B, proposalHash);
-//         _approveProposal(topDelegate_C, proposalHash);
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
 
-//         vm.expectRevert(IProposalValidator.ProposalValidator_InsufficientApprovals.selector);
-//         vm.prank(owner);
-//         validator.moveToVote(targets, values, calldatas, description);
-//     }
+        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalDoesNotExist.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteProtocolOrGovernorUpgradeProposal(_againstThreshold, proposalDescription);
+    }
 
-//     function test_moveToVote_alreadyProposed_reverts() public {
-//         // Approve with all 4 delegates
-//         _approveProposal(topDelegate_A, proposalHash);
-//         _approveProposal(topDelegate_B, proposalHash);
-//         _approveProposal(topDelegate_C, proposalHash);
-//         _approveProposal(topDelegate_D, proposalHash);
+    function test_moveToVoteProtocolOrGovernorUpgradeProposal_proposalAlreadyMovedToVote_reverts() public {
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
 
-//         _mockAndExpect(
-//             address(governor),
-//             abi.encodeCall(IOptimismGovernor.propose, (targets, values, calldatas, description,
-// proposalVotingModule)),
-//             abi.encode(1)
-//         );
+        // Set proposal data inVoting to true
+        validator.setProposalData(expectedHash, approvedProposer, proposalType, true, 0);
 
-//         vm.prank(owner);
-//         validator.moveToVote(targets, values, calldatas, description);
+        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalAlreadyMovedToVote.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteProtocolOrGovernorUpgradeProposal(againstThreshold, proposalDescription);
+    }
 
-//         vm.expectRevert(IProposalValidator.ProposalValidator_ProposalAlreadySubmitted.selector);
-//         vm.prank(owner);
-//         validator.moveToVote(targets, values, calldatas, description);
-//     }
-// }
+    function test_moveToVoteProtocolOrGovernorUpgradeProposal_proposalIdMismatch_reverts(bytes32 _randomHash) public {
+        vm.assume(_randomHash != expectedHash);
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
+
+        // Mock the governor.proposeWithModule call
+        _mockAndExpect(
+            address(governor),
+            abi.encodeCall(
+                IOptimismGovernor.proposeWithModule,
+                (VotingModule(optimisticVotingModule), votingModuleData, proposalDescription, uint8(proposalType))
+            ),
+            abi.encode(uint256(_randomHash))
+        );
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalIdMismatch.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteProtocolOrGovernorUpgradeProposal(againstThreshold, proposalDescription);
+    }
+}
+
+contract ProposalValidator_MoveToVoteCouncilMemberElectionsProposal_Test is ProposalValidator_Init {
+    ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType.CouncilMemberElections;
+    uint128 criteriaValue = 1;
+    bytes32 expectedHash;
+    bytes votingModuleData;
+    string proposalDescription = "Test proposal";
+    string[] optionsDescriptions = new string[](2);
+
+    function setUp() public override {
+        super.setUp();
+
+        // Create a proposal for move to vote with 1 top choice and 2 options
+        optionsDescriptions[0] = "Option 1";
+        optionsDescriptions[1] = "Option 2";
+        (expectedHash, votingModuleData) = _createCouncilElectionProposalForMoveToVote(
+            approvedProposer,
+            approvedProposerCouncilMemberElectionsAttestationUid,
+            criteriaValue,
+            optionsDescriptions,
+            proposalDescription
+        );
+    }
+
+    function test_moveToVoteCouncilMemberElectionsProposal_succeeds() public {
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        // Mock the governor.proposeWithModule call
+        _mockAndExpect(
+            address(governor),
+            abi.encodeCall(
+                IOptimismGovernor.proposeWithModule,
+                (VotingModule(approvalVotingModule), votingModuleData, proposalDescription, uint8(proposalType))
+            ),
+            abi.encode(uint256(expectedHash))
+        );
+
+        // Expect the ProposalMovedToVote event to be emitted
+        vm.expectEmit(address(validator));
+        emit ProposalMovedToVote(expectedHash, approvedProposer);
+
+        // Move to vote
+        vm.roll(START_BLOCK + 1);
+        vm.prank(approvedProposer);
+        validator.moveToVoteCouncilMemberElectionsProposal(criteriaValue, optionsDescriptions, proposalDescription);
+
+        // Check that the proposal is in voting
+        (,, bool inVoting,,) = validator.getProposalData(expectedHash);
+        assertTrue(inVoting, "Proposal should be in voting");
+    }
+}
+
+contract ProposalValidator_MoveToVoteCouncilMemberElectionsProposal_TestFail is ProposalValidator_Init {
+    ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType.CouncilMemberElections;
+    uint128 criteriaValue = 1;
+    string proposalDescription = "Test proposal";
+    string[] optionsDescriptions = new string[](2);
+    bytes32 expectedHash;
+    bytes votingModuleData;
+
+    function setUp() public override {
+        super.setUp();
+
+        // Create a proposal for move to vote with 1 top choice and 2 options
+        optionsDescriptions[0] = "Option 1";
+        optionsDescriptions[1] = "Option 2";
+        (expectedHash, votingModuleData) = _createCouncilElectionProposalForMoveToVote(
+            approvedProposer,
+            approvedProposerCouncilMemberElectionsAttestationUid,
+            criteriaValue,
+            optionsDescriptions,
+            proposalDescription
+        );
+    }
+
+    function test_moveToVoteCouncilMemberElectionsProposal_proposalDoesNotExist_wrongCaller_reverts(address _caller)
+        public
+    {
+        vm.assume(_caller != approvedProposer);
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalDoesNotExist.selector);
+        vm.prank(_caller);
+        validator.moveToVoteCouncilMemberElectionsProposal(criteriaValue, optionsDescriptions, proposalDescription);
+    }
+
+    function test_moveToVoteCouncilMemberElectionsProposal_proposalDoesNotExist_wrongProposalType_reverts() public {
+        // This will generate a different proposal hash which will make the proposal type wrong
+        uint128 _criteriaValue = 2; // we use 2 since it is the max based on the created proposal in setUp
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalDoesNotExist.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteCouncilMemberElectionsProposal(_criteriaValue, optionsDescriptions, proposalDescription);
+    }
+
+    function test_moveToVoteCouncilMemberElectionsProposal_insufficientApprovals_reverts() public {
+        // Set proposal data approved count to 0 since it is 1 by the approval on the setUp
+        validator.setProposalData(expectedHash, approvedProposer, proposalType, false, 0);
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_InsufficientApprovals.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteCouncilMemberElectionsProposal(criteriaValue, optionsDescriptions, proposalDescription);
+    }
+
+    function test_moveToVoteCouncilMemberElectionsProposal_proposalAlreadyMovedToVote_reverts() public {
+        // Set proposal data inVoting to true
+        validator.setProposalData(expectedHash, approvedProposer, proposalType, true, 2);
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalAlreadyMovedToVote.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteCouncilMemberElectionsProposal(criteriaValue, optionsDescriptions, proposalDescription);
+    }
+
+    function test_moveToVoteCouncilMemberElectionsProposal_invalidVotingCycle_reverts() public {
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_InvalidVotingCycle.selector);
+        vm.roll(block.number + 101);
+        vm.prank(approvedProposer);
+        validator.moveToVoteCouncilMemberElectionsProposal(criteriaValue, optionsDescriptions, proposalDescription);
+    }
+
+    function test_moveToVoteCouncilMemberElectionsProposal_proposalIdMismatch_reverts(bytes32 _randomHash) public {
+        vm.assume(_randomHash != expectedHash);
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        // Mock the governor.proposeWithModule call
+        _mockAndExpect(
+            address(governor),
+            abi.encodeCall(
+                IOptimismGovernor.proposeWithModule,
+                (VotingModule(approvalVotingModule), votingModuleData, proposalDescription, uint8(proposalType))
+            ),
+            abi.encode(uint256(_randomHash))
+        );
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalIdMismatch.selector);
+        vm.roll(START_BLOCK + 1);
+        vm.prank(approvedProposer);
+        validator.moveToVoteCouncilMemberElectionsProposal(criteriaValue, optionsDescriptions, proposalDescription);
+    }
+}
+
+contract ProposalValidator_MoveToVoteFundingProposal_Test is ProposalValidator_Init {
+    ProposalValidator.ProposalType governanceFundProposalType = ProposalValidator.ProposalType.GovernanceFund;
+    ProposalValidator.ProposalType councilBudgetProposalType = ProposalValidator.ProposalType.CouncilBudget;
+    uint128 criteriaValue = 1;
+    string governanceFundProposalDescription = "Test governance fund proposal";
+    string councilBudgetProposalDescription = "Test council budget proposal";
+    string[] optionsDescriptions = new string[](2);
+    address[] optionsRecipients = new address[](2);
+    uint256[] optionsAmounts = new uint256[](2);
+    bytes32 expectedGovernanceFundHash;
+    bytes32 expectedCouncilBudgetHash;
+    bytes governanceFundVotingModuleData;
+    bytes councilBudgetVotingModuleData;
+
+    function setUp() public override {
+        super.setUp();
+
+        // Create option descriptions for the proposals
+        optionsDescriptions[0] = "Option 1";
+        optionsDescriptions[1] = "Option 2";
+
+        // Create option recipients for the proposals
+        optionsRecipients[0] = makeAddr("optionRecipient1");
+        optionsRecipients[1] = makeAddr("optionRecipient2");
+
+        // Create option amounts for the proposals
+        optionsAmounts[0] = 100 ether;
+        optionsAmounts[1] = 200 ether;
+
+        // Create one proposal for each type
+        (expectedGovernanceFundHash, governanceFundVotingModuleData) = _createFundingProposalForMoveToVote(
+            approvedProposer,
+            criteriaValue,
+            optionsDescriptions,
+            optionsRecipients,
+            optionsAmounts,
+            governanceFundProposalDescription,
+            governanceFundProposalType
+        );
+        (expectedCouncilBudgetHash, councilBudgetVotingModuleData) = _createFundingProposalForMoveToVote(
+            approvedProposer,
+            criteriaValue,
+            optionsDescriptions,
+            optionsRecipients,
+            optionsAmounts,
+            councilBudgetProposalDescription,
+            councilBudgetProposalType
+        );
+    }
+
+    function test_moveToVoteFundingProposal_governanceFund_succeeds() public {
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        // Mock the governor.proposeWithModule call
+        _mockAndExpect(
+            address(governor),
+            abi.encodeCall(
+                IOptimismGovernor.proposeWithModule,
+                (
+                    VotingModule(approvalVotingModule),
+                    governanceFundVotingModuleData,
+                    governanceFundProposalDescription,
+                    uint8(governanceFundProposalType)
+                )
+            ),
+            abi.encode(uint256(expectedGovernanceFundHash))
+        );
+
+        // Expect the ProposalMovedToVote event to be emitted
+        vm.expectEmit(address(validator));
+        emit ProposalMovedToVote(expectedGovernanceFundHash, approvedProposer);
+
+        // Move to vote
+        vm.roll(START_BLOCK + 1);
+        vm.prank(approvedProposer);
+        validator.moveToVoteFundingProposal(
+            criteriaValue,
+            optionsDescriptions,
+            optionsRecipients,
+            optionsAmounts,
+            governanceFundProposalDescription,
+            governanceFundProposalType
+        );
+
+        // Check that the proposal is in voting
+        (,, bool inVoting,,) = validator.getProposalData(expectedGovernanceFundHash);
+        assertTrue(inVoting, "Proposal should be in voting");
+    }
+
+    function test_moveToVoteFundingProposal_councilBudget_succeeds() public {
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        // Mock the governor.proposeWithModule call
+        _mockAndExpect(
+            address(governor),
+            abi.encodeCall(
+                IOptimismGovernor.proposeWithModule,
+                (
+                    VotingModule(approvalVotingModule),
+                    councilBudgetVotingModuleData,
+                    councilBudgetProposalDescription,
+                    uint8(councilBudgetProposalType)
+                )
+            ),
+            abi.encode(uint256(expectedCouncilBudgetHash))
+        );
+
+        // Expect the ProposalMovedToVote event to be emitted
+        vm.expectEmit(address(validator));
+        emit ProposalMovedToVote(expectedCouncilBudgetHash, approvedProposer);
+
+        // Move to vote
+        vm.roll(START_BLOCK + 1);
+        vm.prank(approvedProposer);
+        validator.moveToVoteFundingProposal(
+            criteriaValue,
+            optionsDescriptions,
+            optionsRecipients,
+            optionsAmounts,
+            councilBudgetProposalDescription,
+            councilBudgetProposalType
+        );
+    }
+}
+
+contract ProposalValidator_MoveToVoteFundingProposal_TestFail is ProposalValidator_Init {
+    ProposalValidator.ProposalType governanceFundProposalType = ProposalValidator.ProposalType.GovernanceFund;
+    ProposalValidator.ProposalType councilBudgetProposalType = ProposalValidator.ProposalType.CouncilBudget;
+    uint128 criteriaValue = 1;
+    string governanceFundProposalDescription = "Test governance fund proposal";
+    string councilBudgetProposalDescription = "Test council budget proposal";
+    string[] optionsDescriptions;
+    address[] optionsRecipients;
+    uint256[] optionsAmounts;
+    bytes32 governanceFundExpectedHash;
+    bytes32 councilBudgetExpectedHash;
+    bytes governanceFundVotingModuleData;
+    bytes councilBudgetVotingModuleData;
+
+    function setUp() public override {
+        super.setUp();
+
+        (optionsDescriptions, optionsRecipients, optionsAmounts) = _createMinimalFundingArrays();
+        (governanceFundExpectedHash, governanceFundVotingModuleData) = _createFundingProposalForMoveToVote(
+            approvedProposer,
+            criteriaValue,
+            optionsDescriptions,
+            optionsRecipients,
+            optionsAmounts,
+            governanceFundProposalDescription,
+            governanceFundProposalType
+        );
+        (councilBudgetExpectedHash, councilBudgetVotingModuleData) = _createFundingProposalForMoveToVote(
+            approvedProposer,
+            criteriaValue,
+            optionsDescriptions,
+            optionsRecipients,
+            optionsAmounts,
+            councilBudgetProposalDescription,
+            councilBudgetProposalType
+        );
+    }
+
+    function test_moveToVoteFundingProposal_invalidFundingProposalType_reverts(
+        uint8 _proposalTypeValue,
+        string memory _proposalDescription
+    )
+        public
+    {
+        // Valid funding proposal types are GovernanceFund (3) and CouncilBudget (4)
+        _proposalTypeValue = uint8(bound(_proposalTypeValue, 0, 2));
+        ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType(_proposalTypeValue);
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_InvalidFundingProposalType.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteFundingProposal(
+            criteriaValue, optionsDescriptions, optionsRecipients, optionsAmounts, _proposalDescription, proposalType
+        );
+    }
+
+    function test_moveToVoteFundingProposal_proposalDoesNotExist_reverts(
+        uint8 _proposalTypeValue,
+        uint128 _criteriaValue
+    )
+        public
+    {
+        // Ensure the criteria value is not the same as the one in setUp so when calculating the proposal hash it will
+        // not find the proposal
+        vm.assume(_criteriaValue != criteriaValue);
+
+        // Valid funding proposal types are GovernanceFund (3) and CouncilBudget (4)
+        _proposalTypeValue = uint8(bound(_proposalTypeValue, 3, 4));
+        ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType(_proposalTypeValue);
+
+        string memory proposalDescription;
+        if (proposalType == governanceFundProposalType) {
+            proposalDescription = governanceFundProposalDescription;
+        } else {
+            proposalDescription = councilBudgetProposalDescription;
+        }
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalDoesNotExist.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteFundingProposal(
+            _criteriaValue, optionsDescriptions, optionsRecipients, optionsAmounts, proposalDescription, proposalType
+        );
+    }
+
+    function test_moveToVoteFundingProposal_proposalDoesNotExist_wrongProposalType_reverts(
+        uint8 _wrongProposalTypeValue,
+        uint8 _validProposalTypeValue
+    )
+        public
+    {
+        // Valid funding proposal types are GovernanceFund (3) and CouncilBudget (4)
+        _wrongProposalTypeValue = uint8(bound(_wrongProposalTypeValue, 0, 2));
+        ProposalValidator.ProposalType wrongProposalType = ProposalValidator.ProposalType(_wrongProposalTypeValue);
+
+        _validProposalTypeValue = uint8(bound(_validProposalTypeValue, 3, 4));
+        ProposalValidator.ProposalType validProposalType = ProposalValidator.ProposalType(_validProposalTypeValue);
+
+        string memory proposalDescription;
+        if (validProposalType == governanceFundProposalType) {
+            // Set proposal data proposal type to a different value
+            validator.setProposalData(governanceFundExpectedHash, approvedProposer, wrongProposalType, false, 0);
+            proposalDescription = governanceFundProposalDescription;
+        } else {
+            // Set proposal data proposal type to a different value
+            validator.setProposalData(councilBudgetExpectedHash, approvedProposer, wrongProposalType, false, 0);
+            proposalDescription = councilBudgetProposalDescription;
+        }
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalDoesNotExist.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteFundingProposal(
+            criteriaValue,
+            optionsDescriptions,
+            optionsRecipients,
+            optionsAmounts,
+            proposalDescription,
+            validProposalType
+        );
+    }
+
+    function test_moveToVoteFundingProposal_insufficientApprovals_reverts(uint8 _proposalTypeValue) public {
+        // Valid funding proposal types are GovernanceFund (3) and CouncilBudget (4)
+        _proposalTypeValue = uint8(bound(_proposalTypeValue, 3, 4));
+        ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType(_proposalTypeValue);
+
+        string memory proposalDescription;
+        if (proposalType == governanceFundProposalType) {
+            // Set proposal data approved count to 0 since it is 1 by the approval on the setUp
+            validator.setProposalData(governanceFundExpectedHash, approvedProposer, proposalType, false, 0);
+            proposalDescription = governanceFundProposalDescription;
+        } else {
+            // Set proposal data approved count to 0 since it is 1 by the approval on the setUp
+            validator.setProposalData(councilBudgetExpectedHash, approvedProposer, proposalType, false, 0);
+            proposalDescription = councilBudgetProposalDescription;
+        }
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_InsufficientApprovals.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteFundingProposal(
+            criteriaValue, optionsDescriptions, optionsRecipients, optionsAmounts, proposalDescription, proposalType
+        );
+    }
+
+    function test_moveToVoteFundingProposal_proposalAlreadyMovedToVote_reverts(uint8 _proposalTypeValue) public {
+        // Valid funding proposal types are GovernanceFund (3) and CouncilBudget (4)
+        _proposalTypeValue = uint8(bound(_proposalTypeValue, 3, 4));
+        ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType(_proposalTypeValue);
+
+        string memory proposalDescription;
+        if (proposalType == governanceFundProposalType) {
+            // Set proposal data inVoting to true
+            validator.setProposalData(governanceFundExpectedHash, approvedProposer, proposalType, true, 1);
+            proposalDescription = governanceFundProposalDescription;
+        } else {
+            // Set proposal data inVoting to true
+            validator.setProposalData(councilBudgetExpectedHash, approvedProposer, proposalType, true, 1);
+            proposalDescription = councilBudgetProposalDescription;
+        }
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalAlreadyMovedToVote.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteFundingProposal(
+            criteriaValue, optionsDescriptions, optionsRecipients, optionsAmounts, proposalDescription, proposalType
+        );
+    }
+
+    function test_moveToVoteFundingProposal_invalidVotingCycle_reverts(uint8 _proposalTypeValue) public {
+        // Valid funding proposal types are GovernanceFund (3) and CouncilBudget (4)
+        _proposalTypeValue = uint8(bound(_proposalTypeValue, 3, 4));
+        ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType(_proposalTypeValue);
+
+        string memory proposalDescription;
+        if (proposalType == governanceFundProposalType) {
+            proposalDescription = governanceFundProposalDescription;
+        } else {
+            proposalDescription = councilBudgetProposalDescription;
+        }
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_InvalidVotingCycle.selector);
+        vm.roll(START_BLOCK + 101);
+        vm.prank(approvedProposer);
+        validator.moveToVoteFundingProposal(
+            criteriaValue, optionsDescriptions, optionsRecipients, optionsAmounts, proposalDescription, proposalType
+        );
+    }
+
+    function test_moveToVoteFundingProposal_buildApprovalModuleOptions_exceedsDistributionThreshold_reverts(
+        uint8 _proposalTypeValue
+    )
+        public
+    {
+        // Valid funding proposal types are GovernanceFund (3) and CouncilBudget (4)
+        _proposalTypeValue = uint8(bound(_proposalTypeValue, 3, 4));
+        ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType(_proposalTypeValue);
+
+        string memory proposalDescription;
+        if (proposalType == governanceFundProposalType) {
+            proposalDescription = governanceFundProposalDescription;
+        } else {
+            proposalDescription = councilBudgetProposalDescription;
+        }
+
+        // Set the first option amount to exceed the distribution threshold
+        optionsAmounts[0] = DISTRIBUTION_THRESHOLD + 1;
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_ExceedsDistributionThreshold.selector);
+        vm.prank(approvedProposer);
+        validator.moveToVoteFundingProposal(
+            criteriaValue, optionsDescriptions, optionsRecipients, optionsAmounts, proposalDescription, proposalType
+        );
+    }
+
+    function test_moveToVoteFundingProposal_exceedsDistributionThreshold_reverts(uint8 _proposalTypeValue) public {
+        // Valid funding proposal types are GovernanceFund (3) and CouncilBudget (4)
+        _proposalTypeValue = uint8(bound(_proposalTypeValue, 3, 4));
+        ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType(_proposalTypeValue);
+
+        string memory proposalDescription;
+        if (proposalType == governanceFundProposalType) {
+            proposalDescription = governanceFundProposalDescription;
+        } else {
+            proposalDescription = councilBudgetProposalDescription;
+        }
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        string[] memory _optionsDescriptions = new string[](3);
+        address[] memory _optionsRecipients = new address[](3);
+        uint256[] memory _optionsAmounts = new uint256[](3);
+
+        _optionsDescriptions[0] = "Option 1";
+        _optionsDescriptions[1] = "Option 2";
+        _optionsDescriptions[2] = "Option 3";
+
+        _optionsRecipients[0] = makeAddr("optionRecipient1");
+        _optionsRecipients[1] = makeAddr("optionRecipient2");
+        _optionsRecipients[2] = makeAddr("optionRecipient3");
+
+        _optionsAmounts[0] = DISTRIBUTION_THRESHOLD - 1;
+        _optionsAmounts[1] = DISTRIBUTION_THRESHOLD - 1;
+        _optionsAmounts[2] = DISTRIBUTION_THRESHOLD - 1;
+
+        _createFundingProposalForMoveToVote(
+            approvedProposer,
+            criteriaValue,
+            _optionsDescriptions,
+            _optionsRecipients,
+            _optionsAmounts,
+            proposalDescription,
+            proposalType
+        );
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_ExceedsDistributionThreshold.selector);
+        vm.prank(approvedProposer);
+        vm.roll(START_BLOCK + 1);
+        validator.moveToVoteFundingProposal(
+            criteriaValue, _optionsDescriptions, _optionsRecipients, _optionsAmounts, proposalDescription, proposalType
+        );
+    }
+
+    function test_moveToVoteFundingProposal_proposalIdMismatch_reverts(
+        uint8 _proposalTypeValue,
+        bytes32 _randomHash
+    )
+        public
+    {
+        vm.assume(_randomHash != governanceFundExpectedHash && _randomHash != councilBudgetExpectedHash);
+
+        // Valid funding proposal types are GovernanceFund (3) and CouncilBudget (4)
+        _proposalTypeValue = uint8(bound(_proposalTypeValue, 3, 4));
+        ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType(_proposalTypeValue);
+
+        // Mock the proposal types configurator call
+        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
+
+        bytes memory votingModuleData;
+        string memory proposalDescription;
+        if (proposalType == governanceFundProposalType) {
+            votingModuleData = governanceFundVotingModuleData;
+            proposalDescription = governanceFundProposalDescription;
+        } else {
+            votingModuleData = councilBudgetVotingModuleData;
+            proposalDescription = councilBudgetProposalDescription;
+        }
+
+        // Mock the governor.proposeWithModule call
+        _mockAndExpect(
+            address(governor),
+            abi.encodeCall(
+                IOptimismGovernor.proposeWithModule,
+                (VotingModule(approvalVotingModule), votingModuleData, proposalDescription, uint8(proposalType))
+            ),
+            abi.encode(uint256(_randomHash))
+        );
+
+        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalIdMismatch.selector);
+        vm.roll(START_BLOCK + 1);
+        vm.prank(approvedProposer);
+        validator.moveToVoteFundingProposal(
+            criteriaValue, optionsDescriptions, optionsRecipients, optionsAmounts, proposalDescription, proposalType
+        );
+    }
+}
 
 /// @title ProposalValidator_CanApproveProposal_Test
 /// @notice Tests for the canApproveProposal function
@@ -1054,7 +1785,8 @@ contract ProposalValidator_SubmitFundingProposal_Test is ProposalValidator_Init 
         }
 
         // Calculate expected proposal hash
-        bytes memory votingModuleData = _constructVotingModuleData(descriptions, recipients, amounts, criteriaValue);
+        bytes memory votingModuleData =
+            _constructFundingVotingModuleData(descriptions, recipients, amounts, criteriaValue);
         bytes32 expectedHash =
             validator.hashProposalWithModule(approvalVotingModule, votingModuleData, keccak256(bytes(description)));
 
@@ -1263,7 +1995,7 @@ contract ProposalValidator_SubmitFundingProposal_TestFail is ProposalValidator_I
 
         // Calculate expected proposal hash
         bytes memory votingModuleData =
-            _constructVotingModuleData(descriptions, recipients, amounts, FUNDING_CRITERIA_VALUE);
+            _constructFundingVotingModuleData(descriptions, recipients, amounts, FUNDING_CRITERIA_VALUE);
         bytes32 expectedHash =
             validator.hashProposalWithModule(approvalVotingModule, votingModuleData, keccak256(bytes(description)));
 
@@ -1303,7 +2035,7 @@ contract ProposalValidator_SubmitFundingProposal_TestFail is ProposalValidator_I
 
         // Calculate expected proposal hash
         bytes memory votingModuleData =
-            _constructVotingModuleData(descriptions, recipients, amounts, FUNDING_CRITERIA_VALUE);
+            _constructFundingVotingModuleData(descriptions, recipients, amounts, FUNDING_CRITERIA_VALUE);
         bytes32 expectedHash =
             validator.hashProposalWithModule(approvalVotingModule, votingModuleData, keccak256(bytes(description)));
 

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -82,8 +82,9 @@ contract ProposalValidatorForTest is ProposalValidator {
         )
     {
         ProposalData storage proposal = _proposals[_proposalHash];
-        return
-            (proposal.proposer, proposal.proposalType, proposal.movedToVote, proposal.approvalCount, proposal.votingCycle);
+        return (
+            proposal.proposer, proposal.proposalType, proposal.movedToVote, proposal.approvalCount, proposal.votingCycle
+        );
     }
 
     function setProposalData(
@@ -2502,7 +2503,7 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_TestFail is Prop
         vm.expectRevert(ProposalValidator.ProposalValidator_AttestationRevoked.selector);
         vm.prank(topDelegate_A);
         validator.submitCouncilMemberElectionsProposal(
-            criteriaValue, optionDescriptions, proposalDescription, revocableAttestationUid
+            criteriaValue, optionDescriptions, proposalDescription, revocableAttestationUid, CYCLE_NUMBER
         );
     }
 }
@@ -2876,6 +2877,6 @@ contract ProposalValidator_SubmitUpgradeProposal_TestFail is ProposalValidator_I
 
         vm.expectRevert(ProposalValidator.ProposalValidator_AttestationRevoked.selector);
         vm.prank(topDelegate_A);
-        validator.submitUpgradeProposal(againstThreshold, proposalDescription, attestationUid, proposalType);
+        validator.submitUpgradeProposal(againstThreshold, proposalDescription, attestationUid, proposalType, CYCLE_NUMBER);
     }
 }

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -286,15 +286,15 @@ contract ProposalValidator_Init is CommonTest {
         ProposalValidator.ProposalTypeData[] memory proposalTypesData = new ProposalValidator.ProposalTypeData[](5);
         proposalTypesData[0] = ProposalValidator.ProposalTypeData({
             requiredApprovals: PROPOSAL_REQUIRED_APPROVALS,
-            proposalVotingModule: 0
+            proposalVotingModule: OPTIMISTIC_VOTING_MODULE_ID
         });
         proposalTypesData[1] = ProposalValidator.ProposalTypeData({
             requiredApprovals: PROPOSAL_REQUIRED_APPROVALS,
-            proposalVotingModule: 1
+            proposalVotingModule: OPTIMISTIC_VOTING_MODULE_ID
         });
         proposalTypesData[2] = ProposalValidator.ProposalTypeData({
             requiredApprovals: PROPOSAL_REQUIRED_APPROVALS,
-            proposalVotingModule: 2
+            proposalVotingModule: APPROVAL_VOTING_MODULE_ID
         });
         proposalTypesData[3] = ProposalValidator.ProposalTypeData({
             requiredApprovals: PROPOSAL_REQUIRED_APPROVALS,
@@ -1430,14 +1430,16 @@ contract ProposalValidator_Initialize_Test is ProposalValidator_Init {
             (uint256 requiredApprovals, uint8 proposalVotingModule) = validator.proposalTypesData(proposalTypes[i]);
             assertEq(requiredApprovals, PROPOSAL_REQUIRED_APPROVALS);
 
-            // Both GovernanceFund and CouncilBudget use APPROVAL_VOTING_MODULE_ID
+            // GovernanceFund, CouncilBudget, and CouncilMemberElections use APPROVAL_VOTING_MODULE_ID
             if (
                 proposalTypes[i] == ProposalValidator.ProposalType.GovernanceFund
                     || proposalTypes[i] == ProposalValidator.ProposalType.CouncilBudget
+                    || proposalTypes[i] == ProposalValidator.ProposalType.CouncilMemberElections
             ) {
                 assertEq(proposalVotingModule, APPROVAL_VOTING_MODULE_ID);
             } else {
-                assertEq(proposalVotingModule, uint8(i));
+                // ProtocolOrGovernorUpgrade and MaintenanceUpgrade use OPTIMISTIC_VOTING_MODULE_ID
+                assertEq(proposalVotingModule, OPTIMISTIC_VOTING_MODULE_ID);
             }
         }
     }

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -92,7 +92,8 @@ contract ProposalValidatorForTest is ProposalValidator {
         address _proposer,
         ProposalType _proposalType,
         bool _movedToVote,
-        uint256 _approvalCount
+        uint256 _approvalCount,
+        uint256 _votingCycle
     )
         public
     {
@@ -100,6 +101,7 @@ contract ProposalValidatorForTest is ProposalValidator {
         _proposals[_proposalHash].proposalType = _proposalType;
         _proposals[_proposalHash].movedToVote = _movedToVote;
         _proposals[_proposalHash].approvalCount = _approvalCount;
+        _proposals[_proposalHash].votingCycle = _votingCycle;
     }
 
     function mockApproveProposal(bytes32 _proposalHash, address _delegate) public {
@@ -139,8 +141,6 @@ contract ProposalValidator_Init is CommonTest {
     bytes32 topDelegateAttestation_C;
     bytes32 topDelegateAttestation_D;
     address approvedProposer = makeAddr("approvedProposer");
-    bytes32 approvedProposerUpgradeAttestationUid;
-    bytes32 approvedProposerCouncilMemberElectionsAttestationUid;
     address approvalVotingModule;
     address optimisticVotingModule;
 
@@ -414,7 +414,6 @@ contract ProposalValidator_Init is CommonTest {
     /// @notice Helper function to create a proposal for move to vote
     function _createUpgradeProposalForMoveToVote(
         address proposer,
-        bytes32 attestationUid,
         uint248 againstThreshold,
         string memory proposalDescription
     )
@@ -427,34 +426,13 @@ contract ProposalValidator_Init is CommonTest {
             optimisticVotingModule, votingModuleData_, keccak256(bytes(proposalDescription))
         );
 
-        _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
-
-        // Mock proposalSnapshot to return 0 (proposal doesn't exist in governor)
-        _mockAndExpect(
-            address(governor),
-            abi.encodeCall(IOptimismGovernor.proposalSnapshot, (uint256(proposalHash_))),
-            abi.encode(0)
-        );
-
-        // create proposal
-        vm.prank(proposer);
-        validator.submitUpgradeProposal(
-            againstThreshold,
-            proposalDescription,
-            attestationUid,
-            ProposalValidator.ProposalType.ProtocolOrGovernorUpgrade,
-            CYCLE_NUMBER
-        );
-
-        // approve proposal
-        vm.prank(topDelegate_A);
-        validator.approveProposal(proposalHash_, topDelegateAttestation_A);
+        // 1 vote as default for being able to move to vote
+        validator.setProposalData(proposalHash_, proposer, ProposalValidator.ProposalType.ProtocolOrGovernorUpgrade, false, PROPOSAL_REQUIRED_APPROVALS, CYCLE_NUMBER);
     }
 
     /// @notice Helper function to create a proposal for move to vote for council elections
     function _createCouncilElectionProposalForMoveToVote(
         address proposer,
-        bytes32 attestationUid,
         uint128 criteriaValue,
         string[] memory optionsDescriptions,
         string memory proposalDescription
@@ -467,24 +445,7 @@ contract ProposalValidator_Init is CommonTest {
             approvalVotingModule, votingModuleData_, keccak256(bytes(proposalDescription))
         );
 
-        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
-
-        // Mock proposalSnapshot to return 0 (proposal doesn't exist in governor)
-        _mockAndExpect(
-            address(governor),
-            abi.encodeCall(IOptimismGovernor.proposalSnapshot, (uint256(proposalHash_))),
-            abi.encode(0)
-        );
-
-        // create proposal
-        vm.prank(proposer);
-        validator.submitCouncilMemberElectionsProposal(
-            criteriaValue, optionsDescriptions, proposalDescription, attestationUid, CYCLE_NUMBER
-        );
-
-        // approve proposal
-        vm.prank(topDelegate_A);
-        validator.approveProposal(proposalHash_, topDelegateAttestation_A);
+        validator.setProposalData(proposalHash_, proposer, ProposalValidator.ProposalType.CouncilMemberElections, false, PROPOSAL_REQUIRED_APPROVALS, CYCLE_NUMBER);
     }
 
     /// @notice Helper function to create a proposal for move to vote for a funding proposal type
@@ -506,30 +467,7 @@ contract ProposalValidator_Init is CommonTest {
             approvalVotingModule, votingModuleData_, keccak256(bytes(proposalDescription))
         );
 
-        _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
-
-        // Mock proposalSnapshot to return 0 (proposal doesn't exist in governor)
-        _mockAndExpect(
-            address(governor),
-            abi.encodeCall(IOptimismGovernor.proposalSnapshot, (uint256(proposalHash_))),
-            abi.encode(0)
-        );
-
-        // create proposal
-        vm.prank(proposer);
-        validator.submitFundingProposal(
-            criteriaValue,
-            optionsDescriptions,
-            optionsRecipients,
-            optionsAmounts,
-            proposalDescription,
-            proposalType,
-            CYCLE_NUMBER
-        );
-
-        // approve proposal
-        vm.prank(topDelegate_A);
-        validator.approveProposal(proposalHash_, topDelegateAttestation_A);
+        validator.setProposalData(proposalHash_, proposer, proposalType, false, PROPOSAL_REQUIRED_APPROVALS, CYCLE_NUMBER);
     }
 
     /// @notice Helper function to setup proposal types configurator mocks
@@ -618,13 +556,6 @@ contract ProposalValidator_Init is CommonTest {
         topDelegateAttestation_B = _createTopDelegateAttestation(topDelegate_B);
         topDelegateAttestation_C = _createTopDelegateAttestation(topDelegate_C);
         topDelegateAttestation_D = _createTopDelegateAttestation(topDelegate_D);
-
-        // Create approved proposer attestations
-        approvedProposerUpgradeAttestationUid = _createApprovedProposerAttestation(
-            approvedProposer, ProposalValidator.ProposalType.ProtocolOrGovernorUpgrade
-        );
-        approvedProposerCouncilMemberElectionsAttestationUid =
-            _createApprovedProposerAttestation(approvedProposer, ProposalValidator.ProposalType.CouncilMemberElections);
     }
 
     /// @notice Helper to create a valid attestation for an approved proposer
@@ -682,7 +613,7 @@ contract ProposalValidator_ApproveProposal_Test is ProposalValidator_Init {
         ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType(proposalTypeValue);
 
         // Set mock proposal data of a random proposal in the validator contract
-        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0);
+        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0, CYCLE_NUMBER);
 
         // Expect event to be emitted when approving
         vm.expectEmit(address(validator));
@@ -724,7 +655,7 @@ contract ProposalValidator_ApproveProposal_TestFail is ProposalValidator_Init {
         proposalTypeValue = uint8(bound(proposalTypeValue, 0, 4));
         ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType(proposalTypeValue);
         // set proposal data so that the proposal exists
-        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0);
+        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0, CYCLE_NUMBER);
 
         // Mock the proposal as already approved by the top delegate
         validator.mockApproveProposal(_proposalHash, topDelegate_A);
@@ -761,7 +692,7 @@ contract ProposalValidator_ApproveProposal_TestFail is ProposalValidator_Init {
         );
 
         // set proposal data so that the proposal exists
-        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0);
+        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0, CYCLE_NUMBER);
 
         vm.expectRevert(IProposalValidator.ProposalValidator_InvalidAttestationSchema.selector);
         vm.prank(topDelegate_A);
@@ -773,7 +704,7 @@ contract ProposalValidator_ApproveProposal_TestFail is ProposalValidator_Init {
         proposalTypeValue = uint8(bound(proposalTypeValue, 0, 4));
         ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType(proposalTypeValue);
         // set proposal data so that the proposal exists
-        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0);
+        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0, CYCLE_NUMBER);
 
         // revoke the attestation
         vm.prank(owner);
@@ -806,7 +737,7 @@ contract ProposalValidator_ApproveProposal_TestFail is ProposalValidator_Init {
         );
 
         // Set mock proposal data of a random proposal in the validator contract
-        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0);
+        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0, CYCLE_NUMBER);
 
         // Expect the invalid attestation error to be reverted
         vm.expectRevert(IProposalValidator.ProposalValidator_InvalidAttestation.selector);
@@ -825,7 +756,7 @@ contract ProposalValidator_ApproveProposal_TestFail is ProposalValidator_Init {
         ProposalValidator.ProposalType proposalType = ProposalValidator.ProposalType(proposalTypeValue);
 
         // Set mock proposal data of a random proposal in the validator contract
-        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0);
+        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0, CYCLE_NUMBER);
 
         // create an attestation with partial delegation
         vm.prank(owner);
@@ -869,7 +800,7 @@ contract ProposalValidator_ApproveProposal_TestFail is ProposalValidator_Init {
         );
 
         // Set mock proposal data of a random proposal in the validator contract
-        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0);
+        validator.setProposalData(_proposalHash, topDelegate_A, proposalType, false, 0, CYCLE_NUMBER);
 
         // Expect the invalid attestation error to be reverted when attestation doesn't exist
         vm.expectRevert(IProposalValidator.ProposalValidator_InvalidAttestation.selector);
@@ -889,7 +820,7 @@ contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_Test is P
         super.setUp();
 
         (expectedHash, votingModuleData) = _createUpgradeProposalForMoveToVote(
-            approvedProposer, approvedProposerUpgradeAttestationUid, againstThreshold, proposalDescription
+            approvedProposer, againstThreshold, proposalDescription
         );
     }
 
@@ -932,7 +863,7 @@ contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_TestFail 
         super.setUp();
 
         (expectedHash, votingModuleData) = _createUpgradeProposalForMoveToVote(
-            approvedProposer, approvedProposerUpgradeAttestationUid, againstThreshold, proposalDescription
+            approvedProposer, againstThreshold, proposalDescription
         );
     }
 
@@ -967,7 +898,7 @@ contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_TestFail 
 
     function test_moveToVoteProtocolOrGovernorUpgradeProposal_insufficientApprovals_reverts() public {
         // Set proposal data approved count to 0 since it is 1 by the approval on the setUp
-        validator.setProposalData(expectedHash, approvedProposer, proposalType, false, 0);
+        validator.setProposalData(expectedHash, approvedProposer, proposalType, false, 0, CYCLE_NUMBER);
 
         // Mock the proposal types configurator call
         _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
@@ -982,7 +913,7 @@ contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_TestFail 
         _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
 
         // Set proposal data movedToVote to true
-        validator.setProposalData(expectedHash, approvedProposer, proposalType, true, 1);
+        validator.setProposalData(expectedHash, approvedProposer, proposalType, true, 1, CYCLE_NUMBER);
 
         vm.expectRevert(IProposalValidator.ProposalValidator_ProposalAlreadyMovedToVote.selector);
         vm.prank(approvedProposer);
@@ -1027,7 +958,6 @@ contract ProposalValidator_MoveToVoteCouncilMemberElectionsProposal_Test is Prop
         optionsDescriptions[1] = "Option 2";
         (expectedHash, votingModuleData) = _createCouncilElectionProposalForMoveToVote(
             approvedProposer,
-            approvedProposerCouncilMemberElectionsAttestationUid,
             criteriaValue,
             optionsDescriptions,
             proposalDescription
@@ -1079,7 +1009,6 @@ contract ProposalValidator_MoveToVoteCouncilMemberElectionsProposal_TestFail is 
         optionsDescriptions[1] = "Option 2";
         (expectedHash, votingModuleData) = _createCouncilElectionProposalForMoveToVote(
             approvedProposer,
-            approvedProposerCouncilMemberElectionsAttestationUid,
             criteriaValue,
             optionsDescriptions,
             proposalDescription
@@ -1113,7 +1042,7 @@ contract ProposalValidator_MoveToVoteCouncilMemberElectionsProposal_TestFail is 
 
     function test_moveToVoteCouncilMemberElectionsProposal_insufficientApprovals_reverts() public {
         // Set proposal data approved count to 0 since it is 1 by the approval on the setUp
-        validator.setProposalData(expectedHash, approvedProposer, proposalType, false, 0);
+        validator.setProposalData(expectedHash, approvedProposer, proposalType, false, 0, CYCLE_NUMBER);
 
         // Mock the proposal types configurator call
         _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
@@ -1125,7 +1054,7 @@ contract ProposalValidator_MoveToVoteCouncilMemberElectionsProposal_TestFail is 
 
     function test_moveToVoteCouncilMemberElectionsProposal_proposalAlreadyMovedToVote_reverts() public {
         // Set proposal data movedToVote to true
-        validator.setProposalData(expectedHash, approvedProposer, proposalType, true, 2);
+        validator.setProposalData(expectedHash, approvedProposer, proposalType, true, 2, CYCLE_NUMBER);
 
         // Mock the proposal types configurator call
         _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
@@ -1397,11 +1326,11 @@ contract ProposalValidator_MoveToVoteFundingProposal_TestFail is ProposalValidat
         string memory proposalDescription;
         if (validProposalType == governanceFundProposalType) {
             // Set proposal data proposal type to a different value
-            validator.setProposalData(governanceFundExpectedHash, approvedProposer, wrongProposalType, false, 0);
+            validator.setProposalData(governanceFundExpectedHash, approvedProposer, wrongProposalType, false, 0, CYCLE_NUMBER);
             proposalDescription = governanceFundProposalDescription;
         } else {
             // Set proposal data proposal type to a different value
-            validator.setProposalData(councilBudgetExpectedHash, approvedProposer, wrongProposalType, false, 0);
+            validator.setProposalData(councilBudgetExpectedHash, approvedProposer, wrongProposalType, false, 0, CYCLE_NUMBER);
             proposalDescription = councilBudgetProposalDescription;
         }
 
@@ -1428,11 +1357,11 @@ contract ProposalValidator_MoveToVoteFundingProposal_TestFail is ProposalValidat
         string memory proposalDescription;
         if (proposalType == governanceFundProposalType) {
             // Set proposal data approved count to 0 since it is 1 by the approval on the setUp
-            validator.setProposalData(governanceFundExpectedHash, approvedProposer, proposalType, false, 0);
+            validator.setProposalData(governanceFundExpectedHash, approvedProposer, proposalType, false, 0, CYCLE_NUMBER);
             proposalDescription = governanceFundProposalDescription;
         } else {
             // Set proposal data approved count to 0 since it is 1 by the approval on the setUp
-            validator.setProposalData(councilBudgetExpectedHash, approvedProposer, proposalType, false, 0);
+            validator.setProposalData(councilBudgetExpectedHash, approvedProposer, proposalType, false, 0, CYCLE_NUMBER);
             proposalDescription = councilBudgetProposalDescription;
         }
 
@@ -1454,11 +1383,11 @@ contract ProposalValidator_MoveToVoteFundingProposal_TestFail is ProposalValidat
         string memory proposalDescription;
         if (proposalType == governanceFundProposalType) {
             // Set proposal data movedToVote to true
-            validator.setProposalData(governanceFundExpectedHash, approvedProposer, proposalType, true, 1);
+            validator.setProposalData(governanceFundExpectedHash, approvedProposer, proposalType, true, 1, CYCLE_NUMBER);
             proposalDescription = governanceFundProposalDescription;
         } else {
             // Set proposal data movedToVote to true
-            validator.setProposalData(councilBudgetExpectedHash, approvedProposer, proposalType, true, 1);
+            validator.setProposalData(councilBudgetExpectedHash, approvedProposer, proposalType, true, 1, CYCLE_NUMBER);
             proposalDescription = councilBudgetProposalDescription;
         }
 
@@ -2206,7 +2135,11 @@ contract ProposalValidator_Initialize_Test is ProposalValidator_Init {
         // Verify proposal type data
         for (uint256 i = 0; i < proposalTypes.length; i++) {
             (uint256 requiredApprovals, uint8 proposalVotingModule) = validator.proposalTypesData(proposalTypes[i]);
-            assertEq(requiredApprovals, PROPOSAL_REQUIRED_APPROVALS);
+            if (proposalTypes[i] == ProposalValidator.ProposalType.MaintenanceUpgrade) {
+                assertEq(requiredApprovals, 0);
+            } else {
+                assertEq(requiredApprovals, PROPOSAL_REQUIRED_APPROVALS);
+            }
 
             // GovernanceFund, CouncilBudget, and CouncilMemberElections use APPROVAL_VOTING_MODULE_ID
             if (

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -931,7 +931,7 @@ contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_TestFail 
         );
     }
 
-    function test_moveToVoteProtocolOrGovernorUpgradeProposal_proposalDoesNotExist_wrongCaller_reverts(address _caller)
+    function test_moveToVoteProtocolOrGovernorUpgradeProposal_invalidProposer_reverts(address _caller)
         public
     {
         vm.assume(_caller != approvedProposer);
@@ -939,12 +939,12 @@ contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_TestFail 
         // Mock the proposal types configurator call
         _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
 
-        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalDoesNotExist.selector);
+        vm.expectRevert(IProposalValidator.ProposalValidator_InvalidProposer.selector);
         vm.prank(_caller);
         validator.moveToVoteProtocolOrGovernorUpgradeProposal(againstThreshold, proposalDescription);
     }
 
-    function test_moveToVoteProtocolOrGovernorUpgradeProposal_proposalDoesNotExist_wrongProposalType_reverts(
+    function test_moveToVoteProtocolOrGovernorUpgradeProposal_proposalDoesNotExist_reverts(
         uint248 _againstThreshold
     )
         public
@@ -1069,7 +1069,7 @@ contract ProposalValidator_MoveToVoteCouncilMemberElectionsProposal_TestFail is 
         );
     }
 
-    function test_moveToVoteCouncilMemberElectionsProposal_proposalDoesNotExist_wrongCaller_reverts(address _caller)
+    function test_moveToVoteCouncilMemberElectionsProposal_invalidProposer_reverts(address _caller)
         public
     {
         vm.assume(_caller != approvedProposer);
@@ -1077,12 +1077,12 @@ contract ProposalValidator_MoveToVoteCouncilMemberElectionsProposal_TestFail is 
         // Mock the proposal types configurator call
         _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
 
-        vm.expectRevert(IProposalValidator.ProposalValidator_ProposalDoesNotExist.selector);
+        vm.expectRevert(IProposalValidator.ProposalValidator_InvalidProposer.selector);
         vm.prank(_caller);
         validator.moveToVoteCouncilMemberElectionsProposal(criteriaValue, optionsDescriptions, proposalDescription);
     }
 
-    function test_moveToVoteCouncilMemberElectionsProposal_proposalDoesNotExist_wrongProposalType_reverts() public {
+    function test_moveToVoteCouncilMemberElectionsProposal_proposalDoesNotExist_reverts() public {
         // This will generate a different proposal hash which will make the proposal type wrong
         uint128 _criteriaValue = 2; // we use 2 since it is the max based on the created proposal in setUp
 
@@ -1364,7 +1364,7 @@ contract ProposalValidator_MoveToVoteFundingProposal_TestFail is ProposalValidat
         );
     }
 
-    function test_moveToVoteFundingProposal_proposalDoesNotExist_wrongProposalType_reverts(
+    function test_moveToVoteFundingProposal_proposalDoesNotExistWrongProposalType_reverts(
         uint8 _wrongProposalTypeValue,
         uint8 _validProposalTypeValue
     )
@@ -1478,7 +1478,7 @@ contract ProposalValidator_MoveToVoteFundingProposal_TestFail is ProposalValidat
         );
     }
 
-    function test_moveToVoteFundingProposal_buildApprovalModuleOptions_exceedsDistributionThreshold_reverts(
+    function test_moveToVoteFundingProposal_buildApprovalModuleOptionsExceedsDistributionThreshold_reverts(
         uint8 _proposalTypeValue
     )
         public

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -1128,7 +1128,7 @@ contract ProposalValidator_MoveToVoteCouncilMemberElectionsProposal_TestFail is 
         _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
 
         vm.expectRevert(IProposalValidator.ProposalValidator_InvalidVotingCycle.selector);
-        vm.roll(block.number + 101);
+        vm.roll(block.number + DURATION + 1);
         vm.prank(approvedProposer);
         validator.moveToVoteCouncilMemberElectionsProposal(criteriaValue, optionsDescriptions, proposalDescription);
     }
@@ -1476,7 +1476,7 @@ contract ProposalValidator_MoveToVoteFundingProposal_TestFail is ProposalValidat
         _mockProposalTypesConfiguratorCall(APPROVAL_VOTING_MODULE_ID);
 
         vm.expectRevert(IProposalValidator.ProposalValidator_InvalidVotingCycle.selector);
-        vm.roll(START_BLOCK + 101);
+        vm.roll(START_BLOCK + DURATION + 1);
         vm.prank(approvedProposer);
         validator.moveToVoteFundingProposal(
             criteriaValue, optionsDescriptions, optionsRecipients, optionsAmounts, proposalDescription, proposalType

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -76,28 +76,28 @@ contract ProposalValidatorForTest is ProposalValidator {
         returns (
             address proposer_,
             ProposalType proposalType_,
-            bool inVoting_,
+            bool movedToVote_,
             uint256 approvalCount_,
             uint256 votingCycle_
         )
     {
         ProposalData storage proposal = _proposals[_proposalHash];
         return
-            (proposal.proposer, proposal.proposalType, proposal.inVoting, proposal.approvalCount, proposal.votingCycle);
+            (proposal.proposer, proposal.proposalType, proposal.movedToVote, proposal.approvalCount, proposal.votingCycle);
     }
 
     function setProposalData(
         bytes32 _proposalHash,
         address _proposer,
         ProposalType _proposalType,
-        bool _inVoting,
+        bool _movedToVote,
         uint256 _approvalCount
     )
         public
     {
         _proposals[_proposalHash].proposer = _proposer;
         _proposals[_proposalHash].proposalType = _proposalType;
-        _proposals[_proposalHash].inVoting = _inVoting;
+        _proposals[_proposalHash].movedToVote = _movedToVote;
         _proposals[_proposalHash].approvalCount = _approvalCount;
     }
 
@@ -882,8 +882,8 @@ contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_Test is P
         validator.moveToVoteProtocolOrGovernorUpgradeProposal(againstThreshold, proposalDescription);
 
         // Check that the proposal is in voting
-        (,, bool inVoting,,) = validator.getProposalData(expectedHash);
-        assertTrue(inVoting, "Proposal should be in voting");
+        (,, bool movedToVote,,) = validator.getProposalData(expectedHash);
+        assertTrue(movedToVote, "Proposal should be in voting");
     }
 }
 
@@ -935,7 +935,7 @@ contract ProposalValidator_MoveToVoteProtocolOrGovernorUpgradeProposal_TestFail 
         // Mock the proposal types configurator call
         _mockProposalTypesConfiguratorCall(OPTIMISTIC_VOTING_MODULE_ID);
 
-        // Set proposal data inVoting to true
+        // Set proposal data movedToVote to true
         validator.setProposalData(expectedHash, approvedProposer, proposalType, true, 0);
 
         vm.expectRevert(IProposalValidator.ProposalValidator_ProposalAlreadyMovedToVote.selector);
@@ -1012,8 +1012,8 @@ contract ProposalValidator_MoveToVoteCouncilMemberElectionsProposal_Test is Prop
         validator.moveToVoteCouncilMemberElectionsProposal(criteriaValue, optionsDescriptions, proposalDescription);
 
         // Check that the proposal is in voting
-        (,, bool inVoting,,) = validator.getProposalData(expectedHash);
-        assertTrue(inVoting, "Proposal should be in voting");
+        (,, bool movedToVote,,) = validator.getProposalData(expectedHash);
+        assertTrue(movedToVote, "Proposal should be in voting");
     }
 }
 
@@ -1078,7 +1078,7 @@ contract ProposalValidator_MoveToVoteCouncilMemberElectionsProposal_TestFail is 
     }
 
     function test_moveToVoteCouncilMemberElectionsProposal_proposalAlreadyMovedToVote_reverts() public {
-        // Set proposal data inVoting to true
+        // Set proposal data movedToVote to true
         validator.setProposalData(expectedHash, approvedProposer, proposalType, true, 2);
 
         // Mock the proposal types configurator call
@@ -1208,8 +1208,8 @@ contract ProposalValidator_MoveToVoteFundingProposal_Test is ProposalValidator_I
         );
 
         // Check that the proposal is in voting
-        (,, bool inVoting,,) = validator.getProposalData(expectedGovernanceFundHash);
-        assertTrue(inVoting, "Proposal should be in voting");
+        (,, bool movedToVote,,) = validator.getProposalData(expectedGovernanceFundHash);
+        assertTrue(movedToVote, "Proposal should be in voting");
     }
 
     function test_moveToVoteFundingProposal_councilBudget_succeeds() public {
@@ -1407,11 +1407,11 @@ contract ProposalValidator_MoveToVoteFundingProposal_TestFail is ProposalValidat
 
         string memory proposalDescription;
         if (proposalType == governanceFundProposalType) {
-            // Set proposal data inVoting to true
+            // Set proposal data movedToVote to true
             validator.setProposalData(governanceFundExpectedHash, approvedProposer, proposalType, true, 1);
             proposalDescription = governanceFundProposalDescription;
         } else {
-            // Set proposal data inVoting to true
+            // Set proposal data movedToVote to true
             validator.setProposalData(councilBudgetExpectedHash, approvedProposer, proposalType, true, 1);
             proposalDescription = councilBudgetProposalDescription;
         }
@@ -1818,14 +1818,14 @@ contract ProposalValidator_SubmitFundingProposal_Test is ProposalValidator_Init 
         (
             address storedProposer,
             ProposalValidator.ProposalType storedProposalType,
-            bool inVoting,
+            bool movedToVote,
             uint256 approvalCount,
             uint256 votingCycle
         ) = validator.getProposalData(proposalHash);
 
         assertEq(storedProposer, proposer, "Proposer should match input");
         assertEq(uint8(storedProposalType), uint8(proposalType), "Proposal type should match input");
-        assertFalse(inVoting, "Proposal should not be in voting yet");
+        assertFalse(movedToVote, "Proposal should not be in voting yet");
         assertEq(approvalCount, 0, "Approval count should be 0");
         assertEq(votingCycle, CYCLE_NUMBER, "Voting cycle should match input");
     }
@@ -2279,7 +2279,7 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_Test is Proposal
         (
             address proposer,
             ProposalValidator.ProposalType proposalType,
-            bool inVoting,
+            bool movedToVote,
             uint256 approvalCount,
             uint256 votingCycle
         ) = validator.getProposalData(proposalHash);
@@ -2290,7 +2290,7 @@ contract ProposalValidator_SubmitCouncilMemberElectionsProposal_Test is Proposal
             uint8(ProposalValidator.ProposalType.CouncilMemberElections),
             "Proposal type should be CouncilMemberElections"
         );
-        assertFalse(inVoting, "Proposal should not be in voting yet");
+        assertFalse(movedToVote, "Proposal should not be in voting yet");
         assertEq(approvalCount, 0, "Approval count should be 0");
         assertEq(votingCycle, CYCLE_NUMBER, "Voting cycle should match input");
     }
@@ -2534,14 +2534,14 @@ contract ProposalValidator_SubmitUpgradeProposal_Test is ProposalValidator_Init 
         (
             address storedProposer,
             ProposalValidator.ProposalType storedProposalType,
-            bool inVoting,
+            bool movedToVote,
             uint256 approvalCount,
             uint256 votingCycle
         ) = validator.getProposalData(proposalHash);
 
         assertEq(storedProposer, proposer, "Proposer should match input");
         assertEq(uint8(storedProposalType), uint8(proposalType), "Proposal type should match input");
-        assertTrue(inVoting, "MaintenanceUpgrade should be in voting immediately");
+        assertTrue(movedToVote, "MaintenanceUpgrade should be in voting immediately");
         assertEq(approvalCount, 0, "Approval count should be 0");
         assertEq(votingCycle, CYCLE_NUMBER, "Voting cycle should match input");
     }
@@ -2596,14 +2596,14 @@ contract ProposalValidator_SubmitUpgradeProposal_Test is ProposalValidator_Init 
         (
             address storedProposer,
             ProposalValidator.ProposalType storedProposalType,
-            bool inVoting,
+            bool movedToVote,
             uint256 approvalCount,
             uint256 votingCycle
         ) = validator.getProposalData(proposalHash);
 
         assertEq(storedProposer, proposer, "Proposer should match input");
         assertEq(uint8(storedProposalType), uint8(proposalType), "Proposal type should match input");
-        assertFalse(inVoting, "ProtocolOrGovernorUpgrade should not be in voting yet");
+        assertFalse(movedToVote, "ProtocolOrGovernorUpgrade should not be in voting yet");
         assertEq(approvalCount, 0, "Approval count should be 0");
         assertEq(votingCycle, CYCLE_NUMBER, "Voting cycle should match input");
     }


### PR DESCRIPTION
Closes OPT-781, OPT-896

For Issue 896 : https://github.com/defi-wonderland/optimism/commit/8c9c2d708c342c2b4fab30be966b4c8405deb85d

Also refactored the order of coding blocks in the contract and interface.

There are multiple moveToVote functions instead of 1 this will change in the SPEC however the logic described in the SPEC should be the same.
Some other changes compared to the SPEC to make possible the voting cycle check and voting cycle distribution limit.