### PR TITLE
feat: invariants and tests

### DIFF
--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -119,20 +119,21 @@ contract FeeSplitter_Preconditions is CommonTest {
     /// @notice Add collected fee to a vault
     /// @param _amount The seed of amount to add to the vault
     /// @param _vaultIndex The seed of the vault's index to add the fee to
-    /// @dev The net revenue has an upper bound to avoid overflows in the shares calculator (where
-    /// `uint256 netShare = (netRevenue * uint256(NET_SHARE_BPS)) / BASIS_POINT_SCALE;` would overflow
-    /// otherwise)
+    /// @dev The net and gross revenue have an upper bound to avoid overflows in the shares calculator
     function addCollectedFeeToVault(uint256 _amount, uint256 _vaultIndex) public {
         _vaultIndex = bound(_vaultIndex, 0, 3);
 
         // Avoid having the net revenue exceeding the max uint256 / 1500 (net share default is 1500 bps in the
         // superchain rev shares calculator). This covers the gross share too (as net * 1500 <= gross * 1500)
-        _amount = bound(
-            _amount,
-            0,
-            (type(uint256).max / 1500) - address(Predeploys.SEQUENCER_FEE_WALLET).balance
-                - address(Predeploys.BASE_FEE_VAULT).balance - address(Predeploys.OPERATOR_FEE_VAULT).balance
-        );
+        // or the gross revenue exceeding the max uint256 / 2500.
+        uint256 _maxNetRevenue = (type(uint256).max / 1500) - address(Predeploys.SEQUENCER_FEE_WALLET).balance
+            - address(Predeploys.BASE_FEE_VAULT).balance - address(Predeploys.OPERATOR_FEE_VAULT).balance;
+
+        uint256 _maxGrossRevenue = (type(uint256).max / 2500) - address(Predeploys.SEQUENCER_FEE_WALLET).balance
+            - address(Predeploys.BASE_FEE_VAULT).balance - address(Predeploys.OPERATOR_FEE_VAULT).balance
+            - address(Predeploys.L1_FEE_VAULT).balance;
+
+        _amount = bound(_amount, 0, _maxNetRevenue < _maxGrossRevenue ? _maxNetRevenue : _maxGrossRevenue);
 
         if (_vaultIndex == 0) {
             vm.deal(address(Predeploys.SEQUENCER_FEE_WALLET), _amount);

--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.15;
 
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";
-
 import { StdInvariant } from "forge-std/StdInvariant.sol";
 import { InvariantTest } from "test/invariants/InvariantTest.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
@@ -86,7 +85,7 @@ contract FeeSplitter_Preconditions is CommonTest {
     /// @notice Add collected fee to a vault
     /// @param _amount The seed of amount to add to the vault
     /// @param _vaultIndex The seed of the vault's index to add the fee to
-    /// @dev The net revenue has an upper bound to avoid overflows in the shares calculator (where
+    /// @dev The gross revenue has an upper bound to avoid overflows in the shares calculator (where
     /// `uint256 netShare = (netRevenue * uint256(NET_SHARE_BPS)) / BASIS_POINT_SCALE;` would overflow
     /// otherwise)
     function addCollectedFeeToVault(uint256 _amount, uint256 _vaultIndex) public {

--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { StdUtils } from "forge-std/StdUtils.sol";
+import { Vm } from "forge-std/Vm.sol";
+
+import { StdInvariant } from "forge-std/StdInvariant.sol";
+import { InvariantTest } from "test/invariants/InvariantTest.sol";
+import { CommonTest } from "test/setup/CommonTest.sol";
+import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";
+
+/// @notice A struct to keep track of the state when a disburse call fails
+struct DisburseFailureState {
+    uint256 sequencerFeeVaultBalance;
+    uint256 baseFeeVaultBalance;
+    uint256 l1FeeVaultBalance;
+    uint256 operatorFeeVaultBalance;
+    uint256 attemptTimestamp;
+}
+
+/// @title Handler to call the disburseFees function
+contract FeeSplitter_Disburser is StdUtils {
+    /// @notice Vm instance
+    Vm internal vm;
+
+    /// @notice FeeSplitter contract
+    IFeeSplitter public feeSplitter;
+
+    /// @notice Flag to track if a disburseFees() call failed
+    bool public txFailed;
+
+    /// @notice Keep track of the balances and timestamp of a failed disbursement
+    DisburseFailureState internal failureState;
+
+    /// @notice Aggregate of the vault balances disbursed
+    uint256 public ghost_grossRevenueDisbursed;
+
+    constructor(Vm _vm, IFeeSplitter _feeSplitter) {
+        vm = _vm;
+        feeSplitter = _feeSplitter;
+    }
+
+    /// @notice Get the failure state (convenience, to keep the struct)
+    function getFailureState() external view returns (DisburseFailureState memory failureState_) {
+        failureState_ = failureState;
+    }
+
+    /// @notice handler for FeeSplitter.disburseFees()
+    /// @dev It update important ghost var, in both success and failure cases:
+    /// - success: update the overall amount disbursed (ie add the sum of the vaults balances before disbursement)
+    /// - failure: update the failure state (all vault balances and the current timestamp)
+    function disburse() public {
+        uint256 _aggregateVaultsBalances = address(Predeploys.SEQUENCER_FEE_WALLET).balance
+            + address(Predeploys.BASE_FEE_VAULT).balance + address(Predeploys.L1_FEE_VAULT).balance
+            + address(Predeploys.OPERATOR_FEE_VAULT).balance;
+
+        try feeSplitter.disburseFees() {
+            // reset the fail flags
+            txFailed = false;
+            delete failureState;
+
+            ghost_grossRevenueDisbursed += _aggregateVaultsBalances;
+        } catch {
+            // keep track of the failing state
+            txFailed = true;
+            failureState.sequencerFeeVaultBalance = address(Predeploys.SEQUENCER_FEE_WALLET).balance;
+            failureState.baseFeeVaultBalance = address(Predeploys.BASE_FEE_VAULT).balance;
+            failureState.l1FeeVaultBalance = address(Predeploys.L1_FEE_VAULT).balance;
+            failureState.operatorFeeVaultBalance = address(Predeploys.OPERATOR_FEE_VAULT).balance;
+            failureState.attemptTimestamp = block.timestamp;
+        }
+    }
+}
+
+/// @title Handler to set arbitrary preconditions (balance and block timestamp)
+contract FeeSplitter_Preconditions is CommonTest {
+    /// @notice Warp the block timestamp
+    /// @param _seconds The seed of the seconds to warp the block timestamp by
+    function warp(uint256 _seconds) public {
+        _seconds = bound(_seconds, 0, 10 days);
+        vm.warp(block.timestamp + _seconds);
+    }
+
+    /// @notice Add collected fee to a vault
+    /// @param _amount The seed of amount to add to the vault
+    /// @param _vaultIndex The seed of the vault's index to add the fee to
+    /// @dev The net revenue has an upper bound to avoid overflows in the shares calculator (where
+    /// `uint256 netShare = (netRevenue * uint256(NET_SHARE_BPS)) / BASIS_POINT_SCALE;` would overflow
+    /// otherwise)
+    function addCollectedFeeToVault(uint256 _amount, uint256 _vaultIndex) public {
+        _vaultIndex = bound(_vaultIndex, 0, 3);
+
+        // Avoid having the net revenue exceeding the max uint256 / 1500 (net share default is 1500 bps in the
+        // superchain rev shares calculator)
+        _amount = bound(
+            _amount,
+            0,
+            (type(uint256).max / 1500) - address(Predeploys.SEQUENCER_FEE_WALLET).balance
+                - address(Predeploys.BASE_FEE_VAULT).balance - address(Predeploys.OPERATOR_FEE_VAULT).balance
+        );
+
+        if (_vaultIndex == 0) {
+            vm.deal(address(Predeploys.SEQUENCER_FEE_WALLET), _amount);
+        } else if (_vaultIndex == 1) {
+            vm.deal(address(Predeploys.BASE_FEE_VAULT), _amount);
+        } else if (_vaultIndex == 2) {
+            vm.deal(address(Predeploys.L1_FEE_VAULT), _amount);
+        } else if (_vaultIndex == 3) {
+            vm.deal(address(Predeploys.OPERATOR_FEE_VAULT), _amount);
+        }
+    }
+}
+
+/// @title Invariants for the FeeSplitter
+/// @notice The invariants tested are:
+/// - no dust accumulation in the FeeSplitter
+/// - total disbursed fees should always be equal to the sum of the vault balances before disbursement
+/// - disburseFees can only revert if either one of the vault has a balance below it's minimum withdrawal amount
+///   or if the disbursement interval has not been reached yet
+/// @dev These invariants are covering the system formed by:
+/// FeeSplitter, 4 FeeVault's, SuperchainRevSharesCalculator, L1Withdrawer
+contract FeeSplitter_Invariant is CommonTest {
+    /// @notice Handler for disbursing fees
+    FeeSplitter_Disburser public disburser;
+
+    /// @notice Handler to set test preconditions
+    FeeSplitter_Preconditions public preconditions;
+
+    /// @notice Setup: enable the revenue share, deploy handlers and target them.
+    function setUp() public override {
+        super.enableRevenueShare();
+        super.setUp();
+
+        IFeeSplitter feeSplitter = IFeeSplitter(payable(Predeploys.FEE_SPLITTER));
+
+        disburser = new FeeSplitter_Disburser(vm, feeSplitter);
+        preconditions = new FeeSplitter_Preconditions();
+
+        targetContract(address(disburser));
+
+        targetContract(address(preconditions));
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = FeeSplitter_Preconditions.warp.selector;
+        selectors[1] = FeeSplitter_Preconditions.addCollectedFeeToVault.selector;
+        targetSelector(FuzzSelector({ addr: address(preconditions), selectors: selectors }));
+    }
+
+    /// @notice Invariant: The fee splitter balance should always be 0
+    /// @dev This invariant doesn't account for direct forced transfers (eg selfdestruct)
+    function invariant_noDust() external view {
+        assertEq(address(disburser.feeSplitter()).balance, 0);
+    }
+
+    /// @notice Invariant: The total disbursed fees should always be equal to the sum of the vault balances before
+    /// disbursement
+    /// @dev This invariant can also be expressed as "disburseFees is only successful if all vaults can transfer the
+    /// fee/all or nothing (0 threshold is accepted)" as, otherwise, some funds would still be in the vaults,
+    /// invalidating the equality
+    function invariant_balanceConservation() external view {
+        assertEq(
+            disburser.ghost_grossRevenueDisbursed(),
+            address(l1Withdrawer).balance + l1Withdrawer.recipient().balance
+                + Predeploys.L2_TO_L1_MESSAGE_PASSER.balance + address(chainFeesRecipient).balance
+        );
+    }
+
+    /// @notice Invariants: these are revert invariants, disburseFees can only revert if either one of the vault
+    /// has a balance below it's minimum withdrawal amount (no other revert conditions are possible for the vault)
+    /// or if the disbursement interval has not been reached yet.
+    /// @dev This invariant is also testing the "no partial disbursement", as the previous one.
+    function invariant_disburseReverts() external view {
+        if (disburser.txFailed()) {
+            DisburseFailureState memory _failureState = disburser.getFailureState();
+
+            assertTrue(
+                // either one of the vaults is below the minimum withdrawal amount
+                _failureState.sequencerFeeVaultBalance
+                    < IFeeVault(payable(Predeploys.SEQUENCER_FEE_WALLET)).minWithdrawalAmount()
+                    || _failureState.baseFeeVaultBalance
+                        < IFeeVault(payable(Predeploys.BASE_FEE_VAULT)).minWithdrawalAmount()
+                    || _failureState.l1FeeVaultBalance < IFeeVault(payable(Predeploys.L1_FEE_VAULT)).minWithdrawalAmount()
+                    || _failureState.operatorFeeVaultBalance
+                        < IFeeVault(payable(Predeploys.OPERATOR_FEE_VAULT)).minWithdrawalAmount()
+                // not enough time since last disbursement
+                || _failureState.attemptTimestamp
+                    < disburser.feeSplitter().lastDisbursementTime() + disburser.feeSplitter().feeDisbursementInterval()
+            );
+        }
+    }
+}

--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -7,15 +7,20 @@ import { StdInvariant } from "forge-std/StdInvariant.sol";
 import { InvariantTest } from "test/invariants/InvariantTest.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";
 
 /// @notice A struct to keep track of the state when a disburse call fails
 struct DisburseFailureState {
     uint256 sequencerFeeVaultBalance;
+    uint256 sequencerFeeVaultMinWithdrawalAmount;
     uint256 baseFeeVaultBalance;
+    uint256 baseFeeVaultMinWithdrawalAmount;
     uint256 l1FeeVaultBalance;
+    uint256 l1FeeVaultMinWithdrawalAmount;
     uint256 operatorFeeVaultBalance;
+    uint256 operatorFeeVaultMinWithdrawalAmount;
     uint256 attemptTimestamp;
 }
 
@@ -65,9 +70,17 @@ contract FeeSplitter_Disburser is StdUtils {
             // keep track of the failing state
             txFailed = true;
             failureState.sequencerFeeVaultBalance = address(Predeploys.SEQUENCER_FEE_WALLET).balance;
+            failureState.sequencerFeeVaultMinWithdrawalAmount =
+                IFeeVault(payable(Predeploys.SEQUENCER_FEE_WALLET)).minWithdrawalAmount();
             failureState.baseFeeVaultBalance = address(Predeploys.BASE_FEE_VAULT).balance;
+            failureState.baseFeeVaultMinWithdrawalAmount =
+                IFeeVault(payable(Predeploys.BASE_FEE_VAULT)).minWithdrawalAmount();
             failureState.l1FeeVaultBalance = address(Predeploys.L1_FEE_VAULT).balance;
+            failureState.l1FeeVaultMinWithdrawalAmount =
+                IFeeVault(payable(Predeploys.L1_FEE_VAULT)).minWithdrawalAmount();
             failureState.operatorFeeVaultBalance = address(Predeploys.OPERATOR_FEE_VAULT).balance;
+            failureState.operatorFeeVaultMinWithdrawalAmount =
+                IFeeVault(payable(Predeploys.OPERATOR_FEE_VAULT)).minWithdrawalAmount();
             failureState.attemptTimestamp = block.timestamp;
         }
     }
@@ -75,6 +88,26 @@ contract FeeSplitter_Disburser is StdUtils {
 
 /// @title Handler to set arbitrary preconditions (balance and block timestamp)
 contract FeeSplitter_Preconditions is CommonTest {
+    /// @notice modify the min amount to withdraw from a vault
+    /// @dev We include the case where min amount is 0 (ie no minimum to withdraw)
+    /// @param _minAmount The seed of the min amount to withdraw from a vault
+    /// @param _vaultIndex The seed of the vault's index to set the min amount to withdraw from
+    function setMinAmount(uint256 _minAmount, uint256 _vaultIndex) public {
+        _minAmount = bound(_minAmount, 0, 10 ether);
+
+        vm.prank(IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
+
+        if (_vaultIndex == 0) {
+            IFeeVault(payable(Predeploys.SEQUENCER_FEE_WALLET)).setMinWithdrawalAmount(_minAmount);
+        } else if (_vaultIndex == 1) {
+            IFeeVault(payable(Predeploys.BASE_FEE_VAULT)).setMinWithdrawalAmount(_minAmount);
+        } else if (_vaultIndex == 2) {
+            IFeeVault(payable(Predeploys.L1_FEE_VAULT)).setMinWithdrawalAmount(_minAmount);
+        } else if (_vaultIndex == 3) {
+            IFeeVault(payable(Predeploys.OPERATOR_FEE_VAULT)).setMinWithdrawalAmount(_minAmount);
+        }
+    }
+
     /// @notice Warp the block timestamp
     /// @param _seconds The seed of the seconds to warp the block timestamp by
     function warp(uint256 _seconds) public {
@@ -85,14 +118,14 @@ contract FeeSplitter_Preconditions is CommonTest {
     /// @notice Add collected fee to a vault
     /// @param _amount The seed of amount to add to the vault
     /// @param _vaultIndex The seed of the vault's index to add the fee to
-    /// @dev The gross revenue has an upper bound to avoid overflows in the shares calculator (where
+    /// @dev The net revenue has an upper bound to avoid overflows in the shares calculator (where
     /// `uint256 netShare = (netRevenue * uint256(NET_SHARE_BPS)) / BASIS_POINT_SCALE;` would overflow
     /// otherwise)
     function addCollectedFeeToVault(uint256 _amount, uint256 _vaultIndex) public {
         _vaultIndex = bound(_vaultIndex, 0, 3);
 
         // Avoid having the net revenue exceeding the max uint256 / 1500 (net share default is 1500 bps in the
-        // superchain rev shares calculator)
+        // superchain rev shares calculator). This covers the gross share too (as net * 1500 <= gross * 1500)
         _amount = bound(
             _amount,
             0,
@@ -138,9 +171,10 @@ contract FeeSplitter_Invariant is CommonTest {
         targetContract(address(disburser));
 
         targetContract(address(preconditions));
-        bytes4[] memory selectors = new bytes4[](2);
+        bytes4[] memory selectors = new bytes4[](3);
         selectors[0] = FeeSplitter_Preconditions.warp.selector;
         selectors[1] = FeeSplitter_Preconditions.addCollectedFeeToVault.selector;
+        selectors[2] = FeeSplitter_Preconditions.setMinAmount.selector;
         targetSelector(FuzzSelector({ addr: address(preconditions), selectors: selectors }));
     }
 
@@ -174,17 +208,30 @@ contract FeeSplitter_Invariant is CommonTest {
 
             assertTrue(
                 // either one of the vaults is below the minimum withdrawal amount
-                _failureState.sequencerFeeVaultBalance
-                    < IFeeVault(payable(Predeploys.SEQUENCER_FEE_WALLET)).minWithdrawalAmount()
-                    || _failureState.baseFeeVaultBalance
-                        < IFeeVault(payable(Predeploys.BASE_FEE_VAULT)).minWithdrawalAmount()
-                    || _failureState.l1FeeVaultBalance < IFeeVault(payable(Predeploys.L1_FEE_VAULT)).minWithdrawalAmount()
-                    || _failureState.operatorFeeVaultBalance
-                        < IFeeVault(payable(Predeploys.OPERATOR_FEE_VAULT)).minWithdrawalAmount()
+                _failureState.sequencerFeeVaultBalance < _failureState.sequencerFeeVaultMinWithdrawalAmount
+                    || _failureState.baseFeeVaultBalance < _failureState.baseFeeVaultMinWithdrawalAmount
+                    || _failureState.l1FeeVaultBalance < _failureState.l1FeeVaultMinWithdrawalAmount
+                    || _failureState.operatorFeeVaultBalance < _failureState.operatorFeeVaultMinWithdrawalAmount
                 // not enough time since last disbursement
                 || _failureState.attemptTimestamp
                     < disburser.feeSplitter().lastDisbursementTime() + disburser.feeSplitter().feeDisbursementInterval()
             );
         }
+    }
+
+    function test_repro() external {
+        FeeSplitter_Preconditions(0x1d1499e622D69689cdf9004d05Ec547d650Ff211).addCollectedFeeToVault(
+            (10000 / 250) - 1, 17586
+        );
+        FeeSplitter_Preconditions(0x1d1499e622D69689cdf9004d05Ec547d650Ff211).setMinAmount(0, 0);
+        FeeSplitter_Preconditions(0x1d1499e622D69689cdf9004d05Ec547d650Ff211).setMinAmount(0, 1);
+        FeeSplitter_Preconditions(0x1d1499e622D69689cdf9004d05Ec547d650Ff211).setMinAmount(0, 2);
+        FeeSplitter_Preconditions(0x1d1499e622D69689cdf9004d05Ec547d650Ff211).setMinAmount(0, 3);
+        FeeSplitter_Preconditions(0x1d1499e622D69689cdf9004d05Ec547d650Ff211).warp(
+            1262019975972037049913916341930955891865197205853087
+        );
+
+        FeeSplitter_Disburser(0xa0Cb889707d426A7A386870A03bc70d1b0697598).disburse();
+        this.invariant_disburseReverts();
     }
 }

--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -121,7 +121,6 @@ contract FeeSplitter_Preconditions is CommonTest {
     /// @param _minAmount The seed of the min amount to withdraw from a vault
     /// @param _vaultIndex The seed of the vault's index to set the min amount to withdraw from
     function setMinAmount(uint256 _minAmount, uint256 _vaultIndex) public {
-        _minAmount = bound(_minAmount, 0, 10 ether);
         _vaultIndex = bound(_vaultIndex, 0, 3);
 
         vm.prank(IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
@@ -163,6 +162,36 @@ contract FeeSplitter_Preconditions is CommonTest {
         }
     }
 }
+/// @title Handler to set the call distribution bias for setMinAmount
+/// @notice This bias the distribution of calls to setMinAmount, favoring 80% of the calls to set the min amount to 0
+/// as it is the "vanilla" case.
+/// @dev See https://getfoundry.sh/forge/advanced-testing/invariant-testing#function-call-probability-distribution
+/// We favor this over a single wrapper with a seed to branch to keep distinct edges/selectors while using a corpus
+
+contract FeeSplitter_CallDistributionBias is FeeSplitter_Preconditions {
+    uint256 public amountZeroCalls;
+    uint256 public amountNotZeroCalls;
+
+    function setMinAmountZero1(uint256 _vaultIndex) public {
+        amountZeroCalls++;
+        setMinAmount(0, _vaultIndex);
+    }
+
+    function setMinAmountZero2(uint256 _vaultIndex) public {
+        amountZeroCalls++;
+        setMinAmount(0, _vaultIndex);
+    }
+
+    function setMinAmountZero3(uint256 _vaultIndex) public {
+        amountZeroCalls++;
+        setMinAmount(0, _vaultIndex);
+    }
+
+    function setMinAmountNotZero(uint256 _minAmount, uint256 _vaultIndex) public {
+        amountNotZeroCalls++;
+        setMinAmount(_minAmount, _vaultIndex);
+    }
+}
 
 /// @title Invariants for the FeeSplitter
 /// @notice The invariants tested are:
@@ -179,6 +208,9 @@ contract FeeSplitter_Invariant is CommonTest {
     /// @notice Handler to set test preconditions
     FeeSplitter_Preconditions public preconditions;
 
+    /// @notice Handler to set the call distribution bias
+    FeeSplitter_CallDistributionBias public callDistributionBias;
+
     /// @notice Setup: enable the revenue share, deploy handlers and target them.
     function setUp() public override {
         super.enableRevenueShare();
@@ -186,14 +218,22 @@ contract FeeSplitter_Invariant is CommonTest {
 
         disburser = new FeeSplitter_Disburser(vm, feeSplitter, l1Withdrawer);
         preconditions = new FeeSplitter_Preconditions();
+        callDistributionBias = new FeeSplitter_CallDistributionBias();
 
         targetContract(address(disburser));
 
+        targetContract(address(callDistributionBias));
+        bytes4[] memory selectors = new bytes4[](4);
+        selectors[0] = FeeSplitter_CallDistributionBias.setMinAmountZero1.selector;
+        selectors[1] = FeeSplitter_CallDistributionBias.setMinAmountZero2.selector;
+        selectors[2] = FeeSplitter_CallDistributionBias.setMinAmountZero3.selector;
+        selectors[3] = FeeSplitter_CallDistributionBias.setMinAmountNotZero.selector;
+        targetSelector(FuzzSelector({ addr: address(callDistributionBias), selectors: selectors }));
+
         targetContract(address(preconditions));
-        bytes4[] memory selectors = new bytes4[](3);
+        selectors = new bytes4[](2);
         selectors[0] = FeeSplitter_Preconditions.warp.selector;
         selectors[1] = FeeSplitter_Preconditions.addCollectedFeeToVault.selector;
-        selectors[2] = FeeSplitter_Preconditions.setMinAmount.selector;
         targetSelector(FuzzSelector({ addr: address(preconditions), selectors: selectors }));
     }
 
@@ -248,6 +288,20 @@ contract FeeSplitter_Invariant is CommonTest {
                 || _grossRevenue == 0
                 // rounding down error in the shares calculator
                 || (_grossRevenue * 250) < 10000
+            );
+        }
+    }
+
+    /// @notice After invariant: log the call distribution bias
+    /// @dev This could be an assertion, but only works significant with big calldepth (or keeping a counter accross all
+    /// runs, which needs a file to write to)
+    function afterInvariant() external {
+        uint256 _totalCalls = callDistributionBias.amountZeroCalls() + callDistributionBias.amountNotZeroCalls();
+
+        if (_totalCalls > 0) {
+            emit log_named_uint(
+                "% of calls setting the min amount to zero in this run: ",
+                callDistributionBias.amountZeroCalls() * 100 / _totalCalls
             );
         }
     }

--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -132,8 +132,6 @@ contract FeeSplitter_Invariant is CommonTest {
         super.enableRevenueShare();
         super.setUp();
 
-        IFeeSplitter feeSplitter = IFeeSplitter(payable(Predeploys.FEE_SPLITTER));
-
         disburser = new FeeSplitter_Disburser(vm, feeSplitter);
         preconditions = new FeeSplitter_Preconditions();
 
@@ -160,14 +158,15 @@ contract FeeSplitter_Invariant is CommonTest {
     function invariant_balanceConservation() external view {
         assertEq(
             disburser.ghost_grossRevenueDisbursed(),
-            address(l1Withdrawer).balance + l1Withdrawer.recipient().balance
-                + Predeploys.L2_TO_L1_MESSAGE_PASSER.balance + address(chainFeesRecipient).balance
+            address(l1Withdrawer).balance + Predeploys.L2_TO_L1_MESSAGE_PASSER.balance
+                + address(chainFeesRecipient).balance
         );
     }
 
     /// @notice Invariants: these are revert invariants, disburseFees can only revert if either one of the vault
     /// has a balance below it's minimum withdrawal amount (no other revert conditions are possible for the vault)
-    /// or if the disbursement interval has not been reached yet.
+    /// or if the disbursement interval has not been reached yet (this is making the assumption the recipient are
+    /// NOT reverting when receiving the fees).
     /// @dev This invariant is also testing the "no partial disbursement", as the previous one.
     function invariant_disburseReverts() external view {
         if (disburser.txFailed()) {

--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -163,7 +163,7 @@ contract FeeSplitter_Preconditions is CommonTest {
     }
 }
 /// @title Handler to set the call distribution bias for setMinAmount
-/// @notice This bias the distribution of calls to setMinAmount, favoring 80% of the calls to set the min amount to 0
+/// @notice This bias the distribution of calls to setMinAmount, favoring 75% of the calls to set the min amount to 0
 /// as it is the "vanilla" case.
 /// @dev See https://getfoundry.sh/forge/advanced-testing/invariant-testing#function-call-probability-distribution
 /// We favor this over a single wrapper with a seed to branch to keep distinct edges/selectors while using a corpus

--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -122,18 +122,7 @@ contract FeeSplitter_Preconditions is CommonTest {
     /// @dev The net and gross revenue have an upper bound to avoid overflows in the shares calculator
     function addCollectedFeeToVault(uint256 _amount, uint256 _vaultIndex) public {
         _vaultIndex = bound(_vaultIndex, 0, 3);
-
-        // Avoid having the net revenue exceeding the max uint256 / 1500 (net share default is 1500 bps in the
-        // superchain rev shares calculator). This covers the gross share too (as net * 1500 <= gross * 1500)
-        // or the gross revenue exceeding the max uint256 / 2500.
-        uint256 _maxNetRevenue = (type(uint256).max / 1500) - address(Predeploys.SEQUENCER_FEE_WALLET).balance
-            - address(Predeploys.BASE_FEE_VAULT).balance - address(Predeploys.OPERATOR_FEE_VAULT).balance;
-
-        uint256 _maxGrossRevenue = (type(uint256).max / 2500) - address(Predeploys.SEQUENCER_FEE_WALLET).balance
-            - address(Predeploys.BASE_FEE_VAULT).balance - address(Predeploys.OPERATOR_FEE_VAULT).balance
-            - address(Predeploys.L1_FEE_VAULT).balance;
-
-        _amount = bound(_amount, 0, _maxNetRevenue < _maxGrossRevenue ? _maxNetRevenue : _maxGrossRevenue);
+        _amount = bound(_amount, 0, 100 ether);
 
         if (_vaultIndex == 0) {
             vm.deal(address(Predeploys.SEQUENCER_FEE_WALLET), _amount);
@@ -208,6 +197,9 @@ contract FeeSplitter_Invariant is CommonTest {
         if (disburser.txFailed()) {
             DisburseFailureState memory _failureState = disburser.getFailureState();
 
+            uint256 _grossRevenue = _failureState.sequencerFeeVaultBalance + _failureState.baseFeeVaultBalance
+                + _failureState.l1FeeVaultBalance + _failureState.operatorFeeVaultBalance;
+
             assertTrue(
                 // either one of the vaults is below the minimum withdrawal amount
                 _failureState.sequencerFeeVaultBalance < _failureState.sequencerFeeVaultMinWithdrawalAmount
@@ -217,23 +209,11 @@ contract FeeSplitter_Invariant is CommonTest {
                 // not enough time since last disbursement
                 || _failureState.attemptTimestamp
                     < disburser.feeSplitter().lastDisbursementTime() + disburser.feeSplitter().feeDisbursementInterval()
+                // no revenue at all
+                || _grossRevenue == 0
+                // rounding down error in the shares calculator
+                || (_grossRevenue * 250) < 10000
             );
         }
-    }
-
-    function test_repro() external {
-        FeeSplitter_Preconditions(0x1d1499e622D69689cdf9004d05Ec547d650Ff211).addCollectedFeeToVault(
-            (10000 / 250) - 1, 17586
-        );
-        FeeSplitter_Preconditions(0x1d1499e622D69689cdf9004d05Ec547d650Ff211).setMinAmount(0, 0);
-        FeeSplitter_Preconditions(0x1d1499e622D69689cdf9004d05Ec547d650Ff211).setMinAmount(0, 1);
-        FeeSplitter_Preconditions(0x1d1499e622D69689cdf9004d05Ec547d650Ff211).setMinAmount(0, 2);
-        FeeSplitter_Preconditions(0x1d1499e622D69689cdf9004d05Ec547d650Ff211).setMinAmount(0, 3);
-        FeeSplitter_Preconditions(0x1d1499e622D69689cdf9004d05Ec547d650Ff211).warp(
-            1262019975972037049913916341930955891865197205853087
-        );
-
-        FeeSplitter_Disburser(0xa0Cb889707d426A7A386870A03bc70d1b0697598).disburse();
-        this.invariant_disburseReverts();
     }
 }

--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.15;
 
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";
@@ -11,6 +11,7 @@ import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";
 import { IL1Withdrawer } from "interfaces/L2/IL1Withdrawer.sol";
+import { ISuperchainRevSharesCalculator } from "interfaces/L2/ISuperchainRevSharesCalculator.sol";
 
 /// @notice A struct to keep track of the state when a disburse call fails
 struct DisburseFailureState {
@@ -23,6 +24,7 @@ struct DisburseFailureState {
     uint256 operatorFeeVaultBalance;
     uint256 operatorFeeVaultMinWithdrawalAmount;
     uint256 attemptTimestamp;
+    bytes reason;
 }
 
 /// @title Handler to call the disburseFees function
@@ -94,7 +96,7 @@ contract FeeSplitter_Disburser is StdUtils {
             }
 
             ghost_grossRevenueDisbursed += _aggregateVaultsBalances;
-        } catch {
+        } catch (bytes memory _reason) {
             // keep track of the failing state
             txFailed = true;
             failureState.sequencerFeeVaultBalance = address(Predeploys.SEQUENCER_FEE_WALLET).balance;
@@ -110,6 +112,7 @@ contract FeeSplitter_Disburser is StdUtils {
             failureState.operatorFeeVaultMinWithdrawalAmount =
                 IFeeVault(payable(Predeploys.OPERATOR_FEE_VAULT)).minWithdrawalAmount();
             failureState.attemptTimestamp = block.timestamp;
+            failureState.reason = _reason;
         }
     }
 }
@@ -275,20 +278,34 @@ contract FeeSplitter_Invariant is CommonTest {
             uint256 _grossRevenue = _failureState.sequencerFeeVaultBalance + _failureState.baseFeeVaultBalance
                 + _failureState.l1FeeVaultBalance + _failureState.operatorFeeVaultBalance;
 
-            assertTrue(
-                // either one of the vaults is below the minimum withdrawal amount
+            // either one of the vaults is below the minimum withdrawal amount
+            bool _vaultBelowMinimum = (
                 _failureState.sequencerFeeVaultBalance < _failureState.sequencerFeeVaultMinWithdrawalAmount
                     || _failureState.baseFeeVaultBalance < _failureState.baseFeeVaultMinWithdrawalAmount
                     || _failureState.l1FeeVaultBalance < _failureState.l1FeeVaultMinWithdrawalAmount
                     || _failureState.operatorFeeVaultBalance < _failureState.operatorFeeVaultMinWithdrawalAmount
-                // not enough time since last disbursement
-                || _failureState.attemptTimestamp
-                    < disburser.feeSplitter().lastDisbursementTime() + disburser.feeSplitter().feeDisbursementInterval()
-                // no revenue at all
-                || _grossRevenue == 0
-                // rounding down error in the shares calculator
-                || (_grossRevenue * 250) < 10000
-            );
+            )
+                && keccak256(_failureState.reason)
+                    == keccak256(
+                        abi.encodeWithSignature(
+                            "Error(string)", "FeeVault: withdrawal amount must be greater than minimum withdrawal amount"
+                        )
+                    );
+
+            // not enough time since last disbursement
+            bool _tooEarly = _failureState.attemptTimestamp
+                < disburser.feeSplitter().lastDisbursementTime() + disburser.feeSplitter().feeDisbursementInterval()
+                && bytes4(_failureState.reason) == IFeeSplitter.FeeSplitter_DisbursementIntervalNotReached.selector;
+
+            // no revenue at all
+            bool _noRevenue =
+                _grossRevenue == 0 && bytes4(_failureState.reason) == IFeeSplitter.FeeSplitter_NoFeesCollected.selector;
+
+            // rounding down error in the shares calculator
+            bool _noSharesCalculator = (_grossRevenue * 250) < 10000
+                && bytes4(_failureState.reason) == ISuperchainRevSharesCalculator.SharesCalculator_ZeroGrossShare.selector;
+
+            assertTrue(_vaultBelowMinimum || _tooEarly || _noRevenue || _noSharesCalculator);
         }
     }
 

--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -94,6 +94,7 @@ contract FeeSplitter_Preconditions is CommonTest {
     /// @param _vaultIndex The seed of the vault's index to set the min amount to withdraw from
     function setMinAmount(uint256 _minAmount, uint256 _vaultIndex) public {
         _minAmount = bound(_minAmount, 0, 10 ether);
+        _vaultIndex = bound(_vaultIndex, 0, 3);
 
         vm.prank(IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
 

--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -10,6 +10,7 @@ import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";
+import { IL1Withdrawer } from "interfaces/L2/IL1Withdrawer.sol";
 
 /// @notice A struct to keep track of the state when a disburse call fails
 struct DisburseFailureState {
@@ -32,6 +33,8 @@ contract FeeSplitter_Disburser is StdUtils {
     /// @notice FeeSplitter contract
     IFeeSplitter public feeSplitter;
 
+    IL1Withdrawer public l1Withdrawer;
+
     /// @notice Flag to track if a disburseFees() call failed
     bool public txFailed;
 
@@ -41,9 +44,16 @@ contract FeeSplitter_Disburser is StdUtils {
     /// @notice Aggregate of the vault balances disbursed
     uint256 public ghost_grossRevenueDisbursed;
 
-    constructor(Vm _vm, IFeeSplitter _feeSplitter) {
+    /// @notice Keep track of the last aggregated fee disbursed
+    uint256 public ghost_lastDisbursementAmount;
+
+    /// @notice Keep track of the l1withdrawer should have withdrawn
+    bool public l1withdrawerShouldHaveWithdrawn;
+
+    constructor(Vm _vm, IFeeSplitter _feeSplitter, IL1Withdrawer _l1Withdrawer) {
         vm = _vm;
         feeSplitter = _feeSplitter;
+        l1Withdrawer = _l1Withdrawer;
     }
 
     /// @notice Get the failure state (convenience, to keep the struct)
@@ -56,14 +66,32 @@ contract FeeSplitter_Disburser is StdUtils {
     /// - success: update the overall amount disbursed (ie add the sum of the vaults balances before disbursement)
     /// - failure: update the failure state (all vault balances and the current timestamp)
     function disburse() public {
-        uint256 _aggregateVaultsBalances = address(Predeploys.SEQUENCER_FEE_WALLET).balance
-            + address(Predeploys.BASE_FEE_VAULT).balance + address(Predeploys.L1_FEE_VAULT).balance
-            + address(Predeploys.OPERATOR_FEE_VAULT).balance;
+        uint256 _sequencerFees = address(Predeploys.SEQUENCER_FEE_WALLET).balance;
+        uint256 _baseFees = address(Predeploys.BASE_FEE_VAULT).balance;
+        uint256 _l1Fees = address(Predeploys.L1_FEE_VAULT).balance;
+        uint256 _operatorFees = address(Predeploys.OPERATOR_FEE_VAULT).balance;
+        uint256 _aggregateVaultsBalances = _sequencerFees + _baseFees + _l1Fees + _operatorFees;
+
+        uint256 _l1withdrawerBalanceBeforeDisbursement = address(l1Withdrawer).balance;
 
         try feeSplitter.disburseFees() {
             // reset the fail flags
             txFailed = false;
             delete failureState;
+
+            // Check if the l1withdrawer should have been triggered and empty its balance
+            uint256 _amountToL1Withdrawer = feeSplitter.sharesCalculator().getRecipientsAndAmounts(
+                _sequencerFees, _baseFees, _operatorFees, _l1Fees
+            )[0].amount;
+
+            if (
+                _l1withdrawerBalanceBeforeDisbursement + _amountToL1Withdrawer
+                    >= IL1Withdrawer(payable(l1Withdrawer)).minWithdrawalAmount()
+            ) {
+                l1withdrawerShouldHaveWithdrawn = true;
+            } else {
+                l1withdrawerShouldHaveWithdrawn = false;
+            }
 
             ghost_grossRevenueDisbursed += _aggregateVaultsBalances;
         } catch {
@@ -156,7 +184,7 @@ contract FeeSplitter_Invariant is CommonTest {
         super.enableRevenueShare();
         super.setUp();
 
-        disburser = new FeeSplitter_Disburser(vm, feeSplitter);
+        disburser = new FeeSplitter_Disburser(vm, feeSplitter, l1Withdrawer);
         preconditions = new FeeSplitter_Preconditions();
 
         targetContract(address(disburser));
@@ -173,6 +201,13 @@ contract FeeSplitter_Invariant is CommonTest {
     /// @dev This invariant doesn't account for direct forced transfers (eg selfdestruct)
     function invariant_noDust() external view {
         assertEq(address(disburser.feeSplitter()).balance, 0);
+    }
+
+    /// @notice Invariant: The l1withdrawer should always transfer its whole balance if it reaches the threshold
+    function invariant_l1withdrawerWithdrawn() external view {
+        if (disburser.l1withdrawerShouldHaveWithdrawn()) {
+            assertEq(address(l1Withdrawer).balance, 0);
+        }
     }
 
     /// @notice Invariant: The total disbursed fees should always be equal to the sum of the vault balances before


### PR DESCRIPTION
# Invariants tested:
- total disbursed fees should always be equal to the sum of the vault balances before disbursement - this is the main invariant, as it eliminate: dust somewhere in the flow, "partial" vault withdrawals (eg one vault not transferring its balance as intended), wrong recipient, etc 
- no dust accumulation in the FeeSplitter
- disburseFees can only revert if either one of the vault has a balance below it's minimum withdrawal amount or if the disbursement interval has not been reached yet

The share computation isn't tested here, at it would be a copy-paste of the existing fuzzed unit test (perhaps we could increase the fuzz runs for `testFuzz_getRecipientsAndAmounts_succeeds`, even though it's tightly coupled to the implementation anyway).

To run these efficiently, set `corpus_dir = "corpus"` in the foundry.toml (it can be run with fail_on_revert too, as revert cases are tested).