### PR TITLE
refactor: fetch proposal types configurator externally

### DIFF
--- a/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
+++ b/packages/contracts-bedrock/interfaces/governance/IProposalValidator.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 // Interfaces
 import {IOptimismGovernor} from './IOptimismGovernor.sol';
 import { ISemver } from "interfaces/universal/ISemver.sol";
-import { IProposalTypesConfigurator } from './IProposalTypesConfigurator.sol';
 
 /// @title IProposalValidator
 /// @notice Interface for the ProposalValidator contract.
@@ -167,7 +166,6 @@ interface IProposalValidator is ISemver {
 
     function initialize(
         address _owner,
-        IProposalTypesConfigurator _proposalTypesConfigurator,
         uint256 _cycleNumber,
         uint256 _startingTimestamp,
         uint256 _duration,
@@ -194,8 +192,6 @@ interface IProposalValidator is ISemver {
     function TOP_DELEGATES_ATTESTATION_SCHEMA_UID() external view returns (bytes32);
 
     function OPTIMISTIC_MODULE_PERCENT_DIVISOR() external view returns (uint256);
-
-    function proposalTypesConfigurator() external view returns (IProposalTypesConfigurator);
 
     function proposalTypesData(ProposalType) external view returns (uint256 requiredApprovals, uint8 proposalVotingModule);
 

--- a/packages/contracts-bedrock/snapshots/abi/ProposalValidator.json
+++ b/packages/contracts-bedrock/snapshots/abi/ProposalValidator.json
@@ -135,11 +135,6 @@
         "type": "address"
       },
       {
-        "internalType": "contract IProposalTypesConfigurator",
-        "name": "_proposalTypesConfigurator",
-        "type": "address"
-      },
-      {
         "internalType": "uint256",
         "name": "_cycleNumber",
         "type": "uint256"
@@ -310,19 +305,6 @@
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "proposalTypesConfigurator",
-    "outputs": [
-      {
-        "internalType": "contract IProposalTypesConfigurator",
-        "name": "",
-        "type": "address"
       }
     ],
     "stateMutability": "view",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -176,8 +176,8 @@
     "sourceCodeHash": "0x18f43b227decd0f2a895b8b55e23fa6a47706697c272bbf2482b3f912be446e1"
   },
   "src/governance/ProposalValidator.sol:ProposalValidator": {
-    "initCodeHash": "0x06a2b713907a4a4c961061edeb8f9417f9fdf63fc5512e6794af67fcc548935d",
-    "sourceCodeHash": "0x98cb001a29058d9d4bdd017c73e3520af1e22e9dee15e153799196b3390923df"
+    "initCodeHash": "0xb612561f3182537796ec6bae6a15a4f6b9e63d839e051a165f6b81b3f6ce0807",
+    "sourceCodeHash": "0xbfb241a7033264d5b7097a4326a415b53514c4a4dee01430bd092fa6cbf0872b"
   },
   "src/legacy/DeployerWhitelist.sol:DeployerWhitelist": {
     "initCodeHash": "0x53099379ed48b87f027d55712dbdd1da7d7099925426eb0531da9c0012e02c29",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -176,8 +176,8 @@
     "sourceCodeHash": "0x18f43b227decd0f2a895b8b55e23fa6a47706697c272bbf2482b3f912be446e1"
   },
   "src/governance/ProposalValidator.sol:ProposalValidator": {
-    "initCodeHash": "0xe7a93826772bf108a21923f7e45b1f46cdadb75e48b0c796e43d64f0c1d81504",
-    "sourceCodeHash": "0xadd8e049bf3c652af123b6c64a1d504c92be13b4797ab10b978df907b05dcf7f"
+    "initCodeHash": "0xb6cfa69e3c246f8d7f559e4b772064f20d18a67f9490775d4d3b7fb880215b10",
+    "sourceCodeHash": "0xe46af2e5987f2ace865ee3984bc06e74b3b862fca3afdf845140cfb44083f598"
   },
   "src/legacy/DeployerWhitelist.sol:DeployerWhitelist": {
     "initCodeHash": "0x53099379ed48b87f027d55712dbdd1da7d7099925426eb0531da9c0012e02c29",

--- a/packages/contracts-bedrock/snapshots/storageLayout/ProposalValidator.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/ProposalValidator.json
@@ -35,38 +35,31 @@
     "type": "uint256[49]"
   },
   {
-    "bytes": "20",
-    "label": "proposalTypesConfigurator",
-    "offset": 0,
-    "slot": "101",
-    "type": "contract IProposalTypesConfigurator"
-  },
-  {
     "bytes": "32",
     "label": "proposalDistributionThreshold",
     "offset": 0,
-    "slot": "102",
+    "slot": "101",
     "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "votingCycles",
     "offset": 0,
-    "slot": "103",
+    "slot": "102",
     "type": "mapping(uint256 => struct ProposalValidator.VotingCycleData)"
   },
   {
     "bytes": "32",
     "label": "proposalTypesData",
     "offset": 0,
-    "slot": "104",
+    "slot": "103",
     "type": "mapping(enum ProposalValidator.ProposalType => struct ProposalValidator.ProposalTypeData)"
   },
   {
     "bytes": "32",
     "label": "_proposals",
     "offset": 0,
-    "slot": "105",
+    "slot": "104",
     "type": "mapping(bytes32 => struct ProposalValidator.ProposalData)"
   }
 ]

--- a/packages/contracts-bedrock/src/governance/ProposalValidator.sol
+++ b/packages/contracts-bedrock/src/governance/ProposalValidator.sol
@@ -332,8 +332,9 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         bytes memory proposalVotingModuleData = abi.encode(optimisticSettings);
 
         // Get the optimistic module address from configurator
-        address votingModule =
-            IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(proposalTypesData[_proposalType].proposalVotingModule).module;
+        address votingModule = IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(
+            proposalTypesData[_proposalType].proposalVotingModule
+        ).module;
 
         // Generate unique proposal hash
         proposalHash_ =
@@ -506,8 +507,9 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         bytes memory proposalVotingModuleData = abi.encode(options, settings);
 
         // Get the module address from the configurator
-        address votingModule =
-            IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(proposalTypesData[_proposalType].proposalVotingModule).module;
+        address votingModule = IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(
+            proposalTypesData[_proposalType].proposalVotingModule
+        ).module;
 
         // Generate unique proposal hash
         proposalHash_ = _hashProposalWithModule(votingModule, proposalVotingModuleData, keccak256(bytes(_description)));
@@ -662,8 +664,9 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         // Get the module address from the configurator
         ProposalType proposalType = ProposalType.CouncilMemberElections;
-        address votingModule =
-            IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(proposalTypesData[proposalType].proposalVotingModule).module;
+        address votingModule = IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(
+            proposalTypesData[proposalType].proposalVotingModule
+        ).module;
 
         // Generate unique proposal hash
         proposalHash_ =
@@ -760,8 +763,9 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         bytes memory proposalVotingModuleData = abi.encode(options, settings);
 
         // Get the module address from the configurator
-        address votingModule =
-            IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(proposalTypesData[_proposalType].proposalVotingModule).module;
+        address votingModule = IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(
+            proposalTypesData[_proposalType].proposalVotingModule
+        ).module;
 
         // Generate unique proposal hash
         proposalHash_ = _hashProposalWithModule(votingModule, proposalVotingModuleData, keccak256(bytes(_description)));

--- a/packages/contracts-bedrock/src/governance/ProposalValidator.sol
+++ b/packages/contracts-bedrock/src/governance/ProposalValidator.sol
@@ -217,9 +217,6 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @notice The Optimism Governor contract that will handle the voting phase.
     IOptimismGovernor public immutable GOVERNOR;
 
-    /// @notice The proposal types configurator contract.
-    IProposalTypesConfigurator public proposalTypesConfigurator;
-
     /// @notice The max amount of tokens that can be distributed in a proposal.
     uint256 public proposalDistributionThreshold;
 
@@ -258,7 +255,6 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
     /// @notice Initializes the ProposalValidator contract.
     /// @param _owner The address that will own the contract.
-    /// @param _proposalTypesConfigurator The proposal types configurator contract address.
     /// @param _cycleNumber The number of the current voting cycle.
     /// @param _startingTimestamp The starting timestamp of the voting cycle.
     /// @param _duration The duration of the voting cycle.
@@ -268,7 +264,6 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @param _proposalTypesData Array of proposal type data corresponding to the proposal types.
     function initialize(
         address _owner,
-        IProposalTypesConfigurator _proposalTypesConfigurator,
         uint256 _cycleNumber,
         uint256 _startingTimestamp,
         uint256 _duration,
@@ -284,7 +279,6 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
             revert ProposalValidator_ProposalTypesDataLengthMismatch();
         }
 
-        proposalTypesConfigurator = _proposalTypesConfigurator;
         _setVotingCycleData(_cycleNumber, _startingTimestamp, _duration, _votingCycleDistributionLimit);
         _setProposalDistributionThreshold(_proposalDistributionThreshold);
 
@@ -339,7 +333,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         // Get the optimistic module address from configurator
         address votingModule =
-            proposalTypesConfigurator.proposalTypes(proposalTypesData[_proposalType].proposalVotingModule).module;
+            IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(proposalTypesData[_proposalType].proposalVotingModule).module;
 
         // Generate unique proposal hash
         proposalHash_ =
@@ -425,7 +419,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         bytes memory proposalVotingModuleData = abi.encode(options, settings);
 
         // Get the module address from the configurator
-        address votingModule = proposalTypesConfigurator.proposalTypes(
+        address votingModule = IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(
             proposalTypesData[ProposalType.CouncilMemberElections].proposalVotingModule
         ).module;
 
@@ -513,7 +507,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         // Get the module address from the configurator
         address votingModule =
-            proposalTypesConfigurator.proposalTypes(proposalTypesData[_proposalType].proposalVotingModule).module;
+            IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(proposalTypesData[_proposalType].proposalVotingModule).module;
 
         // Generate unique proposal hash
         proposalHash_ = _hashProposalWithModule(votingModule, proposalVotingModuleData, keccak256(bytes(_description)));
@@ -593,7 +587,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         // Get the module address from the configurator
         ProposalType proposalType = ProposalType.ProtocolOrGovernorUpgrade;
-        address votingModule = proposalTypesConfigurator.proposalTypes(
+        address votingModule = IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(
             proposalTypesData[ProposalType.ProtocolOrGovernorUpgrade].proposalVotingModule
         ).module;
 
@@ -669,7 +663,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
         // Get the module address from the configurator
         ProposalType proposalType = ProposalType.CouncilMemberElections;
         address votingModule =
-            proposalTypesConfigurator.proposalTypes(proposalTypesData[proposalType].proposalVotingModule).module;
+            IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(proposalTypesData[proposalType].proposalVotingModule).module;
 
         // Generate unique proposal hash
         proposalHash_ =
@@ -767,7 +761,7 @@ contract ProposalValidator is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         // Get the module address from the configurator
         address votingModule =
-            proposalTypesConfigurator.proposalTypes(proposalTypesData[_proposalType].proposalVotingModule).module;
+            IProposalTypesConfigurator(GOVERNOR.PROPOSAL_TYPES_CONFIGURATOR()).proposalTypes(proposalTypesData[_proposalType].proposalVotingModule).module;
 
         // Generate unique proposal hash
         proposalHash_ = _hashProposalWithModule(votingModule, proposalVotingModuleData, keccak256(bytes(_description)));

--- a/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
+++ b/packages/contracts-bedrock/test/governance/ProposalValidator.t.sol
@@ -465,6 +465,12 @@ contract ProposalValidator_Init is CommonTest {
         }
 
         _mockAndExpect(
+            address(governor),
+            abi.encodeCall(IOptimismGovernor.PROPOSAL_TYPES_CONFIGURATOR, ()),
+            abi.encode(proposalTypesConfigurator)
+        );
+
+        _mockAndExpect(
             address(proposalTypesConfigurator),
             abi.encodeCall(IProposalTypesConfigurator.proposalTypes, (_votingModuleId)),
             abi.encode(
@@ -501,7 +507,6 @@ contract ProposalValidator_Init is CommonTest {
                 impl.initialize,
                 (
                     owner,
-                    proposalTypesConfigurator,
                     CYCLE_NUMBER,
                     START_TIMESTAMP,
                     DURATION,
@@ -619,7 +624,6 @@ contract ProposalValidator_Initialize_Test is ProposalValidator_Init {
                 impl.initialize,
                 (
                     owner,
-                    proposalTypesConfigurator,
                     CYCLE_NUMBER,
                     START_TIMESTAMP,
                     DURATION,
@@ -691,7 +695,6 @@ contract ProposalValidator_Initialize_Test is ProposalValidator_Init {
                 impl.initialize,
                 (
                     owner,
-                    proposalTypesConfigurator,
                     CYCLE_NUMBER,
                     START_TIMESTAMP,
                     DURATION,


### PR DESCRIPTION
Closes OPT-938
Fixes [L-2] ProposalValidator should fetch the ProposalConfigurator from the OptimismGovernor .