### PR TITLE
chore: use w3 library

### DIFF
--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -20,6 +20,9 @@ jovian:
 interop:
     @just acceptance-test "" interop
 
+cgt:
+    @just acceptance-test "" cgt
+
 
 # Run acceptance tests with mise-managed binary
 # Usage: just acceptance-test [devnet] [gate]

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_l1_portal_introspection_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_l1_portal_introspection_test.go
@@ -2,7 +2,6 @@ package custom_gas_token
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -10,9 +9,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3"
 )
 
 // TestCGT_L1PortalIntrospection checks that the L1 OptimismPortal exposes
@@ -31,24 +30,23 @@ func TestCGT_L1PortalIntrospection(gt *testing.T) {
 	defer cancel()
 
 	// Portal exposes systemConfig() -> address
-	const portalABI = `[
-	  {"inputs":[],"name":"systemConfig","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"}
-	]`
-	pa, err := abi.JSON(strings.NewReader(portalABI))
+	systemConfigFunc := w3.MustNewFunc("systemConfig()", "address")
+
+	data, err := systemConfigFunc.EncodeArgs()
 	if err != nil {
-		t.Require().Fail("parse portal ABI: %v", err)
+		t.Require().Fail("encode systemConfig() args: %v", err)
 	}
 
-	data, _ := pa.Pack("systemConfig")
 	out, err := l1c.Call(ctx, ethereum.CallMsg{To: &portal, Data: data}, rpc.LatestBlockNumber)
 	if err != nil {
 		t.Require().Fail("portal.systemConfig() call failed: %v", err)
 	}
-	vals, err := pa.Unpack("systemConfig", out)
-	if err != nil {
-		t.Require().Fail("unpack portal.systemConfig() failed: %v", err)
+
+	var sysCfg common.Address
+	if err := systemConfigFunc.DecodeReturns(out, &sysCfg); err != nil {
+		t.Require().Fail("decode portal.systemConfig() returns: %v", err)
 	}
-	sysCfg := vals[0].(common.Address)
+
 	if sysCfg == (common.Address{}) {
 		t.Require().Fail("portal.systemConfig() returned zero address")
 	}

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_reverts_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_reverts_test.go
@@ -2,7 +2,6 @@ package custom_gas_token
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,7 +12,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/lmittmann/w3"
 )
 
 // TestCGT_MessengerRejectsValue ensures that sending native value to the
@@ -48,22 +47,11 @@ func TestCGT_L2StandardBridge_LegacyWithdrawReverts(gt *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Ctx(), 30*time.Second)
 	defer cancel()
 
-	bridgeABIJSON := `[
-		{"inputs":[
-			{"internalType":"address","name":"_l2Token","type":"address"},
-			{"internalType":"uint256","name":"_amount","type":"uint256"},
-			{"internalType":"uint32","name":"_minGasLimit","type":"uint32"},
-			{"internalType":"bytes","name":"_extraData","type":"bytes"}
-		],
-		"name":"withdraw","outputs":[],"stateMutability":"payable","type":"function"}
-	]`
-	bridgeABI, err := abi.JSON(strings.NewReader(bridgeABIJSON))
-	if err != nil {
-		t.Require().Fail("%v", err)
-	}
+	withdrawFunc := w3.MustNewFunc("withdraw(address,uint256,uint32,bytes)", "")
+
 	// Any address is fine; the ETH-specific legacy path should be disabled under CGT.
 	anyAddress := l2XDMAddr
-	data, err := bridgeABI.Pack("withdraw", anyAddress, big.NewInt(1), uint32(100_000), []byte{})
+	data, err := withdrawFunc.EncodeArgs(anyAddress, big.NewInt(1), uint32(100_000), []byte{})
 	if err != nil {
 		t.Require().Fail("%v", err)
 	}

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_systemconfig_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_systemconfig_test.go
@@ -2,7 +2,6 @@ package custom_gas_token
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -10,9 +9,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3"
 )
 
 // TestCGT_SystemConfigFlagOnL1 checks that the L1 SystemConfig contract reports
@@ -25,47 +24,37 @@ func TestCGT_SystemConfigFlagOnL1(gt *testing.T) {
 	l1c := sys.L1EL.EthClient()
 	portal := sys.L2Chain.DepositContractAddr()
 
-	portalABI := `[
-	  {"inputs":[],"name":"systemConfig","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"}
-	]`
-	igasToken := `[
-	  {"inputs":[],"name":"isCustomGasToken","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"}
-	]`
+	systemConfigFunc := w3.MustNewFunc("systemConfig()", "address")
+	isCustomGasTokenFunc := w3.MustNewFunc("isCustomGasToken()", "bool")
 
-	pa, err := abi.JSON(strings.NewReader(portalABI))
-	if err != nil {
-		t.Require().Fail("%v", err)
-	}
 	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
 	defer cancel()
 
 	// Resolve SystemConfig via Portal.systemConfig()
-	data, _ := pa.Pack("systemConfig")
+	data, _ := systemConfigFunc.EncodeArgs()
 	out, err := l1c.Call(ctx, ethereum.CallMsg{To: &portal, Data: data}, rpc.LatestBlockNumber)
 	if err != nil {
 		t.Require().Fail("portal.systemConfig() call failed: %v", err)
 	}
-	vals, err := pa.Unpack("systemConfig", out)
-	if err != nil {
+	var sysCfg common.Address
+	if err := systemConfigFunc.DecodeReturns(out, &sysCfg); err != nil {
 		t.Require().Fail("unpack portal.systemConfig() failed: %v", err)
 	}
-	sysCfg := vals[0].(common.Address)
 	if (sysCfg == common.Address{}) {
 		t.Require().Fail("portal.systemConfig() returned zero address")
 	}
 
 	// Ask SystemConfig whether CGT is enabled.
-	ga, _ := abi.JSON(strings.NewReader(igasToken))
-	data, _ = ga.Pack("isCustomGasToken")
+	data, _ = isCustomGasTokenFunc.EncodeArgs()
 	out, err = l1c.Call(ctx, ethereum.CallMsg{To: &sysCfg, Data: data}, rpc.LatestBlockNumber)
 	if err != nil {
 		t.Require().Fail("SystemConfig.isCustomGasToken() call failed: %v", err)
 	}
-	vals, err = ga.Unpack("isCustomGasToken", out)
-	if err != nil {
+	var isCustom bool
+	if err := isCustomGasTokenFunc.DecodeReturns(out, &isCustom); err != nil {
 		t.Require().Fail("unpack isCustomGasToken failed: %v", err)
 	}
-	if !vals[0].(bool) {
+	if !isCustom {
 		t.Skip("SystemConfig.isCustomGasToken() = false on this devnet; skipping")
 	}
 }
@@ -86,35 +75,21 @@ func TestCGT_SystemConfigFeatureFlag(gt *testing.T) {
 	defer cancel()
 
 	// Resolve SystemConfig via Portal.systemConfig()
-	const portalABI = `[
-	  {"inputs":[],"name":"systemConfig","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"}
-	]`
-	pa, err := abi.JSON(strings.NewReader(portalABI))
-	if err != nil {
-		t.Require().Fail("parse portal ABI: %v", err)
-	}
-	data, _ := pa.Pack("systemConfig")
+	systemConfigFunc := w3.MustNewFunc("systemConfig()", "address")
+	isCustomGasTokenFunc := w3.MustNewFunc("isCustomGasToken()", "bool")
+
+	data, _ := systemConfigFunc.EncodeArgs()
 	out, err := l1c.Call(ctx, ethereum.CallMsg{To: &portal, Data: data}, rpc.LatestBlockNumber)
 	if err != nil {
 		t.Require().Fail("portal.systemConfig() call failed: %v", err)
 	}
-	vals, err := pa.Unpack("systemConfig", out)
-	if err != nil {
+	var sysCfg common.Address
+	if err := systemConfigFunc.DecodeReturns(out, &sysCfg); err != nil {
 		t.Require().Fail("unpack portal.systemConfig() failed: %v", err)
 	}
-	sysCfg := vals[0].(common.Address) // keep as interface; ABI unpack returns []interface{}
 
 	// Query the CGT flag on SystemConfig via IGasToken.isCustomGasToken().
-	const igasTokenABI = `[
-	  {"inputs":[],"name":"isCustomGasToken","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"}
-	]`
-	ga, err := abi.JSON(strings.NewReader(igasTokenABI))
-	if err != nil {
-		t.Require().Fail("parse IGasToken ABI: %v", err)
-	}
-
-	// Build the call
-	data, _ = ga.Pack("isCustomGasToken")
+	data, _ = isCustomGasTokenFunc.EncodeArgs()
 	out, err = l1c.Call(ctx, ethereum.CallMsg{
 		To:   &sysCfg,
 		Data: data,
@@ -122,11 +97,11 @@ func TestCGT_SystemConfigFeatureFlag(gt *testing.T) {
 	if err != nil {
 		t.Require().Fail("SystemConfig.isCustomGasToken() call failed: %v", err)
 	}
-	flag, err := ga.Unpack("isCustomGasToken", out)
-	if err != nil {
+	var flag bool
+	if err := isCustomGasTokenFunc.DecodeReturns(out, &flag); err != nil {
 		t.Require().Fail("unpack isCustomGasToken failed: %v", err)
 	}
-	if !flag[0].(bool) {
+	if !flag {
 		t.Skip("SystemConfig.isCustomGasToken() = false on this devnet; skipping")
 	}
 }

--- a/op-acceptance-tests/tests/custom_gas_token/helpers.go
+++ b/op-acceptance-tests/tests/custom_gas_token/helpers.go
@@ -3,16 +3,15 @@ package custom_gas_token
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3"
 )
 
 var (
@@ -24,49 +23,48 @@ var (
 	l2BridgeAddr = common.HexToAddress("0x4200000000000000000000000000000000000010")
 )
 
-const igasTokenABI = `[
-  {"inputs":[],"name":"isCustomGasToken","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},
-  {"inputs":[],"name":"gasPayingTokenName","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},
-  {"inputs":[],"name":"gasPayingTokenSymbol","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"}
-]`
-
 // ensureCGTOrSkip probes L2 L1Block for CGT mode. If not enabled, the test is skipped.
 // Returns (name, symbol).
 func ensureCGTOrSkip(t devtest.T, sys *presets.Minimal) (string, string) {
 	l2 := sys.L2EL.Escape().L2EthClient()
 
-	abiGT, err := abi.JSON(strings.NewReader(igasTokenABI))
-	t.Require().NoError(err)
+	isCustomGasTokenFunc := w3.MustNewFunc("isCustomGasToken()", "bool")
+	gasPayingTokenNameFunc := w3.MustNewFunc("gasPayingTokenName()", "string")
+	gasPayingTokenSymbolFunc := w3.MustNewFunc("gasPayingTokenSymbol()", "string")
 
 	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
 	defer cancel()
 
 	// isCustomGasToken()
-	data, _ := abiGT.Pack("isCustomGasToken")
+	data, _ := isCustomGasTokenFunc.EncodeArgs()
 	out, err := l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
 	if err != nil {
 		t.Skipf("CGT not enabled (isCustomGasToken() call failed): %v", err)
 	}
-	vals, err := abiGT.Unpack("isCustomGasToken", out)
-	t.Require().NoError(err)
-	if !vals[0].(bool) {
+	var isCustom bool
+	if err := isCustomGasTokenFunc.DecodeReturns(out, &isCustom); err != nil {
+		t.Require().NoError(err)
+	}
+	if !isCustom {
 		t.Skip("CGT disabled on this devnet (native ETH mode detected)")
 	}
 
 	// Read metadata (name/symbol)
-	data, _ = abiGT.Pack("gasPayingTokenName")
+	data, _ = gasPayingTokenNameFunc.EncodeArgs()
 	out, err = l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
 	t.Require().NoError(err)
-	vn, err := abiGT.Unpack("gasPayingTokenName", out)
-	t.Require().NoError(err)
-	name := vn[0].(string)
+	var name string
+	if err := gasPayingTokenNameFunc.DecodeReturns(out, &name); err != nil {
+		t.Require().NoError(err)
+	}
 
-	data, _ = abiGT.Pack("gasPayingTokenSymbol")
+	data, _ = gasPayingTokenSymbolFunc.EncodeArgs()
 	out, err = l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
 	t.Require().NoError(err)
-	vs, err := abiGT.Unpack("gasPayingTokenSymbol", out)
-	t.Require().NoError(err)
-	symbol := vs[0].(string)
+	var symbol string
+	if err := gasPayingTokenSymbolFunc.DecodeReturns(out, &symbol); err != nil {
+		t.Require().NoError(err)
+	}
 
 	return name, symbol
 }


### PR DESCRIPTION
Closes OPT-1153

Test Skip Analysis

  Background

  Two tests in the custom gas token suite are intentionally skipped due to a configuration limitation in the devnet setup:

  - TestCGT_SystemConfigFlagOnL1
  - TestCGT_SystemConfigFeatureFlag

  Root Cause

  These tests verify that the CUSTOM_GAS_TOKEN feature flag is enabled in the L1 SystemConfig contract by calling SystemConfig.isCustomGasToken(). However, the current devnet setup only configures
  CGT functionality on L2 via WithCustomGasToken(), but does not automatically enable the corresponding feature flag in the L1 SystemConfig contract.

  Technical Details

  The tests follow this flow:
  1. Call Portal.systemConfig() to get the SystemConfig address
  2. Call SystemConfig.isCustomGasToken() to check if the feature flag is enabled
  3. Skip if the flag returns false with message: "SystemConfig.isCustomGasToken() = false on this devnet; skipping"

  The CUSTOM_GAS_TOKEN feature flag (bytes32: 0x435553544f4d5f4741535f544f4b454e00000000000000000000000000000000) needs to be explicitly enabled via SystemConfig.setFeature() by the
  L1ProxyAdminOwner.

  Test Results Status

  - ✅ 6 tests PASS - Core CGT functionality works correctly
  - ⏭️ 2 tests SKIP - Expected behavior for current devnet configuration
  - ❌ 0 tests FAIL - No regressions introduced

  Pre-Migration Verification

  Confirmed that these same 2 tests were also skipped before the w3 library migration, proving that our changes did not introduce any regressions.

  Future Considerations

  To make these tests pass, the devnet setup would need to be enhanced to automatically call SystemConfig.setFeature(CUSTOM_GAS_TOKEN, true) after deployment, using the L1ProxyAdminOwner role. This
   is a devnet infrastructure enhancement rather than a test code issue.