### PR TITLE
refactor: modify overhead functions to include transaction data

### DIFF
--- a/packages/contracts-bedrock/interfaces/L2/IGasTank.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IGasTank.sol
@@ -29,31 +29,27 @@ interface IGasTank {
     event WithdrawalFinalized(address indexed from, address indexed to, uint256 amount);
 
     // Errors
-    error MaxDepositExceeded();
     error InvalidOrigin();
     error InvalidPayload();
     error InsufficientBalance();
-    error AlreadyClaimed();
     error MessageNotAuthorized();
     error WithdrawPending();
     error InvalidLength();
 
     // Constants
-    function MAX_DEPOSIT() external pure returns (uint256);
     function WITHDRAWAL_DELAY() external pure returns (uint256);
     function MESSENGER() external pure returns (IL2ToL2CrossDomainMessenger);
 
     // State Variables
     function balanceOf(address) external view returns (uint256);
     function withdrawals(address) external view returns (uint256 timestamp, uint256 amount);
-    function claimed(bytes32) external view returns (bool);
     function authorizedMessages(address, bytes32) external view returns (bool);
 
     // Functions
     function deposit(address _to) external payable;
     function initiateWithdrawal(uint256 _amount) external;
     function finalizeWithdrawal(address _to) external;
-    function authorizeClaim(bytes32 _messageHash) external;
+    function authorizeClaim(bytes32[] calldata _messageHashes) external;
     function relayMessage(
         Identifier calldata _id,
         bytes calldata _sentMessage
@@ -72,5 +68,5 @@ interface IGasTank {
     )
         external
         view
-        returns (uint256 l2Cost_, uint256 l1Cost_);
+        returns (uint256 overhead_);
 }

--- a/packages/contracts-bedrock/interfaces/L2/IGasTank.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IGasTank.sol
@@ -65,5 +65,12 @@ interface IGasTank {
         external
         pure
         returns (bytes32 messageHash_, address relayer_, uint256 relayCost_, bytes32[] memory nestedMessageHashes_);
-    function claimOverhead(uint256 _numHashes, uint256 _baseFee) external pure returns (uint256);
+    function claimOverhead(
+        uint256 _numHashes,
+        uint256 _baseFee,
+        bytes calldata _data
+    )
+        external
+        view
+        returns (uint256 l2Cost_, uint256 l1Cost_);
 }

--- a/packages/contracts-bedrock/src/L2/GasTank.sol
+++ b/packages/contracts-bedrock/src/L2/GasTank.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.25;
 import { ICrossL2Inbox } from "interfaces/L2/ICrossL2Inbox.sol";
 import { IGasTank } from "interfaces/L2/IGasTank.sol";
 import { IL2ToL2CrossDomainMessenger, Identifier } from "interfaces/L2/IL2ToL2CrossDomainMessenger.sol";
+import { IGasPriceOracle } from "interfaces/L2/IGasPriceOracle.sol";
 
 // Libraries
 import { Encoding } from "src/libraries/Encoding.sol";
@@ -26,6 +27,9 @@ contract GasTank is IGasTank {
     /// @notice The cross domain messenger
     IL2ToL2CrossDomainMessenger public constant MESSENGER =
         IL2ToL2CrossDomainMessenger(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
+
+    /// @notice The gas price oracle for L1 cost calculations
+    IGasPriceOracle public constant GAS_PRICE_ORACLE = IGasPriceOracle(Predeploys.GAS_PRICE_ORACLE);
 
     /// @notice The balance of each gas provider
     mapping(address gasProvider => uint256 balance) public balanceOf;
@@ -115,7 +119,8 @@ contract GasTank is IGasTank {
         }
 
         // Get the gas used
-        relayCost_ = _cost(initialGas - gasleft(), block.basefee) + _relayOverhead(nestedMessageHashes_.length);
+        relayCost_ = _cost(initialGas - gasleft(), block.basefee) + _relayOverhead(nestedMessageHashes_.length)
+            + GAS_PRICE_ORACLE.getL1Fee(msg.data);
 
         // Emit the event with the relationship between the origin message and the destination messages
         emit RelayedMessageGasReceipt(messageHash, msg.sender, relayCost_, nestedMessageHashes_);
@@ -152,7 +157,8 @@ contract GasTank is IGasTank {
 
         balanceOf[_gasProvider] -= relayCost;
 
-        uint256 claimCost = _min(balanceOf[_gasProvider], claimOverhead(nestedMessageHashesLength, block.basefee));
+        (uint256 l2ClaimCost, uint256 l1ClaimCost) = claimOverhead(nestedMessageHashesLength, block.basefee, msg.data);
+        uint256 claimCost = _min(balanceOf[_gasProvider], l2ClaimCost + l1ClaimCost);
 
         balanceOf[_gasProvider] -= claimCost;
 
@@ -188,17 +194,43 @@ contract GasTank is IGasTank {
     /// @notice Calculates the overhead of a claim
     /// @param _numHashes The number of destination hashes relayed
     /// @param _baseFee The base fee of the block
-    /// @return overhead_ The overhead cost of the claim transaction in wei
-    function claimOverhead(uint256 _numHashes, uint256 _baseFee) public pure returns (uint256 overhead_) {
-        overhead_ = _cost(151_800 + _numHashes * 23_000, _baseFee);
+    /// @param _data The data of the transaction
+    /// @return l2Cost_ The L2 overhead cost of the claim transaction in wei
+    /// @return l1Cost_ The L1 data availability cost of the claim transaction in wei
+    function claimOverhead(
+        uint256 _numHashes,
+        uint256 _baseFee,
+        bytes calldata _data
+    )
+        public
+        view
+        returns (uint256 l2Cost_, uint256 l1Cost_)
+    {
+        uint256 dynamicCost;
+        uint256 fixedCost;
+
+        if (_numHashes == 0) {
+            fixedCost = 298_000;
+        } else if (_numHashes == 1) {
+            fixedCost = 328_000;
+        } else {
+            fixedCost = 273_600;
+            dynamicCost = 34_800 * _numHashes;
+            dynamicCost += (_numHashes * _numHashes) >> 12;
+        }
+
+        // Calculate L2 and L1 costs separately
+        l2Cost_ = _cost(fixedCost + dynamicCost, _baseFee);
+        l1Cost_ = GAS_PRICE_ORACLE.getL1Fee(_data);
     }
 
     /// @notice Calculates the overhead to emit RelayedMessageGasReceipt
     /// @param _numHashes The number of destination hashes relayed
     /// @return overhead_ The gas cost to emit the event in wei
     function _relayOverhead(uint256 _numHashes) internal view returns (uint256 overhead_) {
-        uint256 memoryExpansionGas = (418 * _numHashes) + ((_numHashes * _numHashes) >> 9);
-        overhead_ = _cost(34_245 + memoryExpansionGas, block.basefee);
+        uint256 dynamicCost = 418 * _numHashes;
+        uint256 fixedCost = 34_300;
+        overhead_ = _cost(fixedCost + dynamicCost, block.basefee);
     }
 
     /// @notice Calculates the cost of gas used in wei

--- a/packages/contracts-bedrock/src/L2/GasTank.sol
+++ b/packages/contracts-bedrock/src/L2/GasTank.sol
@@ -18,9 +18,6 @@ import { SafeSend } from "src/universal/SafeSend.sol";
 contract GasTank is IGasTank {
     using Encoding for uint256;
 
-    /// @notice The maximum amount of funds that can be deposited into the gas tank
-    uint256 public constant MAX_DEPOSIT = 0.01 ether;
-
     /// @notice The delay before a withdrawal can be finalized
     uint256 public constant WITHDRAWAL_DELAY = 7 days;
 
@@ -40,17 +37,11 @@ contract GasTank is IGasTank {
     /// @notice The authorized messages for claiming
     mapping(address gasProvider => mapping(bytes32 messageHash => bool authorized)) public authorizedMessages;
 
-    /// @notice The claimed messages
-    mapping(bytes32 messageHash => bool claimed) public claimed;
-
     /// @notice Deposits funds into the gas tank, from which the relayer can claim the repayment after relaying
     /// @param _to The address to deposit the funds to
     function deposit(address _to) external payable {
-        uint256 newBalance = balanceOf[_to] + msg.value;
+        balanceOf[_to] += msg.value;
 
-        if (newBalance > MAX_DEPOSIT) revert MaxDepositExceeded();
-
-        balanceOf[_to] = newBalance;
         emit Deposit(_to, msg.value);
     }
 
@@ -81,12 +72,13 @@ contract GasTank is IGasTank {
     }
 
     /// @notice Authorizes a message to be claimed by the relayer
-    /// @param _messageHash The hash of the message to authorize
-    function authorizeClaim(bytes32 _messageHash) external {
-        authorizedMessages[msg.sender][_messageHash] = true;
+    /// @param _messageHashes The hashes of the messages to authorize
+    function authorizeClaim(bytes32[] calldata _messageHashes) external {
+        uint256 messageHashesLength = _messageHashes.length;
 
-        bytes32[] memory _messageHashes = new bytes32[](1);
-        _messageHashes[0] = _messageHash;
+        for (uint256 i; i < messageHashesLength; i++) {
+            authorizedMessages[msg.sender][_messageHashes[i]] = true;
+        }
 
         emit AuthorizedClaims(msg.sender, _messageHashes);
     }
@@ -122,7 +114,6 @@ contract GasTank is IGasTank {
         relayCost_ = _cost(initialGas - gasleft(), block.basefee) + _relayOverhead(nestedMessageHashes_.length)
             + GAS_PRICE_ORACLE.getL1Fee(msg.data);
 
-        // Emit the event with the relationship between the origin message and the destination messages
         emit RelayedMessageGasReceipt(messageHash, msg.sender, relayCost_, nestedMessageHashes_);
     }
 
@@ -142,27 +133,23 @@ contract GasTank is IGasTank {
 
         if (!authorizedMessages[_gasProvider][messageHash]) revert MessageNotAuthorized();
 
-        if (claimed[messageHash]) revert AlreadyClaimed();
-
         uint256 nestedMessageHashesLength = nestedMessageHashes.length;
 
-        // Authorize nested messages by the same gas provider
-        for (uint256 i; i < nestedMessageHashesLength; i++) {
-            authorizedMessages[_gasProvider][nestedMessageHashes[i]] = true;
+        if (nestedMessageHashesLength != 0) {
+            for (uint256 i; i < nestedMessageHashesLength; i++) {
+                authorizedMessages[_gasProvider][nestedMessageHashes[i]] = true;
+            }
+            emit AuthorizedClaims(_gasProvider, nestedMessageHashes);
         }
-
-        if (nestedMessageHashesLength != 0) emit AuthorizedClaims(_gasProvider, nestedMessageHashes);
 
         if (balanceOf[_gasProvider] < relayCost) revert InsufficientBalance();
 
-        balanceOf[_gasProvider] -= relayCost;
+        uint256 claimCost =
+            _min(balanceOf[_gasProvider], claimOverhead(nestedMessageHashesLength, block.basefee, msg.data));
 
-        (uint256 l2ClaimCost, uint256 l1ClaimCost) = claimOverhead(nestedMessageHashesLength, block.basefee, msg.data);
-        uint256 claimCost = _min(balanceOf[_gasProvider], l2ClaimCost + l1ClaimCost);
+        balanceOf[_gasProvider] -= relayCost + claimCost;
 
-        balanceOf[_gasProvider] -= claimCost;
-
-        claimed[messageHash] = true;
+        delete authorizedMessages[_gasProvider][messageHash];
 
         new SafeSend{ value: relayCost }(payable(relayer));
 
@@ -195,8 +182,7 @@ contract GasTank is IGasTank {
     /// @param _numHashes The number of destination hashes relayed
     /// @param _baseFee The base fee of the block
     /// @param _data The data of the transaction
-    /// @return l2Cost_ The L2 overhead cost of the claim transaction in wei
-    /// @return l1Cost_ The L1 data availability cost of the claim transaction in wei
+    /// @return overhead_ The overhead cost of the claim transaction in wei
     function claimOverhead(
         uint256 _numHashes,
         uint256 _baseFee,
@@ -204,31 +190,30 @@ contract GasTank is IGasTank {
     )
         public
         view
-        returns (uint256 l2Cost_, uint256 l1Cost_)
+        returns (uint256 overhead_)
     {
         uint256 dynamicCost;
         uint256 fixedCost;
 
         if (_numHashes == 0) {
-            fixedCost = 298_000;
+            fixedCost = 274_000;
         } else if (_numHashes == 1) {
-            fixedCost = 328_000;
+            fixedCost = 304_600;
         } else {
-            fixedCost = 273_600;
+            fixedCost = 249_000;
             dynamicCost = 34_800 * _numHashes;
             dynamicCost += (_numHashes * _numHashes) >> 12;
         }
 
         // Calculate L2 and L1 costs separately
-        l2Cost_ = _cost(fixedCost + dynamicCost, _baseFee);
-        l1Cost_ = GAS_PRICE_ORACLE.getL1Fee(_data);
+        overhead_ = _cost(fixedCost + dynamicCost, _baseFee) + GAS_PRICE_ORACLE.getL1Fee(_data);
     }
 
     /// @notice Calculates the overhead to emit RelayedMessageGasReceipt
     /// @param _numHashes The number of destination hashes relayed
     /// @return overhead_ The gas cost to emit the event in wei
     function _relayOverhead(uint256 _numHashes) internal view returns (uint256 overhead_) {
-        uint256 dynamicCost = 418 * _numHashes;
+        uint256 dynamicCost = 417 * _numHashes;
         uint256 fixedCost = 34_300;
         overhead_ = _cost(fixedCost + dynamicCost, block.basefee);
     }


### PR DESCRIPTION
## Gas Overhead Functions Analysis

`claimOverhead` Function
This function calculates the estimated gas cost for executing a claim transaction. The calculation varies based on the number of nested message hashes (_numHashes):
- 0 hashes: Fixed cost of 298,000 gas
- 1 hash: Fixed cost of 328,000 gas
- 2+ hashes: Fixed cost of 273,600 + dynamic cost of 34,800 per hash
The key factor affecting gas calculation is the for loop in the claim function that iterates through nested messages to authorize them. Each iteration adds computational overhead, which is why the dynamic cost increases linearly with the number of nested messages.
The function returns both L2 cost (computational gas) and L1 cost (data availability via GAS_PRICE_ORACLE.getL1Fee()).

`relayOverhead` Function
This function calculates the gas cost for emitting the RelayedMessageGasReceipt event during message relay:
- Fixed cost: 34,300 gas
- Dynamic cost: 418 gas per destination hash
The overhead accounts for the event emission that logs the relationship between origin and destination messages.

![image](https://github.com/user-attachments/assets/59dc6331-e9aa-4d8b-b5e1-8a7d9c6b3565)
![image](https://github.com/user-attachments/assets/2d624e1c-f696-44fd-acf1-d2829aa482ac)

### Graph Interpretation
- Positive values: Overpaying (calculated cost > actual cost)
- Negative values: Underpaying (calculated cost < actual cost)
- Claim overhead shows higher variance due to nested message complexity
- Relay overhead shows more predictable convergence to accurate estimates