### PR TITLE
refactor(cgt): move cgt flag to portal

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -89,10 +89,12 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     function initialize(
         ISystemConfig _systemConfig,
         IAnchorStateRegistry _anchorStateRegistry,
-        IETHLockbox _ethLockbox
+        IETHLockbox _ethLockbox,
+        bool _isCustomGasToken
     )
         external;
     function initVersion() external view returns (uint8);
+    function isCustomGasToken() external view returns (bool);
     function l2Sender() external view returns (address);
     function minimumGasLimit(uint64 _byteCount) external pure returns (uint64);
     function numProofSubmitters(bytes32 _withdrawalHash) external view returns (uint256);

--- a/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
+++ b/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
@@ -58,8 +58,7 @@ interface ISystemConfig is IProxyAdminOwnedBase {
         address _batchInbox,
         Addresses memory _addresses,
         uint256 _l2ChainId,
-        ISuperchainConfig _superchainConfig,
-        bool _isCustomGasToken
+        ISuperchainConfig _superchainConfig
     )
         external;
     function initVersion() external view returns (uint8);

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
@@ -299,11 +299,29 @@
         "internalType": "contract IETHLockbox",
         "name": "_ethLockbox",
         "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isCustomGasToken",
+        "type": "bool"
       }
     ],
     "name": "initialize",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isCustomGasToken",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
@@ -406,11 +406,6 @@
         "internalType": "contract ISuperchainConfig",
         "name": "_superchainConfig",
         "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "_isCustomGasToken",
-        "type": "bool"
       }
     ],
     "name": "initialize",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -21,15 +21,15 @@
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
     "initCodeHash": "0xb86dcf914d22c5f3871544ba71013e5137e9cfbc7d5359702b9220eb06628d7d",
-    "sourceCodeHash": "0x2dec26f399d4c164905ab5f60e7c4a8a27bb6ba32080df534802c976eb48e607"
+    "sourceCodeHash": "0xf8096cb7493b92c4d9631dbea6462f51b604ee4c7f98a3593100b157bb01b442"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0x4c9b9f7888ce14a672dae0f24af9cf20627b1629b5075a364ad17f4db0d06a70",
     "sourceCodeHash": "0xb65ed0b9cc62c13a053f1b416792802269be37409df917c31e1140f064cf1073"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0xb1d8fd9016739d0b366accf2fbd396087b26744fef41e127e9931b6fdf2865da",
-    "sourceCodeHash": "0x6175f24fbfb70f97ab9083064b80fb234b0178f6aae7f3b26fb3b56559646315"
+    "initCodeHash": "0x308b65ecfb2cb74b06eb6ca32d3a54dc711b1e15b54bc5d510e39e1dcb91b99e",
+    "sourceCodeHash": "0x4bea9142f873f99bb44fdb50ed7e65041cc98f9b1c328d5e3812666d5e981ac9"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
     "initCodeHash": "0x5a76c8530cb24cf23d3baacc6eefaac226382af13f1e2a35535d2ec2b0573b29",
@@ -40,8 +40,8 @@
     "sourceCodeHash": "0xad12c20a00dc20683bd3f68e6ee254f968da6cc2d98930be6534107ee5cb11d9"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0x2819aa4558b13a3091e9b65a892ff7ba16e53ba66530c28bb573efcd0561dc41",
-    "sourceCodeHash": "0xe57b4110614f269804638fa4a3448cf57ed46f4f4ca43c66dfcdd6414e1d5513"
+    "initCodeHash": "0x31ee221cef680b15cc25013ae2142bef541c26b2ecc7665ec28fd4585f469cad",
+    "sourceCodeHash": "0xb53da5831a507d1ce896b18b3b2cd9091afa7200b9a0b3dea06f7475660cfd95"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x9b664e3d84ad510091337b4aacaa494b142512e2f6f7fbcdb6210ed62ca9b885",

--- a/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal2.json
@@ -145,5 +145,12 @@
     "offset": 20,
     "slot": "63",
     "type": "bool"
+  },
+  {
+    "bytes": "1",
+    "label": "isCustomGasToken",
+    "offset": 21,
+    "slot": "63",
+    "type": "bool"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/SystemConfig.json
@@ -124,12 +124,5 @@
     "offset": 0,
     "slot": "108",
     "type": "contract ISuperchainConfig"
-  },
-  {
-    "bytes": "1",
-    "label": "isCustomGasToken",
-    "offset": 20,
-    "slot": "108",
-    "type": "bool"
   }
 ]

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1077,7 +1077,7 @@ contract OPContractsManagerDeployer is OPContractsManagerBase {
             output.opChainProxyAdmin, address(output.l1ERC721BridgeProxy), implementation.l1ERC721BridgeImpl, data
         );
 
-        data = encodeOptimismPortalInitializer(output);
+        data = encodeOptimismPortalInitializer(output, _input);
         upgradeToAndCall(
             output.opChainProxyAdmin, address(output.optimismPortalProxy), implementation.optimismPortalImpl, data
         );
@@ -1229,7 +1229,10 @@ contract OPContractsManagerDeployer is OPContractsManagerBase {
     }
 
     /// @notice Helper method for encoding the OptimismPortal initializer data.
-    function encodeOptimismPortalInitializer(OPContractsManager.DeployOutput memory _output)
+    function encodeOptimismPortalInitializer(
+        OPContractsManager.DeployOutput memory _output,
+        OPContractsManager.DeployInput memory _input
+    )
         internal
         view
         virtual
@@ -1237,7 +1240,12 @@ contract OPContractsManagerDeployer is OPContractsManagerBase {
     {
         return abi.encodeCall(
             IOptimismPortal.initialize,
-            (_output.systemConfigProxy, _output.anchorStateRegistryProxy, _output.ethLockboxProxy)
+            (
+                _output.systemConfigProxy,
+                _output.anchorStateRegistryProxy,
+                _output.ethLockboxProxy,
+                _input.isCustomGasToken
+            )
         );
     }
 
@@ -1296,8 +1304,7 @@ contract OPContractsManagerDeployer is OPContractsManagerBase {
                 chainIdToBatchInboxAddress(_input.l2ChainId),
                 opChainAddrs,
                 _input.l2ChainId,
-                _superchainConfig,
-                _input.isCustomGasToken
+                _superchainConfig
             )
         );
     }

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -125,6 +125,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @notice Whether the OptimismPortal is using Super Roots or Output Roots.
     bool public superRootsActive;
 
+    /// @notice Whether the gas token is custom.
+    bool public isCustomGasToken;
+
     /// @notice Emitted when a transaction is deposited from L1 to L2. The parameters of this event
     ///         are read by the rollup node and used to derive deposit transactions on L2.
     /// @param from       Address that triggered the deposit transaction.
@@ -250,10 +253,12 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @param _systemConfig Address of the SystemConfig.
     /// @param _anchorStateRegistry Address of the AnchorStateRegistry.
     /// @param _ethLockbox Contract of the ETHLockbox.
+    /// @param _isCustomGasToken Whether the gas token is custom.
     function initialize(
         ISystemConfig _systemConfig,
         IAnchorStateRegistry _anchorStateRegistry,
-        IETHLockbox _ethLockbox
+        IETHLockbox _ethLockbox,
+        bool _isCustomGasToken
     )
         external
         reinitializer(initVersion())
@@ -265,6 +270,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         systemConfig = _systemConfig;
         anchorStateRegistry = _anchorStateRegistry;
         ethLockbox = _ethLockbox;
+        isCustomGasToken = _isCustomGasToken;
 
         // Set the l2Sender slot, only if it is currently empty. This signals the first
         // initialization of the contract.
@@ -753,7 +759,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     {
         // Handle ETH deposits: prevent when custom gas token is active, otherwise lock in ETHLockbox.
         if (msg.value > 0) {
-            if (systemConfig.isCustomGasToken()) {
+            if (isCustomGasToken) {
                 revert OptimismPortal_NotAllowedOnCGTMode();
             }
             ethLockbox.lockETH{ value: msg.value }();

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -135,9 +135,6 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     /// @notice The SuperchainConfig contract that manages the pause state.
     ISuperchainConfig public superchainConfig;
 
-    /// @notice Whether the gas token is custom.
-    bool public isCustomGasToken;
-
     /// @notice Emitted when configuration is updated.
     /// @param version    SystemConfig version.
     /// @param updateType Type of update.
@@ -183,8 +180,7 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
         address _batchInbox,
         SystemConfig.Addresses memory _addresses,
         uint256 _l2ChainId,
-        ISuperchainConfig _superchainConfig,
-        bool _isCustomGasToken
+        ISuperchainConfig _superchainConfig
     )
         public
         reinitializer(initVersion())
@@ -196,28 +192,25 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
         __Ownable_init();
         transferOwnership(_owner);
 
-        isCustomGasToken = _isCustomGasToken;
+        // These are set in ascending order of their UpdateTypes.
+        _setBatcherHash(_batcherHash);
+        _setGasConfigEcotone({ _basefeeScalar: _basefeeScalar, _blobbasefeeScalar: _blobbasefeeScalar });
+        _setGasLimit(_gasLimit);
+
+        Storage.setAddress(UNSAFE_BLOCK_SIGNER_SLOT, _unsafeBlockSigner);
+        Storage.setAddress(BATCH_INBOX_SLOT, _batchInbox);
+        Storage.setAddress(L1_CROSS_DOMAIN_MESSENGER_SLOT, _addresses.l1CrossDomainMessenger);
+        Storage.setAddress(L1_ERC_721_BRIDGE_SLOT, _addresses.l1ERC721Bridge);
+        Storage.setAddress(L1_STANDARD_BRIDGE_SLOT, _addresses.l1StandardBridge);
+        Storage.setAddress(OPTIMISM_PORTAL_SLOT, _addresses.optimismPortal);
+        Storage.setAddress(OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT, _addresses.optimismMintableERC20Factory);
+
+        _setStartBlock();
+
+        _setResourceConfig(_config);
+
         l2ChainId = _l2ChainId;
         superchainConfig = _superchainConfig;
-
-        {
-            // These are set in ascending order of their UpdateTypes.
-            _setBatcherHash(_batcherHash);
-            _setGasConfigEcotone({ _basefeeScalar: _basefeeScalar, _blobbasefeeScalar: _blobbasefeeScalar });
-            _setGasLimit(_gasLimit);
-
-            Storage.setAddress(UNSAFE_BLOCK_SIGNER_SLOT, _unsafeBlockSigner);
-            Storage.setAddress(BATCH_INBOX_SLOT, _batchInbox);
-            Storage.setAddress(L1_CROSS_DOMAIN_MESSENGER_SLOT, _addresses.l1CrossDomainMessenger);
-            Storage.setAddress(L1_ERC_721_BRIDGE_SLOT, _addresses.l1ERC721Bridge);
-            Storage.setAddress(L1_STANDARD_BRIDGE_SLOT, _addresses.l1StandardBridge);
-            Storage.setAddress(OPTIMISM_PORTAL_SLOT, _addresses.optimismPortal);
-            Storage.setAddress(OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT, _addresses.optimismMintableERC20Factory);
-
-            _setStartBlock();
-
-            _setResourceConfig(_config);
-        }
     }
 
     /// @notice Upgrades the SystemConfig by adding a reference to the SuperchainConfig.
@@ -503,5 +496,11 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     /// @return address The guardian address.
     function guardian() public view returns (address) {
         return superchainConfig.guardian();
+    }
+
+    /// @notice Returns whether the gas token is custom by reading from the OptimismPortal.
+    /// @return bool True if the gas token is custom, false otherwise.
+    function isCustomGasToken() public view returns (bool) {
+        return IOptimismPortal2(payable(optimismPortal())).isCustomGasToken();
     }
 }

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -234,7 +234,7 @@ contract OptimismPortal2_Initialize_Test is OptimismPortal2_TestInit {
 
         // Call the `initialize` function with the sender
         vm.prank(_sender);
-        optimismPortal2.initialize(systemConfig, anchorStateRegistry, ethLockbox);
+        optimismPortal2.initialize(systemConfig, anchorStateRegistry, ethLockbox, false);
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -2413,15 +2413,12 @@ contract OptimismPortal2_CustomGasToken_Test is OptimismPortal2_TestInit {
     function setUp() public override {
         super.setUp();
 
-        uint256 slot = 63; // shared slot: ethLockbox, superRootsActive, isCustomGasToken
-        uint256 offset = 21; // offset in bytes
-
-        bytes32 existingValue = vm.load(address(optimismPortal2), bytes32(slot));
-        // Clear the existing boolean value at offset 21 and set it to true
-        bytes32 clearedValue = bytes32(uint256(existingValue) & ~(uint256(0xFF) << (offset * 8)));
-        bytes32 newValue = bytes32(uint256(clearedValue) | (uint256(1) << (offset * 8)));
-
-        vm.store(address(optimismPortal2), bytes32(slot), newValue);
+        // Use stdStorage to handle packed slot for isCustomGasToken
+        stdstore
+            .enable_packed_slots()
+            .target(address(optimismPortal2))
+            .sig("isCustomGasToken()")
+            .checked_write(true);
     }
 
     /// @notice Tests that isCustomGasToken storage is set correctly

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -2066,13 +2066,7 @@ contract OptimismPortal2_DepositTransaction_Test is OptimismPortal2_TestInit {
 
     /// @notice Tests that `depositTransaction` reverts when the value is greater than 0 and the
     ///         custom gas token is active.
-    function test_depositTransaction_customGasToken_reverts(
-        bytes memory _data,
-        uint64 _gasLimit,
-        uint256 _value
-    )
-        external
-    {
+    function test_depositTransaction_customGasToken_reverts(bytes memory _data, uint256 _value) external {
         // Prevent overflow on an upgrade context
         _value = bound(_value, 1, type(uint256).max - address(ethLockbox).balance);
         // Set the custom gas token to true.
@@ -2468,7 +2462,7 @@ contract OptimismPortal2_CustomGasToken_Test is OptimismPortal2_TestInit {
     function testFuzz_receive_reverts(uint256 value) external {
         value = bound(value, 1, type(uint128).max);
         vm.deal(depositor, value);
-        
+
         address portal = address(optimismPortal2);
 
         vm.prank(depositor);

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -9,6 +9,8 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { NextImpl } from "test/mocks/NextImpl.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
+import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
+import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
 
 // Scripts
 import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
@@ -2404,5 +2406,75 @@ contract OptimismPortal2_Params_Test is CommonTest {
         bytes32 slot21After = vm.load(address(optimismPortal2), bytes32(uint256(21)));
         bytes32 slot21Expected = NextImpl(address(optimismPortal2)).slot21Init();
         assertEq(slot21Expected, slot21After);
+    }
+}
+
+/// @title OptimismPortal2_CustomGasToken_Test
+/// @notice Test suite for OptimismPortal2 with custom gas token enabled.
+contract OptimismPortal2_CustomGasToken_Test is OptimismPortal2_TestInit {
+    using stdStorage for StdStorage;
+
+    /// @notice Sets up a portal with custom gas token enabled
+    function setUp() public override {
+        super.setUp();
+
+        uint256 slot = 63; // shared slot: ethLockbox, superRootsActive, isCustomGasToken
+        uint256 offset = 21; // offset in bytes
+
+        bytes32 existingValue = vm.load(address(optimismPortal2), bytes32(slot));
+        // Clear the existing boolean value at offset 21 and set it to true
+        bytes32 clearedValue = bytes32(uint256(existingValue) & ~(uint256(0xFF) << (offset * 8)));
+        bytes32 newValue = bytes32(uint256(clearedValue) | (uint256(1) << (offset * 8)));
+
+        vm.store(address(optimismPortal2), bytes32(slot), newValue);
+    }
+
+    /// @notice Tests that isCustomGasToken storage is set correctly
+    function test_isCustomGasToken_succeeds() external view {
+        // Check that the public getter returns true
+        assertTrue(OptimismPortal2(payable(address(optimismPortal2))).isCustomGasToken());
+    }
+
+    /// @notice Tests that depositTransaction reverts when value > 0 and custom gas token is enabled
+    function testFuzz_depositTransaction_withValue_reverts(uint256 value) external {
+        value = bound(value, 1, type(uint128).max);
+        vm.deal(depositor, value);
+
+        vm.prank(depositor);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_NotAllowedOnCGTMode.selector);
+        optimismPortal2.depositTransaction{ value: value }({
+            _to: address(0x40),
+            _value: value,
+            _gasLimit: 100_000,
+            _isCreation: false,
+            _data: hex""
+        });
+    }
+
+    /// @notice Tests that depositTransaction succeeds when value = 0 and custom gas token is enabled
+    function test_depositTransaction_withZeroValue_succeeds() external {
+        vm.prank(depositor);
+        optimismPortal2.depositTransaction({
+            _to: address(0x40),
+            _value: 0,
+            _gasLimit: 100_000,
+            _isCreation: false,
+            _data: hex""
+        });
+        // No revert expected
+    }
+
+    /// @notice Tests that receive() reverts when custom gas token is enabled
+    function testFuzz_receive_reverts(uint256 value) external {
+        value = bound(value, 1, type(uint128).max);
+        vm.deal(depositor, value);
+        
+        address portal = address(optimismPortal2);
+
+        vm.prank(depositor);
+        vm.expectRevert(IOptimismPortal.OptimismPortal_NotAllowedOnCGTMode.selector);
+        assembly {
+            pop(call(gas(), portal, value, 0, 0, 0, 0))
+        }
     }
 }

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -191,6 +191,7 @@ contract OptimismPortal2_Initialize_Test is OptimismPortal2_TestInit {
         assertEq(optimismPortal2.paused(), false);
         assertEq(address(optimismPortal2.systemConfig()), address(systemConfig));
         assertEq(address(optimismPortal2.ethLockbox()), address(ethLockbox));
+        assertFalse(OptimismPortal2(payable(address(optimismPortal2))).isCustomGasToken());
 
         returnIfForkTest(
             "OptimismPortal2_Initialize_Test: Do not check guardian and respectedGameType on forked networks"

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -160,8 +160,7 @@ contract SystemConfig_Initialize_Test is SystemConfig_TestInit {
                 optimismMintableERC20Factory: address(0)
             }),
             _l2ChainId: 1234,
-            _superchainConfig: ISuperchainConfig(address(0)),
-            _isCustomGasToken: false
+            _superchainConfig: ISuperchainConfig(address(0))
         });
     }
 
@@ -217,8 +216,7 @@ contract SystemConfig_Initialize_Test is SystemConfig_TestInit {
                 optimismMintableERC20Factory: address(0)
             }),
             _l2ChainId: 1234,
-            _superchainConfig: ISuperchainConfig(address(0)),
-            _isCustomGasToken: false
+            _superchainConfig: ISuperchainConfig(address(0))
         });
     }
 }
@@ -345,8 +343,7 @@ contract SystemConfig_StartBlock_Test is SystemConfig_TestInit {
                 optimismMintableERC20Factory: address(0)
             }),
             _l2ChainId: 1234,
-            _superchainConfig: ISuperchainConfig(address(0)),
-            _isCustomGasToken: false
+            _superchainConfig: ISuperchainConfig(address(0))
         });
         assertEq(systemConfig.startBlock(), block.number);
     }
@@ -377,8 +374,7 @@ contract SystemConfig_StartBlock_Test is SystemConfig_TestInit {
                 optimismMintableERC20Factory: address(0)
             }),
             _l2ChainId: 1234,
-            _superchainConfig: ISuperchainConfig(address(0)),
-            _isCustomGasToken: false
+            _superchainConfig: ISuperchainConfig(address(0))
         });
         assertEq(systemConfig.startBlock(), 1);
     }
@@ -675,8 +671,7 @@ contract SystemConfig_SetResourceConfig_Test is SystemConfig_TestInit {
                 optimismMintableERC20Factory: address(0)
             }),
             _l2ChainId: 1234,
-            _superchainConfig: ISuperchainConfig(address(0)),
-            _isCustomGasToken: false
+            _superchainConfig: ISuperchainConfig(address(0))
         });
     }
 }

--- a/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -47,8 +47,7 @@ contract SystemConfig_GasLimitBoundaries_Invariant is Test {
                         optimismMintableERC20Factory: address(0)
                     }),
                     1234, // _l2ChainId
-                    ISuperchainConfig(address(0)), // _superchainConfig
-                    false // _isCustomGasToken
+                    ISuperchainConfig(address(0)) // _superchainConfig
                 )
             )
         );

--- a/packages/contracts-bedrock/test/opcm/SetDisputeGameImpl.t.sol
+++ b/packages/contracts-bedrock/test/opcm/SetDisputeGameImpl.t.sol
@@ -195,8 +195,7 @@ contract SetDisputeGameImpl_Test is Test {
                     optimismMintableERC20Factory: address(7)
                 }),
                 10,
-                ISuperchainConfig(address(supConfigProxy)),
-                false
+                ISuperchainConfig(address(supConfigProxy))
             )
         );
     }

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -123,7 +123,9 @@ contract Initializer_Test is CommonTest {
             InitializeableContract({
                 name: "OptimismPortal2Impl",
                 target: EIP1967Helper.getImplementation(address(optimismPortal2)),
-                initCalldata: abi.encodeCall(optimismPortal2.initialize, (systemConfig, anchorStateRegistry, ethLockbox))
+                initCalldata: abi.encodeCall(
+                    optimismPortal2.initialize, (systemConfig, anchorStateRegistry, ethLockbox, false)
+                )
             })
         );
         // OptimismPortal2Proxy
@@ -131,7 +133,9 @@ contract Initializer_Test is CommonTest {
             InitializeableContract({
                 name: "OptimismPortal2Proxy",
                 target: address(optimismPortal2),
-                initCalldata: abi.encodeCall(optimismPortal2.initialize, (systemConfig, anchorStateRegistry, ethLockbox))
+                initCalldata: abi.encodeCall(
+                    optimismPortal2.initialize, (systemConfig, anchorStateRegistry, ethLockbox, false)
+                )
             })
         );
 
@@ -166,8 +170,7 @@ contract Initializer_Test is CommonTest {
                             optimismMintableERC20Factory: address(0)
                         }),
                         0,
-                        ISuperchainConfig(address(0)),
-                        false
+                        ISuperchainConfig(address(0))
                     )
                 )
             })
@@ -203,8 +206,7 @@ contract Initializer_Test is CommonTest {
                             optimismMintableERC20Factory: address(0)
                         }),
                         0,
-                        ISuperchainConfig(address(0)),
-                        false
+                        ISuperchainConfig(address(0))
                     )
                 )
             })


### PR DESCRIPTION
- No more stack-too-deep: SystemConfig.initialize avoids the stack pressure.
- Lower gas: OptimismPortal no longer calls SystemConfig on every tx (one less external call).
- Cleaner design: isCustomGasToken was only used by the Portal, so keeping it local reduces coupling.