### PR TITLE
feat: add max disbursement time

### DIFF
--- a/packages/contracts-bedrock/interfaces/L2/IFeeSplitter.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IFeeSplitter.sol
@@ -6,6 +6,7 @@ import { ISharesCalculator } from "interfaces/L2/ISharesCalculator.sol";
 
 interface IFeeSplitter is ISemver {
 
+    error FeeSplitter_ExceedsMaxFeeDisbursementTime();
     error FeeSplitter_SharesCalculatorCannotBeZero();
     error FeeSplitter_DisbursementIntervalNotReached();
     error FeeSplitter_FeeShareInfoEmpty();

--- a/packages/contracts-bedrock/src/L2/FeeSplitter.sol
+++ b/packages/contracts-bedrock/src/L2/FeeSplitter.sol
@@ -21,6 +21,9 @@ import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/I
 /// @notice Withdraws funds from system FeeVault contracts, sends Optimism their revenue share, and
 ///         sends the remaining funds to the fee router.
 contract FeeSplitter is ISemver, Initializable {
+    /// @notice Thrown when the fee disbursement interval exceeds the maximum allowed.
+    error FeeSplitter_ExceedsMaxFeeDisbursementTime();
+
     /// @notice Thrown when the share calculator address is zero.
     error FeeSplitter_SharesCalculatorCannotBeZero();
 
@@ -61,6 +64,9 @@ contract FeeSplitter is ISemver, Initializable {
 
     /// @custom:semver 1.0.0
     string public constant version = "1.0.0";
+
+    /// @notice max time between fee disbursements
+    uint128 public constant MAX_DISBURSEMENT_INTERVAL = 365 days;
 
     /// @notice The contract which determines the recipients and their weights for fee disbursement.
     ISharesCalculator public sharesCalculator;
@@ -105,6 +111,9 @@ contract FeeSplitter is ISemver, Initializable {
     /// @param _sharesCalculator            The share calculator contract.
     /// @param _feeDisbursementInterval    The minimum amount of time in seconds that must pass between fee disbursals.
     function initialize(ISharesCalculator _sharesCalculator, uint128 _feeDisbursementInterval) external initializer {
+        if (_feeDisbursementInterval > MAX_DISBURSEMENT_INTERVAL) {
+            revert FeeSplitter_ExceedsMaxFeeDisbursementTime();
+        }
         sharesCalculator = _sharesCalculator;
         feeDisbursementInterval = _feeDisbursementInterval;
 
@@ -183,6 +192,9 @@ contract FeeSplitter is ISemver, Initializable {
     function setFeeDisbursementInterval(uint128 _newFeeDisbursementInterval) external {
         if (msg.sender != IProxyAdmin(Predeploys.PROXY_ADMIN).owner()) {
             revert FeeSplitter_OnlyProxyAdminOwner();
+        }
+        if (_newFeeDisbursementInterval > MAX_DISBURSEMENT_INTERVAL) {
+            revert FeeSplitter_ExceedsMaxFeeDisbursementTime();
         }
         uint128 oldFeeDisbursementInterval = feeDisbursementInterval;
         feeDisbursementInterval = _newFeeDisbursementInterval;

--- a/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
@@ -96,6 +96,22 @@ contract FeeSplitter_Initialize_Test is FeeSplitter_TestInit {
         feeSplitter.initialize(ISharesCalculator(address(_defaultSharesCalculator)), _defaultFeeDisbursementInterval);
     }
 
+    /// @notice Test revert on initialization when disbursement interval is too long
+    function test_feeSplitter_initializationMaxTime_reverts(uint256 _disbursementInterval) public {
+        _disbursementInterval = bound(_disbursementInterval, 365 days + 1, type(uint128).max);
+
+        // Deploy a fresh instance for testing initialization
+        address impl = address(uint160(uint256(keccak256("FeeSplitterTestImpl3"))));
+        vm.etch(impl, vm.getDeployedCode("FeeSplitter.sol:FeeSplitter"));
+
+        vm.expectRevert(IFeeSplitter.FeeSplitter_ExceedsMaxFeeDisbursementTime.selector);
+
+        vm.prank(_owner);
+        IFeeSplitter(payable(impl)).initialize(
+            ISharesCalculator(address(_defaultSharesCalculator)), uint128(_disbursementInterval)
+        );
+    }
+
     /// @notice Test successful initialization with proper event emission
     function test_feeSplitter_initialization_succeeds() public {
         // Deploy a fresh instance for testing initialization
@@ -446,9 +462,19 @@ contract FeeSplitter_SetFeeDisbursementInterval_Test is FeeSplitter_TestInit {
         feeSplitter.setFeeDisbursementInterval(48 hours);
     }
 
+    /// @notice Test setFeeDisbursementInterval reverts when interval is too long
+    function testFuzz_feeSplitterSetFeeDisbursementInterval_WhenIntervalTooLong_Reverts(uint256 _disbursementInterval) public {
+
+        _disbursementInterval = bound(_disbursementInterval, 365 days + 1, type(uint128).max);
+
+        vm.prank(_owner);
+        vm.expectRevert(IFeeSplitter.FeeSplitter_ExceedsMaxFeeDisbursementTime.selector);
+        feeSplitter.setFeeDisbursementInterval(uint128(_disbursementInterval));
+    }
+
     /// @notice Test successful setFeeDisbursementInterval
     function testFuzz_feeSplitterSetFeeDisbursementInterval_succeeds(uint128 _newInterval) public {
-        _newInterval = uint128(bound(_newInterval, 1, type(uint128).max));
+        _newInterval = uint128(bound(_newInterval, 1, 365 days));
 
         vm.expectEmit(address(feeSplitter));
         emit FeeDisbursementIntervalUpdated(feeSplitter.feeDisbursementInterval(), _newInterval);


### PR DESCRIPTION
added a MAX_DISBURSEMENT_INTERVAL (1 year) in `FeeSplitter.sol` to avoid the chain operator from setting a very long timer and then losing the keys (funds get stuck)