### PR TITLE
feat: genesis init handle

### DIFF
--- a/packages/contracts-bedrock/interfaces/L2/IFeeSplitter.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IFeeSplitter.sol
@@ -19,7 +19,6 @@ interface IFeeSplitter is ISemver {
 
     event FeesReceived(address indexed sender, uint256 amount);
     event FeeDisbursementIntervalUpdated(uint128 oldFeeDisbursementInterval, uint128 newFeeDisbursementInterval);
-    event Initialized(ISharesCalculator sharesCalculator, uint128 feeDisbursementInterval);
     event FeesDisbursed(ISharesCalculator.ShareInfo[] shareInfo, uint256 grossRevenue);
     event SharesCalculatorUpdated(address oldSharesCalculator, address newSharesCalculator);
 

--- a/packages/contracts-bedrock/interfaces/L2/IFeeSplitter.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IFeeSplitter.sol
@@ -5,7 +5,6 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 import { ISharesCalculator } from "interfaces/L2/ISharesCalculator.sol";
 
 interface IFeeSplitter is ISemver {
-
     error FeeSplitter_SharesCalculatorCannotBeZero();
     error FeeSplitter_DisbursementIntervalNotReached();
     error FeeSplitter_FeeShareInfoEmpty();
@@ -28,10 +27,7 @@ interface IFeeSplitter is ISemver {
     function lastDisbursementTime() external view returns (uint128);
     function feeDisbursementInterval() external view returns (uint128);
 
-    function initialize(
-        ISharesCalculator _sharesCalculator,
-        uint128 _feeDisbursementInterval
-    ) external;
+    function initialize(ISharesCalculator _sharesCalculator) external;
 
     function disburseFees() external;
 

--- a/packages/contracts-bedrock/interfaces/L2/ISuperchainRevSharesCalculator.sol
+++ b/packages/contracts-bedrock/interfaces/L2/ISuperchainRevSharesCalculator.sol
@@ -30,7 +30,7 @@ interface ISuperchainRevSharesCalculator is ISemver {
     )
         external
         view
-        returns (ISharesCalculator.ShareInfo[] memory shareInfo);
+        returns (ISharesCalculator.ShareInfo[] memory);
 
     function setShareRecipient(address payable _shareRecipient) external;
     function setRemainderRecipient(address payable _remainderRecipient) external;

--- a/packages/contracts-bedrock/interfaces/L2/ISuperchainRevSharesCalculator.sol
+++ b/packages/contracts-bedrock/interfaces/L2/ISuperchainRevSharesCalculator.sol
@@ -21,18 +21,20 @@ interface ISuperchainRevSharesCalculator is ISemver {
     function remainderRecipient() external view returns (address payable);
 
     // Functions
-    function initialize(
-        address payable _shareRecipient,
-        address payable _remainderRecipient
-    ) external;
+    function initialize(address payable _shareRecipient, address payable _remainderRecipient) external;
 
     function getRecipientsAndAmounts(
         uint256 _sequencerFeeRevenue,
         uint256 _baseFeeRevenue,
         uint256 _operatorFeeRevenue,
         uint256 _l1FeeRevenue
-    ) external view returns (ISharesCalculator.ShareInfo[] memory shareInfo);
+    )
+        external
+        view
+        returns (ISharesCalculator.ShareInfo[] memory shareInfo);
 
     function setShareRecipient(address payable _shareRecipient) external;
     function setRemainderRecipient(address payable _remainderRecipient) external;
+
+    function __constructor__(address payable _shareRecipient, address payable _remainderRecipient) external;
 }

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -6,7 +6,7 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Scripts
 import { Script } from "forge-std/Script.sol";
-import { OutputMode, OutputModeUtils, Fork, ForkUtils } from "scripts/libraries/Config.sol";
+import { OutputMode, OutputModeUtils, Fork, ForkUtils, Config } from "scripts/libraries/Config.sol";
 import { SetPreinstalls } from "scripts/SetPreinstalls.s.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
@@ -14,6 +14,7 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Preinstalls } from "src/libraries/Preinstalls.sol";
 import { Types } from "src/libraries/Types.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 // Interfaces
 import { ISequencerFeeVault } from "interfaces/L2/ISequencerFeeVault.sol";
@@ -32,6 +33,7 @@ import { IGasPriceOracle } from "interfaces/L2/IGasPriceOracle.sol";
 import { IL1Block } from "interfaces/L2/IL1Block.sol";
 import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";
 import { ISharesCalculator } from "interfaces/L2/ISharesCalculator.sol";
+import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 
 /// @title L2Genesis
 /// @notice Generates the genesis state for the L2 network.
@@ -67,6 +69,8 @@ contract L2Genesis is Script {
         bool fundDevAccounts;
         address feeSplitterSharesCalculator;
         uint256 feeSplitterFeeDisbursementInterval;
+        bool useRevenueShare;
+        address chainFeesRecipient;
     }
 
     using ForkUtils for Fork;
@@ -590,15 +594,33 @@ contract L2Genesis is Script {
 
     /// @notice This predeploy is following the safety invariant #1.
     function setFeeSplitter(Input memory _input) internal {
-        address impl = _setImplementationCode(Predeploys.FEE_SPLITTER);
+        if (_input.useRevenueShare) {
+            // Deploy L1Withdrawer with constructor args, then etch runtime to fixed address
+            uint256 withdrawalMinGasLimit = 300_000;
+            uint32 depositMinGasLimit = 200_000;
+            uint256 thresholdAmount = 10 ether;
+            bytes memory depositData =
+                abi.encodeCall(IL1StandardBridge.depositETHTo, (Constants.OP_FEES_MULTISIG, depositMinGasLimit, ""));
+            address _l1WithdrawerDeployed = vm.deployCode(
+                "L1Withdrawer.sol:L1Withdrawer",
+                abi.encode(thresholdAmount, Constants.OP_FEES_MULTISIG, withdrawalMinGasLimit, depositData)
+            );
+            vm.etch(Predeploys.L1_WITHDRAWER, _l1WithdrawerDeployed.code);
+
+            // Deploy SuperchainRevSharesCalculator with recipients, then etch runtime to fixed address
+            address _calcDeployed = vm.deployCode(
+                "SuperchainRevSharesCalculator.sol:SuperchainRevSharesCalculator",
+                abi.encode(payable(Predeploys.L1_WITHDRAWER), payable(_input.chainFeesRecipient))
+            );
+            vm.etch(Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR, _calcDeployed.code);
+        }
         // Initialize the implementation with dummy values
-        IFeeSplitter(payable(impl)).initialize(
-            ISharesCalculator(address(0)), uint128(0)
-        );
+        address impl = _setImplementationCode(Predeploys.FEE_SPLITTER);
+        IFeeSplitter(payable(impl)).initialize(ISharesCalculator(address(0)));
 
         // Initialize the proxy with the actual values
         IFeeSplitter(payable(Predeploys.FEE_SPLITTER)).initialize(
-            ISharesCalculator(_input.feeSplitterSharesCalculator), uint128(_input.feeSplitterFeeDisbursementInterval)
+            ISharesCalculator(Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR)
         );
     }
 

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -611,7 +611,7 @@ contract L2Genesis is Script {
                 abi.encode(thresholdAmount, Constants.OP_FEES_MULTISIG, withdrawalMinGasLimit, depositData),
                 l1WithdrawerSalt
             );
-            // Save to artifacts if available (not in test context)
+            // Save to artifacts if available
             if (address(artifacts).code.length > 0) {
                 artifacts.save("L1Withdrawer", l1Withdrawer);
             }
@@ -623,7 +623,7 @@ contract L2Genesis is Script {
                 abi.encode(payable(l1Withdrawer), payable(_input.chainFeesRecipient)),
                 calcSalt
             );
-            // Save to artifacts if available (not in test context)
+            // Save to artifacts if available
             if (address(artifacts).code.length > 0) {
                 artifacts.save("SuperchainRevSharesCalculator", revSharesCalculator);
             }
@@ -635,7 +635,6 @@ contract L2Genesis is Script {
         // Initialize the proxy with the actual values
         // Only set the shares calculator if revenue sharing is enabled
         address sharesCalculator = revSharesCalculator;
-
         IFeeSplitter(payable(Predeploys.FEE_SPLITTER)).initialize(ISharesCalculator(sharesCalculator));
     }
 

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -596,7 +596,7 @@ contract L2Genesis is Script {
     /// @notice This predeploy is following the safety invariant #1.
     function setFeeSplitter(Input memory _input) internal {
         if (_input.useRevenueShare) {
-            // Deploy L1Withdrawer with constructor args, then etch runtime to fixed address
+            // Deploy L1Withdrawer with constructor args
             uint256 withdrawalMinGasLimit = 300_000;
             uint32 depositMinGasLimit = 200_000;
             uint256 thresholdAmount = 10 ether;
@@ -606,30 +606,10 @@ contract L2Genesis is Script {
                 "L1Withdrawer.sol:L1Withdrawer",
                 abi.encode(thresholdAmount, Constants.OP_FEES_MULTISIG, withdrawalMinGasLimit, depositData)
             );
-            vm.etch(Predeploys.L1_WITHDRAWER, _l1WithdrawerDeployed.code);
 
-            // Manually set the storage values since constructor storage isn't copied with etch
-            // minWithdrawalAmount is at slot 0
-            vm.store(Predeploys.L1_WITHDRAWER, bytes32(uint256(0)), bytes32(thresholdAmount));
-            // recipient is at slot 1
-            vm.store(
-                Predeploys.L1_WITHDRAWER, bytes32(uint256(1)), bytes32(uint256(uint160(Constants.OP_FEES_MULTISIG)))
-            );
-            // withdrawalGasLimit is at slot 2
-            vm.store(Predeploys.L1_WITHDRAWER, bytes32(uint256(2)), bytes32(withdrawalMinGasLimit));
-            // withdrawalData is at slot 3 (bytes data)
-            // Since depositData.length is 132 bytes (> 32), use long form encoding
-            // Store length * 2 + 1 at slot 3 for long form
-            vm.store(Predeploys.L1_WITHDRAWER, bytes32(uint256(3)), bytes32((depositData.length * 2) + 1));
-            // Store data starting at keccak256(slot 3)
-            bytes32 dataSlot = keccak256(abi.encode(uint256(3)));
-            for (uint256 i = 0; i < (depositData.length + 31) / 32; i++) {
-                bytes32 chunk;
-                assembly {
-                    chunk := mload(add(add(depositData, 0x20), mul(i, 0x20)))
-                }
-                vm.store(Predeploys.L1_WITHDRAWER, bytes32(uint256(dataSlot) + i), chunk);
-            }
+            // Etch the deployed code to the predeploy address and copy the storage
+            vm.etch(Predeploys.L1_WITHDRAWER, _l1WithdrawerDeployed.code);
+            vm.copyStorage(_l1WithdrawerDeployed, Predeploys.L1_WITHDRAWER);
 
             // Deploy SuperchainRevSharesCalculator with constructor args
             address _calcDeployed = vm.deployCode(
@@ -637,22 +617,9 @@ contract L2Genesis is Script {
                 abi.encode(payable(Predeploys.L1_WITHDRAWER), payable(_input.chainFeesRecipient))
             );
 
-            // Etch the deployed code to the predeploy address
+            // Etch the deployed code to the predeploy address and copy the storage
             vm.etch(Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR, _calcDeployed.code);
-
-            // Manually set the storage values since constructor storage isn't copied with etch
-            // shareRecipient is at slot 0
-            vm.store(
-                Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR,
-                bytes32(uint256(0)),
-                bytes32(uint256(uint160(Predeploys.L1_WITHDRAWER)))
-            );
-            // remainderRecipient is at slot 1
-            vm.store(
-                Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR,
-                bytes32(uint256(1)),
-                bytes32(uint256(uint160(_input.chainFeesRecipient)))
-            );
+            vm.copyStorage(_calcDeployed, Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR);
         }
         // Initialize the implementation with dummy values
         address impl = _setImplementationCode(Predeploys.FEE_SPLITTER);

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -15,6 +15,7 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Preinstalls } from "src/libraries/Preinstalls.sol";
 import { Types } from "src/libraries/Types.sol";
 import { Constants } from "src/libraries/Constants.sol";
+import { Artifacts } from "scripts/Artifacts.s.sol";
 
 // Interfaces
 import { ISequencerFeeVault } from "interfaces/L2/ISequencerFeeVault.sol";
@@ -68,7 +69,6 @@ contract L2Genesis is Script {
         bool deployCrossL2Inbox;
         bool enableGovernance;
         bool fundDevAccounts;
-        address feeSplitterSharesCalculator;
         uint256 feeSplitterFeeDisbursementInterval;
         bool useRevenueShare;
         address chainFeesRecipient;
@@ -595,6 +595,9 @@ contract L2Genesis is Script {
 
     /// @notice This predeploy is following the safety invariant #1.
     function setFeeSplitter(Input memory _input) internal {
+        Artifacts artifacts = Artifacts(address(uint160(uint256(keccak256(abi.encode("optimism.artifacts"))))));
+
+        address revSharesCalculator;
         if (_input.useRevenueShare) {
             // Deploy L1Withdrawer with constructor args
             uint256 withdrawalMinGasLimit = 300_000;
@@ -602,24 +605,30 @@ contract L2Genesis is Script {
             uint256 thresholdAmount = 10 ether;
             bytes memory depositData =
                 abi.encodeCall(IL1StandardBridge.depositETHTo, (Constants.OP_FEES_MULTISIG, depositMinGasLimit, ""));
-            address _l1WithdrawerDeployed = vm.deployCode(
+            bytes32 l1WithdrawerSalt = keccak256("L1Withdrawer");
+            address l1Withdrawer = DeployUtils.create2(
                 "L1Withdrawer.sol:L1Withdrawer",
-                abi.encode(thresholdAmount, Constants.OP_FEES_MULTISIG, withdrawalMinGasLimit, depositData)
+                abi.encode(thresholdAmount, Constants.OP_FEES_MULTISIG, withdrawalMinGasLimit, depositData),
+                l1WithdrawerSalt
             );
-
-            // Etch the deployed code to the predeploy address and copy the storage
-            vm.etch(Predeploys.L1_WITHDRAWER, _l1WithdrawerDeployed.code);
-            vm.copyStorage(_l1WithdrawerDeployed, Predeploys.L1_WITHDRAWER);
+            // Save to artifacts if available (not in test context)
+            if (address(artifacts).code.length > 0) {
+                artifacts.save("L1Withdrawer", l1Withdrawer);
+            }
+            console.log("l1Withdrawer", l1Withdrawer);
 
             // Deploy SuperchainRevSharesCalculator with constructor args
-            address _calcDeployed = vm.deployCode(
+            bytes32 calcSalt = keccak256("SuperchainRevSharesCalculator");
+            revSharesCalculator = DeployUtils.create2(
                 "SuperchainRevSharesCalculator.sol:SuperchainRevSharesCalculator",
-                abi.encode(payable(Predeploys.L1_WITHDRAWER), payable(_input.chainFeesRecipient))
+                abi.encode(payable(l1Withdrawer), payable(_input.chainFeesRecipient)),
+                calcSalt
             );
-
-            // Etch the deployed code to the predeploy address and copy the storage
-            vm.etch(Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR, _calcDeployed.code);
-            vm.copyStorage(_calcDeployed, Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR);
+            // Save to artifacts if available (not in test context)
+            if (address(artifacts).code.length > 0) {
+                artifacts.save("SuperchainRevSharesCalculator", revSharesCalculator);
+            }
+            console.log("revSharesCalculator", revSharesCalculator);
         }
         // Initialize the implementation with dummy values
         address impl = _setImplementationCode(Predeploys.FEE_SPLITTER);
@@ -627,7 +636,7 @@ contract L2Genesis is Script {
 
         // Initialize the proxy with the actual values
         // Only set the shares calculator if revenue sharing is enabled
-        address sharesCalculator = _input.useRevenueShare ? Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR : address(0);
+        address sharesCalculator = revSharesCalculator;
 
         IFeeSplitter(payable(Predeploys.FEE_SPLITTER)).initialize(ISharesCalculator(sharesCalculator));
     }
@@ -647,3 +656,5 @@ contract L2Genesis is Script {
         }
     }
 }
+
+import { console } from "forge-std/console.sol";

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -615,7 +615,6 @@ contract L2Genesis is Script {
             if (address(artifacts).code.length > 0) {
                 artifacts.save("L1Withdrawer", l1Withdrawer);
             }
-            console.log("l1Withdrawer", l1Withdrawer);
 
             // Deploy SuperchainRevSharesCalculator with constructor args
             bytes32 calcSalt = keccak256("SuperchainRevSharesCalculator");
@@ -628,7 +627,6 @@ contract L2Genesis is Script {
             if (address(artifacts).code.length > 0) {
                 artifacts.save("SuperchainRevSharesCalculator", revSharesCalculator);
             }
-            console.log("revSharesCalculator", revSharesCalculator);
         }
         // Initialize the implementation with dummy values
         address impl = _setImplementationCode(Predeploys.FEE_SPLITTER);
@@ -656,5 +654,3 @@ contract L2Genesis is Script {
         }
     }
 }
-
-import { console } from "forge-std/console.sol";

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -32,6 +32,7 @@ import { IL2CrossDomainMessenger } from "interfaces/L2/IL2CrossDomainMessenger.s
 import { IGasPriceOracle } from "interfaces/L2/IGasPriceOracle.sol";
 import { IL1Block } from "interfaces/L2/IL1Block.sol";
 import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";
+import { ISuperchainRevSharesCalculator } from "interfaces/L2/ISuperchainRevSharesCalculator.sol";
 import { ISharesCalculator } from "interfaces/L2/ISharesCalculator.sol";
 import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 
@@ -607,21 +608,61 @@ contract L2Genesis is Script {
             );
             vm.etch(Predeploys.L1_WITHDRAWER, _l1WithdrawerDeployed.code);
 
-            // Deploy SuperchainRevSharesCalculator with recipients, then etch runtime to fixed address
+            // Manually set the storage values since constructor storage isn't copied with etch
+            // minWithdrawalAmount is at slot 0
+            vm.store(Predeploys.L1_WITHDRAWER, bytes32(uint256(0)), bytes32(thresholdAmount));
+            // recipient is at slot 1
+            vm.store(
+                Predeploys.L1_WITHDRAWER, bytes32(uint256(1)), bytes32(uint256(uint160(Constants.OP_FEES_MULTISIG)))
+            );
+            // withdrawalGasLimit is at slot 2
+            vm.store(Predeploys.L1_WITHDRAWER, bytes32(uint256(2)), bytes32(withdrawalMinGasLimit));
+            // withdrawalData is at slot 3 (bytes data)
+            // Since depositData.length is 132 bytes (> 32), use long form encoding
+            // Store length * 2 + 1 at slot 3 for long form
+            vm.store(Predeploys.L1_WITHDRAWER, bytes32(uint256(3)), bytes32((depositData.length * 2) + 1));
+            // Store data starting at keccak256(slot 3)
+            bytes32 dataSlot = keccak256(abi.encode(uint256(3)));
+            for (uint256 i = 0; i < (depositData.length + 31) / 32; i++) {
+                bytes32 chunk;
+                assembly {
+                    chunk := mload(add(add(depositData, 0x20), mul(i, 0x20)))
+                }
+                vm.store(Predeploys.L1_WITHDRAWER, bytes32(uint256(dataSlot) + i), chunk);
+            }
+
+            // Deploy SuperchainRevSharesCalculator with constructor args
             address _calcDeployed = vm.deployCode(
                 "SuperchainRevSharesCalculator.sol:SuperchainRevSharesCalculator",
                 abi.encode(payable(Predeploys.L1_WITHDRAWER), payable(_input.chainFeesRecipient))
             );
+
+            // Etch the deployed code to the predeploy address
             vm.etch(Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR, _calcDeployed.code);
+
+            // Manually set the storage values since constructor storage isn't copied with etch
+            // shareRecipient is at slot 0
+            vm.store(
+                Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR,
+                bytes32(uint256(0)),
+                bytes32(uint256(uint160(Predeploys.L1_WITHDRAWER)))
+            );
+            // remainderRecipient is at slot 1
+            vm.store(
+                Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR,
+                bytes32(uint256(1)),
+                bytes32(uint256(uint160(_input.chainFeesRecipient)))
+            );
         }
         // Initialize the implementation with dummy values
         address impl = _setImplementationCode(Predeploys.FEE_SPLITTER);
         IFeeSplitter(payable(impl)).initialize(ISharesCalculator(address(0)));
 
         // Initialize the proxy with the actual values
-        IFeeSplitter(payable(Predeploys.FEE_SPLITTER)).initialize(
-            ISharesCalculator(Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR)
-        );
+        // Only set the shares calculator if revenue sharing is enabled
+        address sharesCalculator = _input.useRevenueShare ? Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR : address(0);
+
+        IFeeSplitter(payable(Predeploys.FEE_SPLITTER)).initialize(ISharesCalculator(sharesCalculator));
     }
 
     /// @notice Sets the bytecode in state

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -161,7 +161,7 @@ contract DeployConfig is Script {
         daResolverRefundPercentage = _readOr(_json, "$.daResolverRefundPercentage", 0);
 
         useInterop = _readOr(_json, "$.useInterop", false);
-        useUpgradedFork = _readOr(_json, "$.useUpgradedFork", false);
+        useUpgradedFork;
         useRevenueShare = _readOr(_json, "$.useRevenueShare", false);
         chainFeesRecipient = _readOr(_json, "$.chainFeesRecipient", address(0));
     }

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -82,6 +82,8 @@ contract DeployConfig is Script {
 
     bool public useInterop;
     bool public useUpgradedFork;
+    bool public useRevenueShare;
+    address public chainFeesRecipient;
 
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
@@ -159,7 +161,9 @@ contract DeployConfig is Script {
         daResolverRefundPercentage = _readOr(_json, "$.daResolverRefundPercentage", 0);
 
         useInterop = _readOr(_json, "$.useInterop", false);
-        useUpgradedFork;
+        useUpgradedFork = _readOr(_json, "$.useUpgradedFork", false);
+        useRevenueShare = _readOr(_json, "$.useRevenueShare", false);
+        chainFeesRecipient = _readOr(_json, "$.chainFeesRecipient", address(0));
     }
 
     function fork() public view returns (Fork fork_) {

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -51,7 +51,6 @@ contract DeployConfig is Script {
     uint256 public operatorFeeVaultMinimumWithdrawalAmount;
     uint256 public operatorFeeVaultWithdrawalNetwork;
     address public governanceTokenOwner;
-    address public feeSplitterSharesCalculator;
     uint256 public feeSplitterFeeDisbursementInterval;
     uint256 public l2GenesisBlockGasLimit;
     uint32 public basefeeScalar;
@@ -126,7 +125,6 @@ contract DeployConfig is Script {
         operatorFeeVaultMinimumWithdrawalAmount = stdJson.readUint(_json, "$.operatorFeeVaultMinimumWithdrawalAmount");
         operatorFeeVaultWithdrawalNetwork = stdJson.readUint(_json, "$.operatorFeeVaultWithdrawalNetwork");
         governanceTokenOwner = stdJson.readAddress(_json, "$.governanceTokenOwner");
-        feeSplitterSharesCalculator = _readOr(_json, "$.feeSplitterSharesCalculator", address(0));
         feeSplitterFeeDisbursementInterval = _readOr(_json, "$.feeSplitterFeeDisbursementInterval", uint256(0));
         l2GenesisBlockGasLimit = stdJson.readUint(_json, "$.l2GenesisBlockGasLimit");
         basefeeScalar = uint32(_readOr(_json, "$.gasPriceOracleBaseFeeScalar", 1368));

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -215,6 +215,11 @@ contract DeployConfig is Script {
         useInterop = _useInterop;
     }
 
+    /// @notice Allow the `useRevenueShare` config to be overridden in testing environments
+    function setUseRevenueShare(bool _useRevenueShare) public {
+        useRevenueShare = _useRevenueShare;
+    }
+
     /// @notice Allow the `fundDevAccounts` config to be overridden.
     function setFundDevAccounts(bool _fundDevAccounts) public {
         fundDevAccounts = _fundDevAccounts;

--- a/packages/contracts-bedrock/src/L2/FeeSplitter.sol
+++ b/packages/contracts-bedrock/src/L2/FeeSplitter.sol
@@ -81,11 +81,6 @@ contract FeeSplitter is ISemver, Initializable {
     /// @param newFeeDisbursementInterval The new fee disbursement interval.
     event FeeDisbursementIntervalUpdated(uint128 oldFeeDisbursementInterval, uint128 newFeeDisbursementInterval);
 
-    /// @notice Emitted when the contract is initialized with its initial configuration.
-    /// @param sharesCalculator           The share calculator contract.
-    /// @param feeDisbursementInterval   The minimum amount of time in seconds that must pass between fee disbursals.
-    event Initialized(ISharesCalculator sharesCalculator, uint128 feeDisbursementInterval);
-
     /// @notice Emitted when fees are disbursed to the recipients.
     /// @param shareInfo The recipients of the fee share.
     /// @param grossRevenue The gross revenue before disbursement.

--- a/packages/contracts-bedrock/src/L2/FeeSplitter.sol
+++ b/packages/contracts-bedrock/src/L2/FeeSplitter.sol
@@ -103,12 +103,10 @@ contract FeeSplitter is ISemver, Initializable {
     /// @notice Initializes the contract with all required addresses and parameters.
     /// @dev This function can only be called once and must be called by the ProxyAdmin owner.
     /// @param _sharesCalculator            The share calculator contract.
-    /// @param _feeDisbursementInterval    The minimum amount of time in seconds that must pass between fee disbursals.
-    function initialize(ISharesCalculator _sharesCalculator, uint128 _feeDisbursementInterval) external initializer {
+    function initialize(ISharesCalculator _sharesCalculator) external initializer {
         sharesCalculator = _sharesCalculator;
-        feeDisbursementInterval = _feeDisbursementInterval;
-
-        emit Initialized(_sharesCalculator, _feeDisbursementInterval);
+        // As default, the fee disbursement interval is 1 day
+        feeDisbursementInterval = 1 days;
     }
 
     /// @dev Receives ETH fees withdrawn from L2 FeeVaults.

--- a/packages/contracts-bedrock/src/libraries/Constants.sol
+++ b/packages/contracts-bedrock/src/libraries/Constants.sol
@@ -38,6 +38,9 @@ library Constants {
     ///         transactions.
     address internal constant DEPOSITOR_ACCOUNT = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001;
 
+    // TODO: set address
+    address internal constant OP_FEES_MULTISIG = 0x876235EFb64d7F43E682502c61b381e9050D2AA4;
+
     /// @notice Returns the default values for the ResourceConfig. These are the recommended values
     ///         for a production network.
     function DEFAULT_RESOURCE_CONFIG() internal pure returns (IResourceMetering.ResourceConfig memory) {

--- a/packages/contracts-bedrock/src/libraries/Constants.sol
+++ b/packages/contracts-bedrock/src/libraries/Constants.sol
@@ -38,8 +38,8 @@ library Constants {
     ///         transactions.
     address internal constant DEPOSITOR_ACCOUNT = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001;
 
-    // TODO: set address
-    address internal constant OP_FEES_MULTISIG = 0x876235EFb64d7F43E682502c61b381e9050D2AA4;
+    // TODO: IMPORTANT!! Update address
+    address internal constant OP_FEES_MULTISIG = 0x4200000000000000000000000000000000000018;
 
     /// @notice Returns the default values for the ResourceConfig. These are the recommended values
     ///         for a production network.

--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -116,10 +116,6 @@ library Predeploys {
     /// @notice Address of the FeeSplitter predeploy.
     address internal constant FEE_SPLITTER = 0x420000000000000000000000000000000000002B;
 
-    // TODO: Prec addresses
-    address internal constant L1_WITHDRAWER = 0x1000000000000000000000000000000000000000;
-    address internal constant SUPERCHAIN_REV_SHARES_CALCULATOR = 0x1000000000000000000000000000000000000001;
-
     /// @notice Returns the name of the predeploy at the given address.
     function getName(address _addr) internal pure returns (string memory out_) {
         require(isPredeployNamespace(_addr), "Predeploys: address must be a predeploy");

--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -116,6 +116,10 @@ library Predeploys {
     /// @notice Address of the FeeSplitter predeploy.
     address internal constant FEE_SPLITTER = 0x420000000000000000000000000000000000002B;
 
+    // TODO: Prec addresses
+    address internal constant L1_WITHDRAWER = 0x1000000000000000000000000000000000000000;
+    address internal constant SUPERCHAIN_REV_SHARES_CALCULATOR = 0x1000000000000000000000000000000000000001;
+
     /// @notice Returns the name of the predeploy at the given address.
     function getName(address _addr) internal pure returns (string memory out_) {
         require(isPredeployNamespace(_addr), "Predeploys: address must be a predeploy");

--- a/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
@@ -33,10 +33,9 @@ contract FeeSplitter_TestInit is CommonTest {
 
     /// @notice Test setup.
     function setUp() public virtual override {
+        // Enable revenue sharing before calling parent setUp
+        super.enableRevenueShare();
         super.setUp();
-
-        // Etch the FeeSplitter contract
-        vm.etch(address(feeSplitter), vm.getDeployedCode("FeeSplitter.sol:FeeSplitter"));
 
         // Get the owner from ProxyAdmin
         _owner = IProxyAdmin(Predeploys.PROXY_ADMIN).owner();
@@ -88,14 +87,15 @@ contract FeeSplitter_TestInit is CommonTest {
 /// @title FeeSplitter_Initialize_Test
 /// @notice Tests the initialization functions of the `FeeSplitter` contract.
 contract FeeSplitter_Initialize_Test is FeeSplitter_TestInit {
-    /// @notice Test that re-initialization fails
-    function test_constructor_succeeds() public {
+    /// @notice Test that re-initialization fails on the already-initialized predeploy
+    function test_reinitialization_reverts() public {
+        // The FeeSplitter at the predeploy address is already initialized through genesis
         vm.prank(_owner);
         vm.expectRevert("Initializable: contract is already initialized");
         feeSplitter.initialize(ISharesCalculator(address(_defaultSharesCalculator)));
     }
 
-    /// @notice Test successful initialization with proper event emission
+    /// @notice Test successful initialization with proper event emission on a fresh instance
     function test_feeSplitter_initialization_succeeds() public {
         // Deploy a fresh instance for testing initialization
         address impl = address(uint160(uint256(keccak256("FeeSplitterTestImpl3"))));

--- a/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
@@ -105,6 +105,7 @@ contract FeeSplitter_Initialize_Test is FeeSplitter_TestInit {
         IFeeSplitter(payable(impl)).initialize(ISharesCalculator(address(_defaultSharesCalculator)));
 
         assertEq(address(IFeeSplitter(payable(impl)).sharesCalculator()), address(_defaultSharesCalculator));
+        assertEq(IFeeSplitter(payable(impl)).feeDisbursementInterval(), 1 days);
     }
 }
 

--- a/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
@@ -21,7 +21,6 @@ contract FeeSplitter_TestInit is CommonTest {
     // Events
     event FeesReceived(address indexed sender, uint256 amount);
     event FeeDisbursementIntervalUpdated(uint128 oldFeeDisbursementInterval, uint128 newFeeDisbursementInterval);
-    event Initialized(ISharesCalculator sharesCalculator, uint128 feeDisbursementInterval);
     event FeesDisbursed(ISharesCalculator.ShareInfo[] shareInfo, uint256 grossRevenue);
     event SharesCalculatorUpdated(address oldSharesCalculator, address newSharesCalculator);
 
@@ -29,7 +28,7 @@ contract FeeSplitter_TestInit is CommonTest {
     address internal _owner;
     address internal _defaultRevenueShareRecipient = makeAddr("RevenueShareRecipient");
     address internal _defaultRevenueRemainderRecipient = makeAddr("RemainderRecipient");
-    uint128 internal _defaultFeeDisbursementInterval = 24 hours;
+    uint128 internal _defaultFeeDisbursementInterval = 1 days;
     address internal _defaultSharesCalculator = makeAddr("SharesCalculator");
 
     /// @notice Test setup.
@@ -93,7 +92,7 @@ contract FeeSplitter_Initialize_Test is FeeSplitter_TestInit {
     function test_constructor_succeeds() public {
         vm.prank(_owner);
         vm.expectRevert("Initializable: contract is already initialized");
-        feeSplitter.initialize(ISharesCalculator(address(_defaultSharesCalculator)), _defaultFeeDisbursementInterval);
+        feeSplitter.initialize(ISharesCalculator(address(_defaultSharesCalculator)));
     }
 
     /// @notice Test successful initialization with proper event emission
@@ -102,19 +101,10 @@ contract FeeSplitter_Initialize_Test is FeeSplitter_TestInit {
         address impl = address(uint160(uint256(keccak256("FeeSplitterTestImpl3"))));
         vm.etch(impl, vm.getDeployedCode("FeeSplitter.sol:FeeSplitter"));
 
-        vm.expectEmit(address(impl));
-        emit Initialized({
-            sharesCalculator: ISharesCalculator(address(_defaultSharesCalculator)),
-            feeDisbursementInterval: _defaultFeeDisbursementInterval
-        });
-
         vm.prank(_owner);
-        IFeeSplitter(payable(impl)).initialize(
-            ISharesCalculator(address(_defaultSharesCalculator)), _defaultFeeDisbursementInterval
-        );
+        IFeeSplitter(payable(impl)).initialize(ISharesCalculator(address(_defaultSharesCalculator)));
 
         assertEq(address(IFeeSplitter(payable(impl)).sharesCalculator()), address(_defaultSharesCalculator));
-        assertEq(IFeeSplitter(payable(impl)).feeDisbursementInterval(), _defaultFeeDisbursementInterval);
     }
 }
 
@@ -127,7 +117,7 @@ contract FeeSplitter_Receive_Test is FeeSplitter_TestInit {
 
         vm.prank(_caller);
         vm.expectRevert(IFeeSplitter.FeeSplitter_ReceiveWindowClosed.selector);
-        (bool success,) = payable(address(feeSplitter)).call{ value: _amount }("");
+        payable(address(feeSplitter)).call{ value: _amount }("");
     }
 
     /// @notice Test receive function from non-approved vault reverts even during disbursement
@@ -147,9 +137,9 @@ contract FeeSplitter_Receive_Test is FeeSplitter_TestInit {
         vm.deal(_caller, _amount);
 
         vm.prank(_caller);
-        vm.expectRevert(IFeeSplitter.FeeSplitter_SenderNotApprovedVault.selector); // Now we test the actual sender
-            // validation
-        (bool success,) = payable(address(feeSplitter)).call{ value: _amount }("");
+        // Now we test the actual sender validation
+        vm.expectRevert(IFeeSplitter.FeeSplitter_SenderNotApprovedVault.selector);
+        payable(address(feeSplitter)).call{ value: _amount }("");
     }
 
     /// @notice Test receive function works during disbursement from SequencerFeeVault
@@ -357,8 +347,9 @@ contract FeeSplitter_DisburseFees_Test is FeeSplitter_TestInit {
         uint256 halfGrossRevenue = expectedGrossRevenue / 2;
         ISharesCalculator.ShareInfo[] memory expectedShareInfo = new ISharesCalculator.ShareInfo[](2);
         expectedShareInfo[0] = ISharesCalculator.ShareInfo(payable(_defaultRevenueShareRecipient), halfGrossRevenue);
-        expectedShareInfo[1] =
-            ISharesCalculator.ShareInfo(payable(_defaultRevenueRemainderRecipient), expectedGrossRevenue - halfGrossRevenue);
+        expectedShareInfo[1] = ISharesCalculator.ShareInfo(
+            payable(_defaultRevenueRemainderRecipient), expectedGrossRevenue - halfGrossRevenue
+        );
 
         // Get the actual shares calculator from the FeeSplitter
         address actualSharesCalculator = address(feeSplitter.sharesCalculator());

--- a/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
@@ -6,17 +6,17 @@ import { IL2ToL1MessagePasser } from "interfaces/L2/IL2ToL1MessagePasser.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { IL1Withdrawer } from "interfaces/L2/IL1Withdrawer.sol";
+import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 /// @title L1Withdrawer_Test
 /// @notice Tests all functionality of L1Withdrawer including receive, withdrawal, and setters.
 contract L1Withdrawer_Test is CommonTest {
-    address l1Withdrawer;
-    IL1Withdrawer l1WithdrawerInterface;
-
-    address recipient = makeAddr("recipient");
-    uint256 minWithdrawalAmount = 1 ether;
-    uint256 withdrawalGasLimit = 150_000;
-    bytes withdrawalData = hex"1234";
+    // Test-specific parameters (the actual L1Withdrawer from genesis has different values)
+    address recipient = Constants.OP_FEES_MULTISIG;
+    uint256 minWithdrawalAmount = 10 ether;
+    uint256 withdrawalGasLimit = 300_000;
+    bytes withdrawalData = abi.encodeCall(IL1StandardBridge.depositETHTo, (Constants.OP_FEES_MULTISIG, 200_000, ""));
 
     event WithdrawalInitiated(address indexed recipient, uint256 amount);
     event FundsReceived(address indexed sender, uint256 amount, uint256 newBalance);
@@ -26,17 +26,9 @@ contract L1Withdrawer_Test is CommonTest {
     event WithdrawalDataUpdated(bytes oldWithdrawalData, bytes newWithdrawalData);
 
     function setUp() public override {
+        // Enable revenue sharing before calling parent setUp
+        super.enableRevenueShare();
         super.setUp();
-
-        l1Withdrawer = DeployUtils.create1(
-            "L1Withdrawer.sol:L1Withdrawer",
-            DeployUtils.encodeConstructor(
-                abi.encodeCall(
-                    IL1Withdrawer.__constructor__, (minWithdrawalAmount, recipient, withdrawalGasLimit, withdrawalData)
-                )
-            )
-        );
-        l1WithdrawerInterface = IL1Withdrawer(l1Withdrawer);
     }
 
     function testFuzz_receive_belowThreshold_succeeds(uint256 _amount) external {
@@ -128,9 +120,9 @@ contract L1Withdrawer_Test is CommonTest {
         emit MinWithdrawalAmountUpdated(minWithdrawalAmount, _newMinWithdrawalAmount);
 
         vm.prank(owner);
-        l1WithdrawerInterface.setMinWithdrawalAmount(_newMinWithdrawalAmount);
+        l1Withdrawer.setMinWithdrawalAmount(_newMinWithdrawalAmount);
 
-        assertEq(l1WithdrawerInterface.minWithdrawalAmount(), _newMinWithdrawalAmount);
+        assertEq(l1Withdrawer.minWithdrawalAmount(), _newMinWithdrawalAmount);
     }
 
     function testFuzz_setMinWithdrawalAmount_asNonOwner_reverts(address _caller) external {
@@ -141,9 +133,9 @@ contract L1Withdrawer_Test is CommonTest {
 
         vm.expectRevert(IL1Withdrawer.L1Withdrawer_OnlyProxyAdminOwner.selector);
         vm.prank(_caller);
-        l1WithdrawerInterface.setMinWithdrawalAmount(newMinWithdrawalAmount);
+        l1Withdrawer.setMinWithdrawalAmount(newMinWithdrawalAmount);
 
-        assertEq(l1WithdrawerInterface.minWithdrawalAmount(), minWithdrawalAmount);
+        assertEq(l1Withdrawer.minWithdrawalAmount(), minWithdrawalAmount);
     }
 
     function testFuzz_setRecipient_asOwner_succeeds(address _newRecipient) external {
@@ -153,9 +145,9 @@ contract L1Withdrawer_Test is CommonTest {
         emit RecipientUpdated(recipient, _newRecipient);
 
         vm.prank(owner);
-        l1WithdrawerInterface.setRecipient(_newRecipient);
+        l1Withdrawer.setRecipient(_newRecipient);
 
-        assertEq(l1WithdrawerInterface.recipient(), _newRecipient);
+        assertEq(l1Withdrawer.recipient(), _newRecipient);
     }
 
     function testFuzz_setRecipient_asNonOwner_reverts(address _caller) external {
@@ -166,9 +158,9 @@ contract L1Withdrawer_Test is CommonTest {
 
         vm.expectRevert(IL1Withdrawer.L1Withdrawer_OnlyProxyAdminOwner.selector);
         vm.prank(_caller);
-        l1WithdrawerInterface.setRecipient(newRecipient);
+        l1Withdrawer.setRecipient(newRecipient);
 
-        assertEq(l1WithdrawerInterface.recipient(), recipient);
+        assertEq(l1Withdrawer.recipient(), recipient);
     }
 
     function testFuzz_setWithdrawalGasLimit_asOwner_succeeds(uint256 _newWithdrawalGasLimit) external {
@@ -178,9 +170,9 @@ contract L1Withdrawer_Test is CommonTest {
         emit WithdrawalGasLimitUpdated(withdrawalGasLimit, _newWithdrawalGasLimit);
 
         vm.prank(owner);
-        l1WithdrawerInterface.setWithdrawalGasLimit(_newWithdrawalGasLimit);
+        l1Withdrawer.setWithdrawalGasLimit(_newWithdrawalGasLimit);
 
-        assertEq(l1WithdrawerInterface.withdrawalGasLimit(), _newWithdrawalGasLimit);
+        assertEq(l1Withdrawer.withdrawalGasLimit(), _newWithdrawalGasLimit);
     }
 
     function testFuzz_setWithdrawalGasLimit_asNonOwner_reverts(address _caller) external {
@@ -191,9 +183,9 @@ contract L1Withdrawer_Test is CommonTest {
 
         vm.expectRevert(IL1Withdrawer.L1Withdrawer_OnlyProxyAdminOwner.selector);
         vm.prank(_caller);
-        l1WithdrawerInterface.setWithdrawalGasLimit(newWithdrawalGasLimit);
+        l1Withdrawer.setWithdrawalGasLimit(newWithdrawalGasLimit);
 
-        assertEq(l1WithdrawerInterface.withdrawalGasLimit(), withdrawalGasLimit);
+        assertEq(l1Withdrawer.withdrawalGasLimit(), withdrawalGasLimit);
     }
 
     function testFuzz_setWithdrawalData_asOwner_succeeds(bytes memory _newWithdrawalData) external {
@@ -203,9 +195,9 @@ contract L1Withdrawer_Test is CommonTest {
         emit WithdrawalDataUpdated(withdrawalData, _newWithdrawalData);
 
         vm.prank(owner);
-        l1WithdrawerInterface.setWithdrawalData(_newWithdrawalData);
+        l1Withdrawer.setWithdrawalData(_newWithdrawalData);
 
-        assertEq(l1WithdrawerInterface.withdrawalData(), _newWithdrawalData);
+        assertEq(l1Withdrawer.withdrawalData(), _newWithdrawalData);
     }
 
     function testFuzz_setWithdrawalData_asNonOwner_reverts(address _caller) external {
@@ -216,8 +208,8 @@ contract L1Withdrawer_Test is CommonTest {
 
         vm.expectRevert(IL1Withdrawer.L1Withdrawer_OnlyProxyAdminOwner.selector);
         vm.prank(_caller);
-        l1WithdrawerInterface.setWithdrawalData(newWithdrawalData);
+        l1Withdrawer.setWithdrawalData(newWithdrawalData);
 
-        assertEq(l1WithdrawerInterface.withdrawalData(), withdrawalData);
+        assertEq(l1Withdrawer.withdrawalData(), withdrawalData);
     }
 }

--- a/packages/contracts-bedrock/test/L2/SuperchainRevSharesCalculator.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainRevSharesCalculator.t.sol
@@ -11,10 +11,11 @@ import { ISuperchainRevSharesCalculator } from "interfaces/L2/ISuperchainRevShar
 // Libraries
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Config } from "scripts/libraries/Config.sol";
 
 /// @notice Base setup contract for SuperchainRevSharesCalculator tests.
 contract SuperchainRevSharesCalculator_TestInit is CommonTest {
-    ISuperchainRevSharesCalculator calculator;
     address payable shareRecipient;
     address payable remainderRecipient;
 
@@ -22,96 +23,98 @@ contract SuperchainRevSharesCalculator_TestInit is CommonTest {
     event RemainderRecipientUpdated(address indexed oldRemainderRecipient, address indexed newRemainderRecipient);
 
     function setUp() public virtual override {
+        // Enable revenue sharing before calling parent setUp
+        super.enableRevenueShare();
         super.setUp();
 
-        shareRecipient = payable(makeAddr("shareRecipient"));
-        remainderRecipient = payable(makeAddr("remainderRecipient"));
-        
-        calculator = ISuperchainRevSharesCalculator(
-            DeployUtils.create1({
-                _name: "SuperchainRevSharesCalculator",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(ISuperchainRevSharesCalculator.__constructor__, (shareRecipient, remainderRecipient)))
-            })
-        );
+        shareRecipient = payable(Predeploys.L1_WITHDRAWER);
+        remainderRecipient = payable(deploy.cfg().chainFeesRecipient());
     }
 }
 
 /// @notice Tests for SuperchainRevSharesCalculator constructor.
 contract SuperchainRevSharesCalculator_Constructor_Test is SuperchainRevSharesCalculator_TestInit {
-    
-    /// @notice Tests that constructor 
+    /// @notice Tests that constructor
     function test_constructor_succeeds() external view {
         // Verify constants are set correctly on the deployed calculator
-        assertEq(calculator.version(), "1.0.0");
-        assertEq(calculator.BASIS_POINT_SCALE(), 10_000);
-        assertEq(calculator.GROSS_SHARE_BPS(), 250);
-        assertEq(calculator.NET_SHARE_BPS(), 1_500);
-        
-        // Verify share and remainder recipients are set 
-        assertEq(address(calculator.shareRecipient()), address(shareRecipient));
-        assertEq(address(calculator.remainderRecipient()), address(remainderRecipient));
+        assertEq(superchainRevSharesCalculator.version(), "1.0.0");
+        assertEq(superchainRevSharesCalculator.BASIS_POINT_SCALE(), 10_000);
+        assertEq(superchainRevSharesCalculator.GROSS_SHARE_BPS(), 250);
+        assertEq(superchainRevSharesCalculator.NET_SHARE_BPS(), 1_500);
+
+        // Verify share and remainder recipients are set
+        assertEq(address(superchainRevSharesCalculator.shareRecipient()), address(shareRecipient));
+        assertEq(address(superchainRevSharesCalculator.remainderRecipient()), address(remainderRecipient));
     }
 }
 
 /// @notice Tests for SuperchainRevSharesCalculator setShareRecipient function success cases.
 contract SuperchainRevSharesCalculator_SetShareRecipient_Test is SuperchainRevSharesCalculator_TestInit {
-    
     /// @notice Tests that setShareRecipient reverts when not called by ProxyAdmin owner.
-    function testFuzz_setShareRecipient_notProxyAdminOwner_reverts(address _caller, address payable _newShareRecipient) external {
+    function testFuzz_setShareRecipient_notProxyAdminOwner_reverts(
+        address _caller,
+        address payable _newShareRecipient
+    )
+        external
+    {
         vm.assume(_caller != proxyAdminOwner);
-                
+
         vm.expectRevert(ISuperchainRevSharesCalculator.SharesCalculator_OnlyProxyAdminOwner.selector);
         vm.prank(_caller);
-        calculator.setShareRecipient(_newShareRecipient);
+        superchainRevSharesCalculator.setShareRecipient(_newShareRecipient);
     }
-    
+
     /// @notice Tests that setShareRecipient updates recipient and emits event.
     function testFuzz_setShareRecipient_succeeds(address payable _newShareRecipient) external {
-        
-        vm.expectEmit(address(calculator));
+        vm.expectEmit(address(superchainRevSharesCalculator));
         emit ShareRecipientUpdated(shareRecipient, _newShareRecipient);
-        
+
         vm.prank(proxyAdminOwner);
-        calculator.setShareRecipient(_newShareRecipient);
-        
-        assertEq(address(calculator.shareRecipient()), address(_newShareRecipient));
+        superchainRevSharesCalculator.setShareRecipient(_newShareRecipient);
+
+        assertEq(address(superchainRevSharesCalculator.shareRecipient()), address(_newShareRecipient));
     }
 }
 
 /// @notice Tests for SuperchainRevSharesCalculator setRemainderRecipient function success cases.
 contract SuperchainRevSharesCalculator_SetRemainderRecipient_Test is SuperchainRevSharesCalculator_TestInit {
-        
     /// @notice Tests that setRemainderRecipient reverts when not called by ProxyAdmin owner.
-    function testFuzz_setRemainderRecipient_notProxyAdminOwner_reverts(address _caller, address payable _newRemainderRecipient) external {
+    function testFuzz_setRemainderRecipient_notProxyAdminOwner_reverts(
+        address _caller,
+        address payable _newRemainderRecipient
+    )
+        external
+    {
         vm.assume(_caller != proxyAdminOwner);
-        
+
         vm.expectRevert(ISuperchainRevSharesCalculator.SharesCalculator_OnlyProxyAdminOwner.selector);
         vm.prank(_caller);
-        calculator.setRemainderRecipient(_newRemainderRecipient);
+        superchainRevSharesCalculator.setRemainderRecipient(_newRemainderRecipient);
     }
 
     /// @notice Tests that setRemainderRecipient updates recipient and emits event.
     function testFuzz_setRemainderRecipient_succeeds(address payable _newRemainderRecipient) external {
-        vm.expectEmit(address(calculator));
+        vm.expectEmit(address(superchainRevSharesCalculator));
         emit RemainderRecipientUpdated(remainderRecipient, _newRemainderRecipient);
-        
+
         vm.prank(proxyAdminOwner);
-        calculator.setRemainderRecipient(_newRemainderRecipient);
-        
-        assertEq(address(calculator.remainderRecipient()), address(_newRemainderRecipient));
+        superchainRevSharesCalculator.setRemainderRecipient(_newRemainderRecipient);
+
+        assertEq(address(superchainRevSharesCalculator.remainderRecipient()), address(_newRemainderRecipient));
     }
 }
 
 /// @notice Tests for SuperchainRevSharesCalculator getRecipientsAndAmounts function.
 contract SuperchainRevSharesCalculator_getRecipientsAndAmounts_Test is SuperchainRevSharesCalculator_TestInit {
-    
     /// @notice Test that getRecipientsAndAmounts reverts when gross share is calculated to be 0.
     function testFuzz_getRecipientsAndAmounts_zeroGrossShare_reverts(
         uint256 _sequencerFees,
         uint256 _baseFees,
         uint256 _operatorFees,
         uint256 _l1Fees
-    ) external {
+    )
+        external
+    {
         // Bound each fee to ensure total revenue < 40 to make gross share = 0
         // With GROSS_SHARE_BPS = 250 and BASIS_POINT_SCALE = 10_000:
         // grossShare = (totalRevenue * 250) / 10_000 = 0 when totalRevenue < 40
@@ -119,143 +122,156 @@ contract SuperchainRevSharesCalculator_getRecipientsAndAmounts_Test is Superchai
         _baseFees = bound(_baseFees, 1, 10);
         _operatorFees = bound(_operatorFees, 1, 10);
         _l1Fees = bound(_l1Fees, 1, 10);
-        
+
         // Verify that gross share would be 0 due to integer division
         uint256 totalRevenue = _sequencerFees + _baseFees + _operatorFees + _l1Fees;
-        uint256 grossShare = (totalRevenue * uint256(calculator.GROSS_SHARE_BPS())) / uint256(calculator.BASIS_POINT_SCALE());
+        uint256 grossShare = (totalRevenue * uint256(superchainRevSharesCalculator.GROSS_SHARE_BPS()))
+            / uint256(superchainRevSharesCalculator.BASIS_POINT_SCALE());
         assertEq(grossShare, 0, "Gross share should be 0");
         assertLt(totalRevenue, 40, "Total revenue should be less than 40 for zero gross share");
-        
+
         // Expect the function to revert with the correct error
         vm.expectRevert(ISuperchainRevSharesCalculator.SharesCalculator_ZeroGrossShare.selector);
-        calculator.getRecipientsAndAmounts(_sequencerFees, _baseFees, _operatorFees, _l1Fees);
+        superchainRevSharesCalculator.getRecipientsAndAmounts(_sequencerFees, _baseFees, _operatorFees, _l1Fees);
     }
-    
+
     /// @notice Fuzz test for cases where gross share is higher than net share.
     function testFuzz_getRecipientsAndAmounts_grossShareHigher_succeeds(
         uint256 _sequencerFees,
         uint256 _baseFees,
         uint256 _operatorFees,
         uint256 _l1Fees
-    ) external view {
+    )
+        external
+        view
+    {
         // Use smaller bounds to prevent overflow
         _sequencerFees = bound(_sequencerFees, 10000, type(uint112).max);
         _baseFees = bound(_baseFees, 10000, type(uint112).max);
         _operatorFees = bound(_operatorFees, 10000, type(uint112).max);
-        
+
         // Calculate other fees (without L1 fees)
         uint256 otherFees = _sequencerFees + _baseFees + _operatorFees;
-        
+
         // For gross > net: we need L1 fees to be very high relative to other fees
         // Set L1 fees to be 90% of total revenue to ensure gross > net
         uint256 minL1Fees = otherFees * 9; // L1 fees = 90% of other fees, so total = 10 * otherFees, L1 = 9 * otherFees
         _l1Fees = bound(_l1Fees, minL1Fees, minL1Fees + 10000);
-        
-        ISharesCalculator.ShareInfo[] memory result = calculator.getRecipientsAndAmounts(
-            _sequencerFees, _baseFees, _operatorFees, _l1Fees
-        );
-        
+
+        ISharesCalculator.ShareInfo[] memory result =
+            superchainRevSharesCalculator.getRecipientsAndAmounts(_sequencerFees, _baseFees, _operatorFees, _l1Fees);
+
         // Verify structure
         assertEq(result.length, 2);
         assertEq(address(result[0].recipient), address(shareRecipient));
         assertEq(address(result[1].recipient), address(remainderRecipient));
-        
+
         // Calculate expected values
         uint256 totalRevenue = _sequencerFees + _baseFees + _operatorFees + _l1Fees;
-        uint256 grossShare = (totalRevenue * uint256(calculator.GROSS_SHARE_BPS())) / uint256(calculator.BASIS_POINT_SCALE());
+        uint256 grossShare = (totalRevenue * uint256(superchainRevSharesCalculator.GROSS_SHARE_BPS()))
+            / uint256(superchainRevSharesCalculator.BASIS_POINT_SCALE());
         uint256 netRevenue = totalRevenue - _l1Fees;
-        uint256 netShare = (netRevenue * uint256(calculator.NET_SHARE_BPS())) / uint256(calculator.BASIS_POINT_SCALE());
-        
+        uint256 netShare = (netRevenue * uint256(superchainRevSharesCalculator.NET_SHARE_BPS()))
+            / uint256(superchainRevSharesCalculator.BASIS_POINT_SCALE());
+
         // Verify gross share is indeed higher
         assertGt(grossShare, netShare, "Gross share should be higher than net share");
-        
+
         // Verify calculations
         assertEq(result[0].amount, grossShare);
         assertEq(result[1].amount, totalRevenue - grossShare);
-        
+
         // Verify total conservation
         assertEq(result[0].amount + result[1].amount, totalRevenue);
     }
-    
+
     /// @notice Fuzz test for cases where net share is higher than gross share.
     function testFuzz_getRecipientsAndAmounts_netShareHigher_succeeds(
         uint256 _sequencerFees,
         uint256 _baseFees,
         uint256 _operatorFees,
         uint256 _l1Fees
-    ) external view {
+    )
+        external
+        view
+    {
         // Use smaller bounds to prevent overflow
         _sequencerFees = bound(_sequencerFees, 10000, type(uint112).max);
         _baseFees = bound(_baseFees, 10000, type(uint112).max);
         _operatorFees = bound(_operatorFees, 10000, type(uint112).max);
-        
+
         // Calculate other fees (without L1 fees)
         uint256 otherFees = _sequencerFees + _baseFees + _operatorFees;
-        
+
         // For net > gross: we need L1 fees to be very low relative to other fees
         // Set L1 fees to be 10% of other fees to ensure net > gross
         uint256 maxL1Fees = otherFees / 10; // L1 fees = 10% of other fees
         _l1Fees = bound(_l1Fees, 1, maxL1Fees);
-        
-        ISharesCalculator.ShareInfo[] memory result = calculator.getRecipientsAndAmounts(
-            _sequencerFees, _baseFees, _operatorFees, _l1Fees
-        );
-        
+
+        ISharesCalculator.ShareInfo[] memory result =
+            superchainRevSharesCalculator.getRecipientsAndAmounts(_sequencerFees, _baseFees, _operatorFees, _l1Fees);
+
         // Verify structure
         assertEq(result.length, 2);
         assertEq(address(result[0].recipient), address(shareRecipient));
         assertEq(address(result[1].recipient), address(remainderRecipient));
-        
+
         // Calculate expected values
         uint256 totalRevenue = _sequencerFees + _baseFees + _operatorFees + _l1Fees;
-        uint256 grossShare = (totalRevenue * uint256(calculator.GROSS_SHARE_BPS())) / uint256(calculator.BASIS_POINT_SCALE());
+        uint256 grossShare = (totalRevenue * uint256(superchainRevSharesCalculator.GROSS_SHARE_BPS()))
+            / uint256(superchainRevSharesCalculator.BASIS_POINT_SCALE());
         uint256 netRevenue = totalRevenue - _l1Fees;
-        uint256 netShare = (netRevenue * uint256(calculator.NET_SHARE_BPS())) / uint256(calculator.BASIS_POINT_SCALE());
-        
+        uint256 netShare = (netRevenue * uint256(superchainRevSharesCalculator.NET_SHARE_BPS()))
+            / uint256(superchainRevSharesCalculator.BASIS_POINT_SCALE());
+
         // Verify net share is indeed higher
         assertGt(netShare, grossShare, "Net share should be higher than gross share");
-        
+
         // Verify calculations
         assertEq(result[0].amount, netShare);
         assertEq(result[1].amount, totalRevenue - netShare);
-        
+
         // Verify total conservation
         assertEq(result[0].amount + result[1].amount, totalRevenue);
     }
-    
+
     /// @notice Comprehensive fuzz test for calculation logic.
     function testFuzz_getRecipientsAndAmounts_succeeds(
         uint256 _sequencerFees,
         uint256 _baseFees,
         uint256 _operatorFees,
         uint256 _l1Fees
-    ) external view {
+    )
+        external
+        view
+    {
         // Use uint112 to prevent overflow when adding & 10000 to prevent 0 fee revert
         _sequencerFees = bound(_sequencerFees, 10000, type(uint112).max);
         _baseFees = bound(_baseFees, 10000, type(uint112).max);
         _operatorFees = bound(_operatorFees, 10000, type(uint112).max);
         _l1Fees = bound(_l1Fees, 10000, type(uint112).max);
-        
-        ISharesCalculator.ShareInfo[] memory result = calculator.getRecipientsAndAmounts(
-            _sequencerFees, _baseFees, _operatorFees, _l1Fees
-        );
-        
+
+        ISharesCalculator.ShareInfo[] memory result =
+            superchainRevSharesCalculator.getRecipientsAndAmounts(_sequencerFees, _baseFees, _operatorFees, _l1Fees);
+
         // Verify structure
         assertEq(result.length, 2);
         assertEq(address(result[0].recipient), address(shareRecipient));
         assertEq(address(result[1].recipient), address(remainderRecipient));
-        
+
         // Calculate expected values
         uint256 totalRevenue = _sequencerFees + _baseFees + _operatorFees + _l1Fees;
-        uint256 grossShare = (totalRevenue * uint256(calculator.GROSS_SHARE_BPS())) / uint256(calculator.BASIS_POINT_SCALE());
+        uint256 grossShare = (totalRevenue * uint256(superchainRevSharesCalculator.GROSS_SHARE_BPS()))
+            / uint256(superchainRevSharesCalculator.BASIS_POINT_SCALE());
         uint256 netRevenue = totalRevenue - _l1Fees;
-        uint256 netShare = (netRevenue * uint256(calculator.NET_SHARE_BPS())) / uint256(calculator.BASIS_POINT_SCALE());
+        uint256 netShare = (netRevenue * uint256(superchainRevSharesCalculator.NET_SHARE_BPS()))
+            / uint256(superchainRevSharesCalculator.BASIS_POINT_SCALE());
         uint256 expectedShareAmount = grossShare > netShare ? grossShare : netShare;
-        
+
         // Verify calculations
         assertEq(result[0].amount, expectedShareAmount);
         assertEq(result[1].amount, totalRevenue - expectedShareAmount);
-        
+
         // Verify total conservation
         assertEq(result[0].amount + result[1].amount, totalRevenue);
     }

--- a/packages/contracts-bedrock/test/L2/SuperchainRevSharesCalculator.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainRevSharesCalculator.t.sol
@@ -27,7 +27,7 @@ contract SuperchainRevSharesCalculator_TestInit is CommonTest {
         super.enableRevenueShare();
         super.setUp();
 
-        shareRecipient = payable(Predeploys.L1_WITHDRAWER);
+        shareRecipient = payable(address(l1Withdrawer));
         remainderRecipient = payable(deploy.cfg().chainFeesRecipient());
     }
 }

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -110,18 +110,13 @@ contract L2Genesis_TestInit is Test {
     }
 
     function testFeeSplitter() internal view {
+        // Only test if revenue share is not enabled
+        if (!input.useRevenueShare) return;
+
         // Check that the shares calculator and fee disbursement interval are set on the fee splitter
         IFeeSplitter feeSplitter = IFeeSplitter(payable(Predeploys.FEE_SPLITTER));
         assertEq(address(feeSplitter.sharesCalculator()), input.feeSplitterSharesCalculator);
         assertEq(feeSplitter.feeDisbursementInterval(), 1 days);
-
-        // Only test if revenue share is not enabled
-        if (!input.useRevenueShare) {
-            // Check the shares calculator and l1 withdrawer addresses have no code
-            assertEq(input.feeSplitterSharesCalculator.code.length, 0);
-            assertEq(address(Predeploys.L1_WITHDRAWER).code.length, 0);
-            return;
-        }
 
         // Check that the superchain rev shares calculator is properly set
         assertEq(

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -173,7 +173,7 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
             enableGovernance: true,
             fundDevAccounts: true,
             feeSplitterFeeDisbursementInterval: 86400,
-            feeSplitterSharesCalculator: address(0x000000000000000000000000000000000000000A),
+            feeSplitterSharesCalculator: Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR,
             useRevenueShare: true,
             chainFeesRecipient: address(0x000000000000000000000000000000000000000b)
         });
@@ -186,5 +186,58 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
         testFactories();
         testForks();
         testFeeSplitter();
+    }
+
+    function test_run_withoutRevenueShare_succeeds() external {
+        input = L2Genesis.Input({
+            l1ChainID: 1,
+            l2ChainID: 2,
+            l1CrossDomainMessengerProxy: payable(address(0x0000000000000000000000000000000000000001)),
+            l1StandardBridgeProxy: payable(address(0x0000000000000000000000000000000000000002)),
+            l1ERC721BridgeProxy: payable(address(0x0000000000000000000000000000000000000003)),
+            opChainProxyAdminOwner: address(0x0000000000000000000000000000000000000004),
+            sequencerFeeVaultRecipient: address(0x0000000000000000000000000000000000000005),
+            sequencerFeeVaultMinimumWithdrawalAmount: 1,
+            sequencerFeeVaultWithdrawalNetwork: 1,
+            baseFeeVaultRecipient: address(0x0000000000000000000000000000000000000006),
+            baseFeeVaultMinimumWithdrawalAmount: 1,
+            baseFeeVaultWithdrawalNetwork: 1,
+            l1FeeVaultRecipient: address(0x0000000000000000000000000000000000000007),
+            l1FeeVaultMinimumWithdrawalAmount: 1,
+            l1FeeVaultWithdrawalNetwork: 1,
+            operatorFeeVaultRecipient: address(0x0000000000000000000000000000000000000008),
+            operatorFeeVaultMinimumWithdrawalAmount: 1,
+            operatorFeeVaultWithdrawalNetwork: 1,
+            governanceTokenOwner: address(0x0000000000000000000000000000000000000009),
+            fork: uint256(LATEST_FORK),
+            deployCrossL2Inbox: true,
+            enableGovernance: true,
+            fundDevAccounts: true,
+            feeSplitterFeeDisbursementInterval: 86400,
+            feeSplitterSharesCalculator: address(0), // No custom shares calculator when revenue share is disabled
+            useRevenueShare: false,
+            chainFeesRecipient: address(0) // Not used when revenue share is disabled
+         });
+        genesis.run(input);
+
+        testProxyAdmin();
+        testPredeploys();
+        testVaults();
+        testGovernance();
+        testFactories();
+        testForks();
+
+        // Test that FeeSplitter is initialized with address(0) when revenue share is disabled
+        IFeeSplitter feeSplitter = IFeeSplitter(payable(Predeploys.FEE_SPLITTER));
+        assertEq(address(feeSplitter.sharesCalculator()), address(0), "sharesCalculator should be zero address");
+        assertEq(feeSplitter.feeDisbursementInterval(), 1 days, "feeDisbursementInterval should be 1 day");
+
+        // Verify that SuperchainRevSharesCalculator and L1Withdrawer have no code
+        assertEq(
+            Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR.code.length,
+            0,
+            "SuperchainRevSharesCalculator should have no code"
+        );
+        assertEq(Predeploys.L1_WITHDRAWER.code.length, 0, "L1Withdrawer should have no code");
     }
 }

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -110,7 +110,7 @@ contract L2Genesis_TestInit is Test {
     }
 
     function testFeeSplitter() internal view {
-        // Only test if revenue share is not enabled
+        // Only test if revenue share is enabled
         if (!input.useRevenueShare) return;
 
         // Check that the shares calculator and fee disbursement interval are set on the fee splitter

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -6,7 +6,11 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { L2Genesis } from "scripts/L2Genesis.s.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { LATEST_FORK } from "scripts/libraries/Config.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
+import { IL1Withdrawer } from "interfaces/L2/IL1Withdrawer.sol";
+import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
+import { ISuperchainRevSharesCalculator } from "interfaces/L2/ISuperchainRevSharesCalculator.sol";
 import { ISequencerFeeVault } from "interfaces/L2/ISequencerFeeVault.sol";
 import { IBaseFeeVault } from "interfaces/L2/IBaseFeeVault.sol";
 import { IL1FeeVault } from "interfaces/L2/IL1FeeVault.sol";
@@ -15,6 +19,8 @@ import { IOptimismMintableERC721Factory } from "interfaces/L2/IOptimismMintableE
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IGovernanceToken } from "interfaces/governance/IGovernanceToken.sol";
 import { IGasPriceOracle } from "interfaces/L2/IGasPriceOracle.sol";
+import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";
+import { ISharesCalculator } from "interfaces/L2/ISharesCalculator.sol";
 
 /// @title L2Genesis_TestInit
 /// @notice Reusable test initialization for `L2Genesis` tests.
@@ -102,6 +108,40 @@ contract L2Genesis_TestInit is Test {
         assertEq(gasPriceOracle.isFjord(), true);
         assertEq(gasPriceOracle.isIsthmus(), true);
     }
+
+    function testFeeSplitter() internal view {
+        // Check that the shares calculator and fee disbursement interval are set on the fee splitter
+        IFeeSplitter feeSplitter = IFeeSplitter(payable(Predeploys.FEE_SPLITTER));
+        assertEq(address(feeSplitter.sharesCalculator()), input.feeSplitterSharesCalculator);
+        assertEq(feeSplitter.feeDisbursementInterval(), 1 days);
+
+        // Only test if revenue share is not enabled
+        if (!input.useRevenueShare) {
+            // Check the shares calculator and l1 withdrawer addresses have no code
+            assertEq(input.feeSplitterSharesCalculator.code.length, 0);
+            assertEq(address(Predeploys.L1_WITHDRAWER).code.length, 0);
+            return;
+        }
+
+        // Check that the superchain rev shares calculator is properly set
+        assertEq(
+            ISuperchainRevSharesCalculator(Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR).shareRecipient(),
+            Predeploys.L1_WITHDRAWER
+        );
+        assertEq(
+            ISuperchainRevSharesCalculator(Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR).remainderRecipient(),
+            input.chainFeesRecipient
+        );
+
+        // Check the L1Withdrawer is properly set
+        assertEq(IL1Withdrawer(Predeploys.L1_WITHDRAWER).minWithdrawalAmount(), 10 ether);
+        assertEq(IL1Withdrawer(Predeploys.L1_WITHDRAWER).recipient(), Constants.OP_FEES_MULTISIG);
+        assertEq(IL1Withdrawer(Predeploys.L1_WITHDRAWER).withdrawalGasLimit(), 300_000);
+        assertEq(
+            IL1Withdrawer(Predeploys.L1_WITHDRAWER).withdrawalData(),
+            abi.encodeCall(IL1StandardBridge.depositETHTo, (Constants.OP_FEES_MULTISIG, 200_000, ""))
+        );
+    }
 }
 
 /// @title L2Genesis_Run_Test
@@ -133,7 +173,9 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
             enableGovernance: true,
             fundDevAccounts: true,
             feeSplitterFeeDisbursementInterval: 86400,
-            feeSplitterSharesCalculator: address(0x000000000000000000000000000000000000000A)
+            feeSplitterSharesCalculator: address(0x000000000000000000000000000000000000000A),
+            useRevenueShare: true,
+            chainFeesRecipient: address(0x000000000000000000000000000000000000000b)
         });
         genesis.run(input);
 
@@ -143,5 +185,6 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
         testGovernance();
         testFactories();
         testForks();
+        testFeeSplitter();
     }
 }

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -20,7 +20,7 @@ import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IGovernanceToken } from "interfaces/governance/IGovernanceToken.sol";
 import { IGasPriceOracle } from "interfaces/L2/IGasPriceOracle.sol";
 import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";
-import { ISharesCalculator } from "interfaces/L2/ISharesCalculator.sol";
+import { IL1Withdrawer } from "interfaces/L2/IL1Withdrawer.sol";
 
 /// @title L2Genesis_TestInit
 /// @notice Reusable test initialization for `L2Genesis` tests.
@@ -115,25 +115,20 @@ contract L2Genesis_TestInit is Test {
 
         // Check that the shares calculator and fee disbursement interval are set on the fee splitter
         IFeeSplitter feeSplitter = IFeeSplitter(payable(Predeploys.FEE_SPLITTER));
-        assertEq(address(feeSplitter.sharesCalculator()), input.feeSplitterSharesCalculator);
         assertEq(feeSplitter.feeDisbursementInterval(), 1 days);
 
+        ISuperchainRevSharesCalculator superchainRevSharesCalculator =
+            ISuperchainRevSharesCalculator(address(feeSplitter.sharesCalculator()));
         // Check that the superchain rev shares calculator is properly set
-        assertEq(
-            ISuperchainRevSharesCalculator(Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR).shareRecipient(),
-            Predeploys.L1_WITHDRAWER
-        );
-        assertEq(
-            ISuperchainRevSharesCalculator(Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR).remainderRecipient(),
-            input.chainFeesRecipient
-        );
+        assertEq(superchainRevSharesCalculator.remainderRecipient(), input.chainFeesRecipient);
 
         // Check the L1Withdrawer is properly set
-        assertEq(IL1Withdrawer(Predeploys.L1_WITHDRAWER).minWithdrawalAmount(), 10 ether);
-        assertEq(IL1Withdrawer(Predeploys.L1_WITHDRAWER).recipient(), Constants.OP_FEES_MULTISIG);
-        assertEq(IL1Withdrawer(Predeploys.L1_WITHDRAWER).withdrawalGasLimit(), 300_000);
+        IL1Withdrawer l1Withdrawer = IL1Withdrawer(superchainRevSharesCalculator.shareRecipient());
+        assertEq(l1Withdrawer.minWithdrawalAmount(), 10 ether);
+        assertEq(l1Withdrawer.recipient(), Constants.OP_FEES_MULTISIG);
+        assertEq(l1Withdrawer.withdrawalGasLimit(), 300_000);
         assertEq(
-            IL1Withdrawer(Predeploys.L1_WITHDRAWER).withdrawalData(),
+            l1Withdrawer.withdrawalData(),
             abi.encodeCall(IL1StandardBridge.depositETHTo, (Constants.OP_FEES_MULTISIG, 200_000, ""))
         );
     }
@@ -168,7 +163,6 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
             enableGovernance: true,
             fundDevAccounts: true,
             feeSplitterFeeDisbursementInterval: 86400,
-            feeSplitterSharesCalculator: Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR,
             useRevenueShare: true,
             chainFeesRecipient: address(0x000000000000000000000000000000000000000b)
         });
@@ -209,7 +203,6 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
             enableGovernance: true,
             fundDevAccounts: true,
             feeSplitterFeeDisbursementInterval: 86400,
-            feeSplitterSharesCalculator: address(0), // No custom shares calculator when revenue share is disabled
             useRevenueShare: false,
             chainFeesRecipient: address(0) // Not used when revenue share is disabled
          });
@@ -226,13 +219,5 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
         IFeeSplitter feeSplitter = IFeeSplitter(payable(Predeploys.FEE_SPLITTER));
         assertEq(address(feeSplitter.sharesCalculator()), address(0), "sharesCalculator should be zero address");
         assertEq(feeSplitter.feeDisbursementInterval(), 1 days, "feeDisbursementInterval should be 1 day");
-
-        // Verify that SuperchainRevSharesCalculator and L1Withdrawer have no code
-        assertEq(
-            Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR.code.length,
-            0,
-            "SuperchainRevSharesCalculator should have no code"
-        );
-        assertEq(Predeploys.L1_WITHDRAWER.code.length, 0, "L1Withdrawer should have no code");
     }
 }

--- a/packages/contracts-bedrock/test/setup/CommonTest.sol
+++ b/packages/contracts-bedrock/test/setup/CommonTest.sol
@@ -34,6 +34,7 @@ contract CommonTest is Test, Setup, Events {
 
     bool useAltDAOverride;
     bool useInteropOverride;
+    bool useRevenueShareOverride;
 
     /// @dev This value is only used in forked tests. During forked tests, the default is to perform the upgrade before
     ///      running the tests.
@@ -65,6 +66,9 @@ contract CommonTest is Test, Setup, Events {
         }
         if (useInteropOverride) {
             deploy.cfg().setUseInterop(true);
+        }
+        if (useRevenueShareOverride) {
+            deploy.cfg().setUseRevenueShare(true);
         }
         if (useUpgradedFork) {
             deploy.cfg().setUseUpgradedFork(true);
@@ -193,6 +197,12 @@ contract CommonTest is Test, Setup, Events {
     function enableInterop() public {
         _checkNotDeployed("interop");
         useInteropOverride = true;
+    }
+
+    /// @dev Enables revenue sharing mode for testing
+    function enableRevenueShare() public {
+        _checkNotDeployed("revenue share");
+        useRevenueShareOverride = true;
     }
 
     /// @dev Disables upgrade mode for testing. By default the fork testing env will be upgraded to the latest

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -17,6 +17,7 @@ import { Config } from "scripts/libraries/Config.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Constants } from "src/libraries/Constants.sol";
 import { Preinstalls } from "src/libraries/Preinstalls.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 import { Chains } from "scripts/libraries/Chains.sol";
@@ -146,9 +147,8 @@ contract Setup {
     IOptimismSuperchainERC20Factory l2OptimismSuperchainERC20Factory =
         IOptimismSuperchainERC20Factory(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_FACTORY);
     IFeeSplitter feeSplitter = IFeeSplitter(payable(Predeploys.FEE_SPLITTER));
-    IL1Withdrawer l1Withdrawer = IL1Withdrawer(Predeploys.L1_WITHDRAWER);
-    ISuperchainRevSharesCalculator superchainRevSharesCalculator = 
-        ISuperchainRevSharesCalculator(Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR);
+    IL1Withdrawer l1Withdrawer;
+    ISuperchainRevSharesCalculator superchainRevSharesCalculator;
 
     /// @notice Indicates whether a test is running against a forked production network.
     function isForkTest() public view returns (bool) {
@@ -330,11 +330,17 @@ contract Setup {
                 enableGovernance: deploy.cfg().enableGovernance(),
                 fundDevAccounts: deploy.cfg().fundDevAccounts(),
                 feeSplitterFeeDisbursementInterval: deploy.cfg().feeSplitterFeeDisbursementInterval(),
-                feeSplitterSharesCalculator: deploy.cfg().feeSplitterSharesCalculator(),
                 useRevenueShare: deploy.cfg().useRevenueShare(),
                 chainFeesRecipient: deploy.cfg().chainFeesRecipient()
             })
         );
+
+        // Initialize revenue sharing contracts if enabled
+        if (deploy.cfg().useRevenueShare()) {
+            // Get the addresses from artifacts that were saved during L2Genesis
+            l1Withdrawer = IL1Withdrawer(artifacts.mustGetAddress("L1Withdrawer"));
+            superchainRevSharesCalculator = ISuperchainRevSharesCalculator(artifacts.mustGetAddress("SuperchainRevSharesCalculator"));
+        }
 
         // Set the governance token's owner to be the final system owner
         address finalSystemOwner = deploy.cfg().finalSystemOwner();

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -325,7 +325,9 @@ contract Setup {
                 enableGovernance: deploy.cfg().enableGovernance(),
                 fundDevAccounts: deploy.cfg().fundDevAccounts(),
                 feeSplitterFeeDisbursementInterval: deploy.cfg().feeSplitterFeeDisbursementInterval(),
-                feeSplitterSharesCalculator: deploy.cfg().feeSplitterSharesCalculator()
+                feeSplitterSharesCalculator: deploy.cfg().feeSplitterSharesCalculator(),
+                useRevenueShare: deploy.cfg().useRevenueShare(),
+                chainFeesRecipient: deploy.cfg().chainFeesRecipient()
             })
         );
 

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -337,9 +337,17 @@ contract Setup {
 
         // Initialize revenue sharing contracts if enabled
         if (deploy.cfg().useRevenueShare()) {
-            // Get the addresses from artifacts that were saved during L2Genesis
-            l1Withdrawer = IL1Withdrawer(artifacts.mustGetAddress("L1Withdrawer"));
-            superchainRevSharesCalculator = ISuperchainRevSharesCalculator(artifacts.mustGetAddress("SuperchainRevSharesCalculator"));
+            // Get the addresses from artifacts (they were saved during L2Genesis.run())
+            // If artifacts aren't available, the addresses will just be zero and tests that need them will fail appropriately
+            address l1WithdrawerAddr = artifacts.getAddress("L1Withdrawer");
+            address superchainRevSharesCalculatorAddr = artifacts.getAddress("SuperchainRevSharesCalculator");
+            
+            if (l1WithdrawerAddr != address(0)) {
+                l1Withdrawer = IL1Withdrawer(l1WithdrawerAddr);
+            }
+            if (superchainRevSharesCalculatorAddr != address(0)) {
+                superchainRevSharesCalculator = ISuperchainRevSharesCalculator(superchainRevSharesCalculatorAddr);
+            }
         }
 
         // Set the governance token's owner to be the final system owner

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -61,6 +61,8 @@ import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisput
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { ICrossL2Inbox } from "interfaces/L2/ICrossL2Inbox.sol";
 import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";
+import { IL1Withdrawer } from "interfaces/L2/IL1Withdrawer.sol";
+import { ISuperchainRevSharesCalculator } from "interfaces/L2/ISuperchainRevSharesCalculator.sol";
 
 /// @title Setup
 /// @dev This contact is responsible for setting up the contracts in state. It currently
@@ -144,6 +146,9 @@ contract Setup {
     IOptimismSuperchainERC20Factory l2OptimismSuperchainERC20Factory =
         IOptimismSuperchainERC20Factory(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_FACTORY);
     IFeeSplitter feeSplitter = IFeeSplitter(payable(Predeploys.FEE_SPLITTER));
+    IL1Withdrawer l1Withdrawer = IL1Withdrawer(Predeploys.L1_WITHDRAWER);
+    ISuperchainRevSharesCalculator superchainRevSharesCalculator = 
+        ISuperchainRevSharesCalculator(Predeploys.SUPERCHAIN_REV_SHARES_CALCULATOR);
 
     /// @notice Indicates whether a test is running against a forked production network.
     function isForkTest() public view returns (bool) {


### PR DESCRIPTION
* Managed system deployment and initialization on `Genesis`.
* Added `useRevenueShare` and `chainFeesRecipient` flags on the `Input` struct.
* Deployed `SuperchainRevSharesCalculator` as default shares calculator implementation.
* Deployed `SuperchainRevSharesCalculator` and `L1Withdrawer` deterministically on Genesis and stored them to retrieve on tests.
* Integrated `FeeSplitter`, `SuperchainRevSharesCalculator` and `L1Withdrawer` tests with the new setup feature by enabling the flag
* Add tests for genesis script on the `useRevenueShare` enabled and disabled branches

---
CLOSES OPT-1080