### PR TITLE
feat(rs): emit events on L1Withdrawer when funds received

### DIFF
--- a/packages/contracts-bedrock/src/L2/L1Withdrawer.sol
+++ b/packages/contracts-bedrock/src/L2/L1Withdrawer.sol
@@ -35,6 +35,11 @@ contract L1Withdrawer is ISemver {
     /// @param recipient The L1 address receiving the withdrawal.
     event WithdrawalInitiated(uint256 amount, address indexed recipient);
 
+    /// @notice Emitted when the contract receives funds.
+    /// @param amount The amount of ETH received.
+    /// @param newBalance The new balance after receiving funds.
+    event FundsReceived(uint256 amount, uint256 newBalance);
+
     /// @notice Emitted when the minimum withdrawal amount is updated.
     /// @param oldMinWithdrawalAmount The previous minimum withdrawal amount.
     /// @param newMinWithdrawalAmount The new minimum withdrawal amount.
@@ -75,6 +80,7 @@ contract L1Withdrawer is ISemver {
     /// @notice Receives ETH and initiates a withdrawal to L1 if the balance meets the threshold.
     receive() external payable {
         uint256 balance = address(this).balance;
+        emit FundsReceived(msg.value, balance);
 
         if (balance >= minWithdrawalAmount) {
             IL2ToL1MessagePasser(payable(Predeploys.L2_TO_L1_MESSAGE_PASSER)).initiateWithdrawal{ value: balance }(

--- a/packages/contracts-bedrock/src/L2/L1Withdrawer.sol
+++ b/packages/contracts-bedrock/src/L2/L1Withdrawer.sol
@@ -38,7 +38,8 @@ contract L1Withdrawer is ISemver {
     /// @notice Emitted when the contract receives funds.
     /// @param amount The amount of ETH received.
     /// @param newBalance The new balance after receiving funds.
-    event FundsReceived(uint256 amount, uint256 newBalance);
+    /// @param sender The address that sent the funds.
+    event FundsReceived(uint256 amount, uint256 newBalance, address indexed sender);
 
     /// @notice Emitted when the minimum withdrawal amount is updated.
     /// @param oldMinWithdrawalAmount The previous minimum withdrawal amount.
@@ -80,7 +81,7 @@ contract L1Withdrawer is ISemver {
     /// @notice Receives ETH and initiates a withdrawal to L1 if the balance meets the threshold.
     receive() external payable {
         uint256 balance = address(this).balance;
-        emit FundsReceived(msg.value, balance);
+        emit FundsReceived(msg.value, balance, msg.sender);
 
         if (balance >= minWithdrawalAmount) {
             IL2ToL1MessagePasser(payable(Predeploys.L2_TO_L1_MESSAGE_PASSER)).initiateWithdrawal{ value: balance }(

--- a/packages/contracts-bedrock/src/L2/L1Withdrawer.sol
+++ b/packages/contracts-bedrock/src/L2/L1Withdrawer.sol
@@ -31,15 +31,15 @@ contract L1Withdrawer is ISemver {
     bytes public withdrawalData;
 
     /// @notice Emitted when a withdrawal to L1 is initiated.
-    /// @param amount The amount of ETH being withdrawn.
     /// @param recipient The L1 address receiving the withdrawal.
-    event WithdrawalInitiated(uint256 amount, address indexed recipient);
+    /// @param amount The amount of ETH being withdrawn.
+    event WithdrawalInitiated(address indexed recipient, uint256 amount);
 
     /// @notice Emitted when the contract receives funds.
+    /// @param sender The address that sent the funds.
     /// @param amount The amount of ETH received.
     /// @param newBalance The new balance after receiving funds.
-    /// @param sender The address that sent the funds.
-    event FundsReceived(uint256 amount, uint256 newBalance, address indexed sender);
+    event FundsReceived(address indexed sender, uint256 amount, uint256 newBalance);
 
     /// @notice Emitted when the minimum withdrawal amount is updated.
     /// @param oldMinWithdrawalAmount The previous minimum withdrawal amount.
@@ -81,14 +81,14 @@ contract L1Withdrawer is ISemver {
     /// @notice Receives ETH and initiates a withdrawal to L1 if the balance meets the threshold.
     receive() external payable {
         uint256 balance = address(this).balance;
-        emit FundsReceived(msg.value, balance, msg.sender);
+        emit FundsReceived(msg.sender, msg.value, balance);
 
         if (balance >= minWithdrawalAmount) {
             IL2ToL1MessagePasser(payable(Predeploys.L2_TO_L1_MESSAGE_PASSER)).initiateWithdrawal{ value: balance }(
                 recipient, withdrawalGasLimit, withdrawalData
             );
 
-            emit WithdrawalInitiated(balance, recipient);
+            emit WithdrawalInitiated(recipient, balance);
         }
     }
 

--- a/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
@@ -19,7 +19,7 @@ contract L1Withdrawer_Test is CommonTest {
     bytes withdrawalData = hex"1234";
 
     event WithdrawalInitiated(uint256 amount, address indexed recipient);
-    event FundsReceived(uint256 amount, uint256 newBalance);
+    event FundsReceived(uint256 amount, uint256 newBalance, address indexed sender);
     event MinWithdrawalAmountUpdated(uint256 oldMinWithdrawalAmount, uint256 newMinWithdrawalAmount);
     event RecipientUpdated(address oldRecipient, address newRecipient);
     event WithdrawalGasLimitUpdated(uint256 oldWithdrawalGasLimit, uint256 newWithdrawalGasLimit);
@@ -45,7 +45,7 @@ contract L1Withdrawer_Test is CommonTest {
         vm.deal(address(this), _amount);
 
         vm.expectEmit(address(l1Withdrawer));
-        emit FundsReceived(_amount, _amount);
+        emit FundsReceived(_amount, _amount, address(this));
 
         (bool success,) = address(l1Withdrawer).call{ value: _amount }("");
 
@@ -60,7 +60,7 @@ contract L1Withdrawer_Test is CommonTest {
         vm.deal(address(this), _sendAmount);
 
         vm.expectEmit(address(l1Withdrawer));
-        emit FundsReceived(_sendAmount, _sendAmount);
+        emit FundsReceived(_sendAmount, _sendAmount, address(this));
 
         vm.expectEmit(address(l1Withdrawer));
         emit WithdrawalInitiated(_sendAmount, recipient);
@@ -91,7 +91,7 @@ contract L1Withdrawer_Test is CommonTest {
         vm.deal(address(this), _firstAmount);
 
         vm.expectEmit(address(l1Withdrawer));
-        emit FundsReceived(_firstAmount, _firstAmount);
+        emit FundsReceived(_firstAmount, _firstAmount, address(this));
 
         (bool success1,) = address(l1Withdrawer).call{ value: _firstAmount }("");
         assertTrue(success1);
@@ -102,7 +102,7 @@ contract L1Withdrawer_Test is CommonTest {
         vm.deal(address(this), _secondAmount);
 
         vm.expectEmit(address(l1Withdrawer));
-        emit FundsReceived(_secondAmount, totalAmount);
+        emit FundsReceived(_secondAmount, totalAmount, address(this));
 
         vm.expectEmit(address(l1Withdrawer));
         emit WithdrawalInitiated(totalAmount, recipient);

--- a/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
@@ -18,8 +18,8 @@ contract L1Withdrawer_Test is CommonTest {
     uint256 withdrawalGasLimit = 150_000;
     bytes withdrawalData = hex"1234";
 
-    event WithdrawalInitiated(uint256 amount, address indexed recipient);
-    event FundsReceived(uint256 amount, uint256 newBalance, address indexed sender);
+    event WithdrawalInitiated(address indexed recipient, uint256 amount);
+    event FundsReceived(address indexed sender, uint256 amount, uint256 newBalance);
     event MinWithdrawalAmountUpdated(uint256 oldMinWithdrawalAmount, uint256 newMinWithdrawalAmount);
     event RecipientUpdated(address oldRecipient, address newRecipient);
     event WithdrawalGasLimitUpdated(uint256 oldWithdrawalGasLimit, uint256 newWithdrawalGasLimit);
@@ -45,7 +45,7 @@ contract L1Withdrawer_Test is CommonTest {
         vm.deal(address(this), _amount);
 
         vm.expectEmit(address(l1Withdrawer));
-        emit FundsReceived(_amount, _amount, address(this));
+        emit FundsReceived(address(this), _amount, _amount);
 
         (bool success,) = address(l1Withdrawer).call{ value: _amount }("");
 
@@ -60,10 +60,10 @@ contract L1Withdrawer_Test is CommonTest {
         vm.deal(address(this), _sendAmount);
 
         vm.expectEmit(address(l1Withdrawer));
-        emit FundsReceived(_sendAmount, _sendAmount, address(this));
+        emit FundsReceived(address(this), _sendAmount, _sendAmount);
 
         vm.expectEmit(address(l1Withdrawer));
-        emit WithdrawalInitiated(_sendAmount, recipient);
+        emit WithdrawalInitiated(recipient, _sendAmount);
 
         vm.expectCall(
             Predeploys.L2_TO_L1_MESSAGE_PASSER,
@@ -91,7 +91,7 @@ contract L1Withdrawer_Test is CommonTest {
         vm.deal(address(this), _firstAmount);
 
         vm.expectEmit(address(l1Withdrawer));
-        emit FundsReceived(_firstAmount, _firstAmount, address(this));
+        emit FundsReceived(address(this), _firstAmount, _firstAmount);
 
         (bool success1,) = address(l1Withdrawer).call{ value: _firstAmount }("");
         assertTrue(success1);
@@ -102,10 +102,10 @@ contract L1Withdrawer_Test is CommonTest {
         vm.deal(address(this), _secondAmount);
 
         vm.expectEmit(address(l1Withdrawer));
-        emit FundsReceived(_secondAmount, totalAmount, address(this));
+        emit FundsReceived(address(this), _secondAmount, totalAmount);
 
         vm.expectEmit(address(l1Withdrawer));
-        emit WithdrawalInitiated(totalAmount, recipient);
+        emit WithdrawalInitiated(recipient, totalAmount);
 
         vm.expectCall(
             Predeploys.L2_TO_L1_MESSAGE_PASSER,

--- a/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
@@ -19,6 +19,7 @@ contract L1Withdrawer_Test is CommonTest {
     bytes withdrawalData = hex"1234";
 
     event WithdrawalInitiated(uint256 amount, address indexed recipient);
+    event FundsReceived(uint256 amount, uint256 newBalance);
     event MinWithdrawalAmountUpdated(uint256 oldMinWithdrawalAmount, uint256 newMinWithdrawalAmount);
     event RecipientUpdated(address oldRecipient, address newRecipient);
     event WithdrawalGasLimitUpdated(uint256 oldWithdrawalGasLimit, uint256 newWithdrawalGasLimit);
@@ -42,6 +43,10 @@ contract L1Withdrawer_Test is CommonTest {
         _amount = bound(_amount, 0, minWithdrawalAmount - 1);
 
         vm.deal(address(this), _amount);
+
+        vm.expectEmit(address(l1Withdrawer));
+        emit FundsReceived(_amount, _amount);
+
         (bool success,) = address(l1Withdrawer).call{ value: _amount }("");
 
         assertTrue(success);
@@ -55,15 +60,16 @@ contract L1Withdrawer_Test is CommonTest {
         vm.deal(address(this), _sendAmount);
 
         vm.expectEmit(address(l1Withdrawer));
+        emit FundsReceived(_sendAmount, _sendAmount);
+
+        vm.expectEmit(address(l1Withdrawer));
+        emit WithdrawalInitiated(_sendAmount, recipient);
+
         vm.expectCall(
             Predeploys.L2_TO_L1_MESSAGE_PASSER,
             _sendAmount,
-            abi.encodeCall(
-                IL2ToL1MessagePasser.initiateWithdrawal,
-                (recipient, withdrawalGasLimit, withdrawalData)
-            )
+            abi.encodeCall(IL2ToL1MessagePasser.initiateWithdrawal, (recipient, withdrawalGasLimit, withdrawalData))
         );
-        emit WithdrawalInitiated(_sendAmount, recipient);
 
         (bool success,) = address(l1Withdrawer).call{ value: _sendAmount }("");
 
@@ -83,6 +89,10 @@ contract L1Withdrawer_Test is CommonTest {
 
         // First deposit (should not trigger withdrawal)
         vm.deal(address(this), _firstAmount);
+
+        vm.expectEmit(address(l1Withdrawer));
+        emit FundsReceived(_firstAmount, _firstAmount);
+
         (bool success1,) = address(l1Withdrawer).call{ value: _firstAmount }("");
         assertTrue(success1);
         assertEq(address(l1Withdrawer).balance, _firstAmount);
@@ -92,15 +102,16 @@ contract L1Withdrawer_Test is CommonTest {
         vm.deal(address(this), _secondAmount);
 
         vm.expectEmit(address(l1Withdrawer));
+        emit FundsReceived(_secondAmount, totalAmount);
+
+        vm.expectEmit(address(l1Withdrawer));
+        emit WithdrawalInitiated(totalAmount, recipient);
+
         vm.expectCall(
             Predeploys.L2_TO_L1_MESSAGE_PASSER,
             totalAmount,
-            abi.encodeCall(
-                IL2ToL1MessagePasser.initiateWithdrawal,
-                (recipient, withdrawalGasLimit, withdrawalData)
-            )
+            abi.encodeCall(IL2ToL1MessagePasser.initiateWithdrawal, (recipient, withdrawalGasLimit, withdrawalData))
         );
-        emit WithdrawalInitiated(totalAmount, recipient);
 
         (bool success2,) = address(l1Withdrawer).call{ value: _secondAmount }("");
         assertTrue(success2);


### PR DESCRIPTION
Closes OPT-1074, OPT-1078

The initial idea was to emit an event *only* when the amount doesn't surpass the received amount. But I think this way provides better observability and we can be sure that all the ETH that has passed through the contract equals to the sum of the amount in all `FundsReceived` events.

Let me know if you want to strictly stick this PR to the comment request