### PR TITLE
refactor: removes immutable vars in favor of view functions

### DIFF
--- a/packages/contracts-bedrock/interfaces/L2/IBaseFeeVault.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IBaseFeeVault.sol
@@ -39,11 +39,4 @@ interface IBaseFeeVault {
     function setWithdrawalNetwork(Types.WithdrawalNetwork _newWithdrawalNetwork) external;
 
     function version() external view returns (string memory);
-
-    function __constructor__(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        Types.WithdrawalNetwork _withdrawalNetwork
-    )
-        external;
 }

--- a/packages/contracts-bedrock/interfaces/L2/IFeeVault.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IFeeVault.sol
@@ -40,15 +40,3 @@ interface IFeeVault {
 
     function __constructor__() external;
 }
-
-interface IFeeVaultConstructor {
-    /// NOTE: This is the real constructor for the FeeVault contract, but can't be added to the main interface because
-    ///       it is an abstract contract, and on the scripts it gets an empty constructor automatically generated that
-    ///       makes the `interfaces-check` script fail.
-    function __constructor__(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        Types.WithdrawalNetwork _withdrawalNetwork
-    )
-        external;
-}

--- a/packages/contracts-bedrock/interfaces/L2/IL1FeeVault.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL1FeeVault.sol
@@ -39,11 +39,4 @@ interface IL1FeeVault {
     function setWithdrawalNetwork(Types.WithdrawalNetwork _newWithdrawalNetwork) external;
 
     function version() external view returns (string memory);
-
-    function __constructor__(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        Types.WithdrawalNetwork _withdrawalNetwork
-    )
-        external;
 }

--- a/packages/contracts-bedrock/interfaces/L2/IOperatorFeeVault.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IOperatorFeeVault.sol
@@ -39,11 +39,4 @@ interface IOperatorFeeVault {
     function setWithdrawalNetwork(Types.WithdrawalNetwork _newWithdrawalNetwork) external;
 
     function version() external view returns (string memory);
-
-    function __constructor__(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        Types.WithdrawalNetwork _withdrawalNetwork
-    )
-        external;
 }

--- a/packages/contracts-bedrock/interfaces/L2/ISequencerFeeVault.sol
+++ b/packages/contracts-bedrock/interfaces/L2/ISequencerFeeVault.sol
@@ -40,11 +40,4 @@ interface ISequencerFeeVault {
 
     function version() external view returns (string memory);
     function l1FeeWallet() external view returns (address);
-
-    function __constructor__(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        Types.WithdrawalNetwork _withdrawalNetwork
-    )
-        external;
 }

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -32,7 +32,7 @@ import { IGasPriceOracle } from "interfaces/L2/IGasPriceOracle.sol";
 import { IL1Block } from "interfaces/L2/IL1Block.sol";
 import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";
 import { ISharesCalculator } from "interfaces/L2/ISharesCalculator.sol";
-import { IFeeVault, IFeeVaultConstructor } from "interfaces/L2/IFeeVault.sol";
+import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
 import { IL1Withdrawer } from "interfaces/L2/IL1Withdrawer.sol";
 import { ISuperchainRevSharesCalculator } from "interfaces/L2/ISuperchainRevSharesCalculator.sol";
 
@@ -320,34 +320,16 @@ contract L2Genesis is Script {
             network = Types.WithdrawalNetwork(_input.sequencerFeeVaultWithdrawalNetwork);
         }
 
-        ISequencerFeeVault vault = ISequencerFeeVault(
-            DeployUtils.create1({
-                _name: "SequencerFeeVault",
-                _args: DeployUtils.encodeConstructor(
-                    abi.encodeCall(
-                        IFeeVaultConstructor.__constructor__,
-                        (recipient, _input.sequencerFeeVaultMinimumWithdrawalAmount, network)
-                    )
-                )
-            })
-        );
-
-        address impl = Predeploys.predeployToCodeNamespace(Predeploys.SEQUENCER_FEE_WALLET);
-        vm.etch(impl, address(vault).code);
+        address impl = _setImplementationCode(Predeploys.SEQUENCER_FEE_WALLET);
 
         /// Initialize
-        ISequencerFeeVault(payable(impl)).initialize(
-            recipient, _input.sequencerFeeVaultMinimumWithdrawalAmount, network
-        );
+        ISequencerFeeVault(payable(impl)).initialize(address(0), 0, Types.WithdrawalNetwork.L1);
+
         ISequencerFeeVault(payable(Predeploys.SEQUENCER_FEE_WALLET)).initialize({
             _recipient: recipient,
             _minWithdrawalAmount: _input.sequencerFeeVaultMinimumWithdrawalAmount,
             _withdrawalNetwork: network
         });
-
-        /// Reset so its not included state dump
-        vm.etch(address(vault), "");
-        vm.resetNonce(address(vault));
     }
 
     /// @notice This predeploy is following the safety invariant #1.
@@ -428,33 +410,16 @@ contract L2Genesis is Script {
             network = Types.WithdrawalNetwork(_input.baseFeeVaultWithdrawalNetwork);
         }
 
-        IBaseFeeVault vault = IBaseFeeVault(
-            DeployUtils.create1({
-                _name: "BaseFeeVault",
-                _args: DeployUtils.encodeConstructor(
-                    abi.encodeCall(
-                        IFeeVaultConstructor.__constructor__,
-                        (recipient, _input.baseFeeVaultMinimumWithdrawalAmount, network)
-                    )
-                )
-            })
-        );
-
-        address impl = Predeploys.predeployToCodeNamespace(Predeploys.BASE_FEE_VAULT);
-        vm.etch(impl, address(vault).code);
+        address impl = _setImplementationCode(Predeploys.BASE_FEE_VAULT);
 
         /// Initialize
-        IBaseFeeVault(payable(impl)).initialize(recipient, _input.baseFeeVaultMinimumWithdrawalAmount, network);
+        IBaseFeeVault(payable(impl)).initialize(address(0), 0, Types.WithdrawalNetwork.L1);
 
         IBaseFeeVault(payable(Predeploys.BASE_FEE_VAULT)).initialize({
             _recipient: recipient,
             _minWithdrawalAmount: _input.baseFeeVaultMinimumWithdrawalAmount,
             _withdrawalNetwork: network
         });
-
-        /// Reset so its not included state dump
-        vm.etch(address(vault), "");
-        vm.resetNonce(address(vault));
     }
 
     /// @notice This predeploy is following the safety invariant #2.
@@ -469,32 +434,16 @@ contract L2Genesis is Script {
             network = Types.WithdrawalNetwork(_input.l1FeeVaultWithdrawalNetwork);
         }
 
-        IL1FeeVault vault = IL1FeeVault(
-            DeployUtils.create1({
-                _name: "L1FeeVault",
-                _args: DeployUtils.encodeConstructor(
-                    abi.encodeCall(
-                        IFeeVaultConstructor.__constructor__, (recipient, _input.l1FeeVaultMinimumWithdrawalAmount, network)
-                    )
-                )
-            })
-        );
-
-        address impl = Predeploys.predeployToCodeNamespace(Predeploys.L1_FEE_VAULT);
-        vm.etch(impl, address(vault).code);
+        address impl = _setImplementationCode(Predeploys.L1_FEE_VAULT);
 
         /// Initialize
-        IL1FeeVault(payable(impl)).initialize(recipient, _input.l1FeeVaultMinimumWithdrawalAmount, network);
+        IL1FeeVault(payable(impl)).initialize(address(0), 0, Types.WithdrawalNetwork.L1);
 
         IL1FeeVault(payable(Predeploys.L1_FEE_VAULT)).initialize({
             _recipient: recipient,
             _minWithdrawalAmount: _input.l1FeeVaultMinimumWithdrawalAmount,
             _withdrawalNetwork: network
         });
-
-        /// Reset so its not included state dump
-        vm.etch(address(vault), "");
-        vm.resetNonce(address(vault));
     }
 
     /// @notice This predeploy is following the safety invariant #2.
@@ -509,33 +458,16 @@ contract L2Genesis is Script {
             network = Types.WithdrawalNetwork(_input.operatorFeeVaultWithdrawalNetwork);
         }
 
-        IOperatorFeeVault vault = IOperatorFeeVault(
-            DeployUtils.create1({
-                _name: "OperatorFeeVault",
-                _args: DeployUtils.encodeConstructor(
-                    abi.encodeCall(
-                        IFeeVaultConstructor.__constructor__,
-                        (recipient, _input.operatorFeeVaultMinimumWithdrawalAmount, network)
-                    )
-                )
-            })
-        );
-
-        address impl = Predeploys.predeployToCodeNamespace(Predeploys.OPERATOR_FEE_VAULT);
-        vm.etch(impl, address(vault).code);
+        address impl = _setImplementationCode(Predeploys.OPERATOR_FEE_VAULT);
 
         /// Initialize
-        IOperatorFeeVault(payable(impl)).initialize(recipient, _input.operatorFeeVaultMinimumWithdrawalAmount, network);
+        IOperatorFeeVault(payable(impl)).initialize(address(0), 0, Types.WithdrawalNetwork.L1);
 
         IOperatorFeeVault(payable(Predeploys.OPERATOR_FEE_VAULT)).initialize({
             _recipient: recipient,
             _minWithdrawalAmount: _input.operatorFeeVaultMinimumWithdrawalAmount,
             _withdrawalNetwork: network
         });
-
-        /// Reset so its not included state dump in state dump
-        vm.etch(address(vault), "");
-        vm.resetNonce(address(vault));
     }
 
     /// @notice This predeploy is following the safety invariant #2.

--- a/packages/contracts-bedrock/snapshots/abi/BaseFeeVault.json
+++ b/packages/contracts-bedrock/snapshots/abi/BaseFeeVault.json
@@ -1,26 +1,5 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_recipient",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_minWithdrawalAmount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "enum Types.WithdrawalNetwork",
-        "name": "_withdrawalNetwork",
-        "type": "uint8"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
     "stateMutability": "payable",
     "type": "receive"
   },

--- a/packages/contracts-bedrock/snapshots/abi/L1FeeVault.json
+++ b/packages/contracts-bedrock/snapshots/abi/L1FeeVault.json
@@ -1,26 +1,5 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_recipient",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_minWithdrawalAmount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "enum Types.WithdrawalNetwork",
-        "name": "_withdrawalNetwork",
-        "type": "uint8"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
     "stateMutability": "payable",
     "type": "receive"
   },

--- a/packages/contracts-bedrock/snapshots/abi/OperatorFeeVault.json
+++ b/packages/contracts-bedrock/snapshots/abi/OperatorFeeVault.json
@@ -1,26 +1,5 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_recipient",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_minWithdrawalAmount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "enum Types.WithdrawalNetwork",
-        "name": "_withdrawalNetwork",
-        "type": "uint8"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
     "stateMutability": "payable",
     "type": "receive"
   },

--- a/packages/contracts-bedrock/snapshots/abi/SequencerFeeVault.json
+++ b/packages/contracts-bedrock/snapshots/abi/SequencerFeeVault.json
@@ -1,26 +1,5 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_recipient",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_minWithdrawalAmount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "enum Types.WithdrawalNetwork",
-        "name": "_withdrawalNetwork",
-        "type": "uint8"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
     "stateMutability": "payable",
     "type": "receive"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0x006e3560f8b2e17133eb10a116916798ddc4345a7b006f8504dab69e810adb1c"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
-    "initCodeHash": "0x3bc87c35ed688507a65368867bb2e535b43e329850792b4adae1a1f8bf4f11ab",
-    "sourceCodeHash": "0xb08e4b48e713cc2485858691a50f1200b6a222d24d80864007ba9df34d1b4650"
+    "initCodeHash": "0x1793a3db107c6ee13e4d7925955aa9b96d4b2e068e1c8a8c54f99b2ab199449e",
+    "sourceCodeHash": "0xcb329746df0baddd3dc03c6c88da5d6bdc0f0a96d30e6dc78d0891bb1e935032"
   },
   "src/L2/CrossL2Inbox.sol:CrossL2Inbox": {
     "initCodeHash": "0x56f868e561c4abe539043f98b16aad9305479e68fd03ece2233249b0c73a24ea",
@@ -76,8 +76,8 @@
     "sourceCodeHash": "0x6e5349fd781d5f0127ff29ccea4d86a80240550cfa322364183a0f629abcb43e"
   },
   "src/L2/L1FeeVault.sol:L1FeeVault": {
-    "initCodeHash": "0x3bc87c35ed688507a65368867bb2e535b43e329850792b4adae1a1f8bf4f11ab",
-    "sourceCodeHash": "0xbde4c77cd8f6930852dad62c0bc352ebdc0d2966f9a658abefa2a3a08d3a5297"
+    "initCodeHash": "0x1793a3db107c6ee13e4d7925955aa9b96d4b2e068e1c8a8c54f99b2ab199449e",
+    "sourceCodeHash": "0x34186bcab29963237b4e0d7575b0a1cff7caf42ccdb55d4b2b2c767db3279189"
   },
   "src/L2/L1Withdrawer.sol:L1Withdrawer": {
     "initCodeHash": "0x91e0be0d49636212678191c06b9b6840c399f08ad946bc7b52f24231691be28b",
@@ -108,8 +108,8 @@
     "sourceCodeHash": "0xbea4229c5c6988243dbc7cf5a086ddd412fe1f2903b8e20d56699fec8de0c2c9"
   },
   "src/L2/OperatorFeeVault.sol:OperatorFeeVault": {
-    "initCodeHash": "0x2e83a44e5105252d41341d0c51a84e2869cb402b0e7103ecc7eb4635e00bc558",
-    "sourceCodeHash": "0xb77cea6c9252d6687990fdb34c38bcef92599733465ac02e8b9330258d38b243"
+    "initCodeHash": "0x436d79247c0cb55b19e11db187ad4210c4b38434ba1d4025e7dc4bc581285be1",
+    "sourceCodeHash": "0xd6e94bc9df025855916aa4184d0bc739b0fbe786dfd037b99dbb51d0d3e46918"
   },
   "src/L2/OptimismMintableERC721.sol:OptimismMintableERC721": {
     "initCodeHash": "0x316c6d716358f5b5284cd5457ea9fca4b5ad4a37835d4b4b300413dafbfa2159",
@@ -132,8 +132,8 @@
     "sourceCodeHash": "0x11b6236911e909ed10d4f194fe7315c1f5533d21cbe69a8ff16248c827df2647"
   },
   "src/L2/SequencerFeeVault.sol:SequencerFeeVault": {
-    "initCodeHash": "0x4519b27da822da90b12731857f3ee12e882f8bb74358362bb692a1918b102753",
-    "sourceCodeHash": "0x4b88009725c56f4e5a0efecafe980bb198b4494154219a9dbe1c8021c9312fcc"
+    "initCodeHash": "0x3bfc3ba591ba099fbd83bb464cc261df94d705f7c8f46cfa358588d4eabbd858",
+    "sourceCodeHash": "0x5fa147acd34a5f1c451404234d22e114c79f1255decc51afd8930d5ce99d7e02"
   },
   "src/L2/SuperchainERC20.sol:SuperchainERC20": {
     "initCodeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",

--- a/packages/contracts-bedrock/src/L2/BaseFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/BaseFeeVault.sol
@@ -4,9 +4,6 @@ pragma solidity 0.8.25;
 // Contracts
 import { FeeVault } from "src/L2/FeeVault.sol";
 
-// Libraries
-import { Types } from "src/libraries/Types.sol";
-
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
@@ -18,16 +15,4 @@ contract BaseFeeVault is FeeVault, ISemver {
     /// @notice Semantic version.
     /// @custom:semver 1.6.0
     string public constant version = "1.6.0";
-
-    /// @notice Constructs the BaseFeeVault contract.
-    /// @param _recipient           Wallet that will receive the fees.
-    /// @param _minWithdrawalAmount Minimum balance for withdrawals.
-    /// @param _withdrawalNetwork   Network which the recipient will receive fees on.
-    constructor(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        Types.WithdrawalNetwork _withdrawalNetwork
-    )
-        FeeVault(_recipient, _minWithdrawalAmount, _withdrawalNetwork)
-    { }
 }

--- a/packages/contracts-bedrock/src/L2/FeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/FeeVault.sol
@@ -21,24 +21,6 @@ abstract contract FeeVault is Initializable {
     /// @notice Error thrown when a function meant to be called by the ProxyAdmin owner is called by another account.
     error FeeVault_OnlyProxyAdminOwner();
 
-    /// @notice Minimum balance before a withdrawal can be triggered.
-    ///         Use the `minWithdrawalAmount()` getter as this is deprecated
-    ///         and is subject to be removed in the future.
-    /// @custom:legacy
-    uint256 public immutable MIN_WITHDRAWAL_AMOUNT;
-
-    /// @notice Account that will receive the fees. Can be located on L1 or L2.
-    ///         Use the `recipient()` getter as this is deprecated
-    ///         and is subject to be removed in the future.
-    /// @custom:legacy
-    address public immutable RECIPIENT;
-
-    /// @notice Network which the recipient will receive fees on.
-    ///         Use the `withdrawalNetwork()` getter as this is deprecated
-    ///         and is subject to be removed in the future.
-    /// @custom:legacy
-    Types.WithdrawalNetwork public immutable WITHDRAWAL_NETWORK;
-
     /// @notice The minimum gas limit for the FeeVault withdrawal transaction.
     uint32 internal constant _WITHDRAWAL_MIN_GAS = 400_000;
 
@@ -88,18 +70,17 @@ abstract contract FeeVault is Initializable {
         Types.WithdrawalNetwork oldWithdrawalNetwork, Types.WithdrawalNetwork newWithdrawalNetwork
     );
 
-    /// @dev Using `__` on params to avoid warnings related to shadowing (even though there is no shadowing)
-    /// @param _recipient           Wallet that will receive the fees.
-    /// @param _minWithdrawalAmount Minimum balance for withdrawals.
-    /// @param _withdrawalNetwork   Network which the recipient will receive fees on.
-    constructor(address _recipient, uint256 _minWithdrawalAmount, Types.WithdrawalNetwork _withdrawalNetwork) {
-        RECIPIENT = _recipient;
-        MIN_WITHDRAWAL_AMOUNT = _minWithdrawalAmount;
-        WITHDRAWAL_NETWORK = _withdrawalNetwork;
-
+    /// @notice Constructor for the FeeVault contract.
+    ///         This constructor is intentionally empty to prevent initialization.
+    ///         Initialization is handled by the `initialize` function.
+    constructor() {
         _disableInitializers();
     }
 
+    /// @notice Initializes the FeeVault contract.
+    /// @param _recipient           Wallet that will receive the fees.
+    /// @param _minWithdrawalAmount Minimum balance for withdrawals.
+    /// @param _withdrawalNetwork   Network which the recipient will receive fees on.
     function initialize(
         address _recipient,
         uint256 _minWithdrawalAmount,
@@ -184,5 +165,31 @@ abstract contract FeeVault is Initializable {
                 _data: hex""
             });
         }
+    }
+
+    /// @notice Minimum balance before a withdrawal can be triggered.
+    ///         Use the `minWithdrawalAmount()` getter as this is deprecated
+    ///         and is subject to be removed in the future.
+    /// @custom:legacy
+    function MIN_WITHDRAWAL_AMOUNT() public view returns (uint256) {
+        return minWithdrawalAmount;
+    }
+
+    /// @notice Account that will receive the fees. Can be located on L1 or L2.
+    ///         Use the `recipient()` getter as this is deprecated
+    ///         and is subject to be removed in the future.
+    /// @custom:legacy
+    /// @return The recipient address.
+    /// @custom:legacy
+    function RECIPIENT() public view returns (address) {
+        return recipient;
+    }
+
+    /// @notice Network which the recipient will receive fees on.
+    ///         Use the `withdrawalNetwork()` getter as this is deprecated
+    ///         and is subject to be removed in the future.
+    /// @custom:legacy
+    function WITHDRAWAL_NETWORK() public view returns (Types.WithdrawalNetwork) {
+        return withdrawalNetwork;
     }
 }

--- a/packages/contracts-bedrock/src/L2/FeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/FeeVault.sol
@@ -180,7 +180,6 @@ abstract contract FeeVault is Initializable {
     ///         and is subject to be removed in the future.
     /// @custom:legacy
     /// @return The recipient address.
-    /// @custom:legacy
     function RECIPIENT() public view returns (address) {
         return recipient;
     }

--- a/packages/contracts-bedrock/src/L2/L1FeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/L1FeeVault.sol
@@ -4,9 +4,6 @@ pragma solidity 0.8.25;
 // Contracts
 import { FeeVault } from "src/L2/FeeVault.sol";
 
-// Libraries
-import { Types } from "src/libraries/Types.sol";
-
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
@@ -18,16 +15,4 @@ contract L1FeeVault is FeeVault, ISemver {
     /// @notice Semantic version.
     /// @custom:semver 1.6.0
     string public constant version = "1.6.0";
-
-    /// @notice Constructs the L1FeeVault contract.
-    /// @param _recipient           Wallet that will receive the fees.
-    /// @param _minWithdrawalAmount Minimum balance for withdrawals.
-    /// @param _withdrawalNetwork   Network which the recipient will receive fees on.
-    constructor(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        Types.WithdrawalNetwork _withdrawalNetwork
-    )
-        FeeVault(_recipient, _minWithdrawalAmount, _withdrawalNetwork)
-    { }
 }

--- a/packages/contracts-bedrock/src/L2/OperatorFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/OperatorFeeVault.sol
@@ -4,9 +4,6 @@ pragma solidity 0.8.25;
 // Contracts
 import { FeeVault } from "src/L2/FeeVault.sol";
 
-// Libraries
-import { Types } from "src/libraries/Types.sol";
-
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
@@ -18,16 +15,4 @@ contract OperatorFeeVault is FeeVault, ISemver {
     /// @notice Semantic version.
     /// @custom:semver 1.1.0
     string public constant version = "1.1.0";
-
-    /// @notice Constructs the OperatorFeeVault contract.
-    /// @param _recipient           Wallet that will receive the fees.
-    /// @param _minWithdrawalAmount Minimum balance for withdrawals.
-    /// @param _withdrawalNetwork   Network which the recipient will receive fees on.
-    constructor(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        Types.WithdrawalNetwork _withdrawalNetwork
-    )
-        FeeVault(_recipient, _minWithdrawalAmount, _withdrawalNetwork)
-    { }
 }

--- a/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol
@@ -4,9 +4,6 @@ pragma solidity 0.8.25;
 // Contracts
 import { FeeVault } from "src/L2/FeeVault.sol";
 
-// Libraries
-import { Types } from "src/libraries/Types.sol";
-
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
@@ -18,18 +15,6 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 contract SequencerFeeVault is FeeVault, ISemver {
     /// @custom:semver 1.6.0
     string public constant version = "1.6.0";
-
-    /// @notice Constructs the SequencerFeeVault contract.
-    /// @param _recipient           Wallet that will receive the fees.
-    /// @param _minWithdrawalAmount Minimum balance for withdrawals.
-    /// @param _withdrawalNetwork   Network which the recipient will receive fees on.
-    constructor(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        Types.WithdrawalNetwork _withdrawalNetwork
-    )
-        FeeVault(_recipient, _minWithdrawalAmount, _withdrawalNetwork)
-    { }
 
     /// @custom:legacy
     /// @notice Legacy getter for the recipient address.

--- a/packages/contracts-bedrock/test/vendor/InitializableOZv5.t.sol
+++ b/packages/contracts-bedrock/test/vendor/InitializableOZv5.t.sol
@@ -5,7 +5,7 @@ import { Test } from "forge-std/Test.sol";
 import { IOptimismSuperchainERC20 } from "interfaces/L2/IOptimismSuperchainERC20.sol";
 import { Initializable } from "@openzeppelin/contracts-v5/proxy/utils/Initializable.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
-import { IFeeVault, IFeeVaultConstructor } from "interfaces/L2/IFeeVault.sol";
+import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
 import { Types } from "src/libraries/Types.sol";
 
 /// @title InitializerOZv5_Test
@@ -51,9 +51,7 @@ contract InitializerOZv5_Test is Test {
                 target: address(
                     DeployUtils.create1({
                         _name: "BaseFeeVault",
-                        _args: DeployUtils.encodeConstructor(
-                            abi.encodeCall(IFeeVaultConstructor.__constructor__, (address(0), 0, Types.WithdrawalNetwork.L1))
-                        )
+                        _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, ()))
                     })
                 ),
                 initCalldata: abi.encodeCall(IFeeVault.initialize, (address(0), 0, Types.WithdrawalNetwork.L1))
@@ -66,9 +64,7 @@ contract InitializerOZv5_Test is Test {
                 target: address(
                     DeployUtils.create1({
                         _name: "OperatorFeeVault",
-                        _args: DeployUtils.encodeConstructor(
-                            abi.encodeCall(IFeeVaultConstructor.__constructor__, (address(0), 0, Types.WithdrawalNetwork.L1))
-                        )
+                        _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, ()))
                     })
                 ),
                 initCalldata: abi.encodeCall(IFeeVault.initialize, (address(0), 0, Types.WithdrawalNetwork.L1))
@@ -81,9 +77,7 @@ contract InitializerOZv5_Test is Test {
                 target: address(
                     DeployUtils.create1({
                         _name: "SequencerFeeVault",
-                        _args: DeployUtils.encodeConstructor(
-                            abi.encodeCall(IFeeVaultConstructor.__constructor__, (address(0), 0, Types.WithdrawalNetwork.L1))
-                        )
+                        _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, ()))
                     })
                 ),
                 initCalldata: abi.encodeCall(IFeeVault.initialize, (address(0), 0, Types.WithdrawalNetwork.L1))
@@ -96,9 +90,7 @@ contract InitializerOZv5_Test is Test {
                 target: address(
                     DeployUtils.create1({
                         _name: "L1FeeVault",
-                        _args: DeployUtils.encodeConstructor(
-                            abi.encodeCall(IFeeVaultConstructor.__constructor__, (address(0), 0, Types.WithdrawalNetwork.L1))
-                        )
+                        _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeeVault.__constructor__, ()))
                     })
                 ),
                 initCalldata: abi.encodeCall(IFeeVault.initialize, (address(0), 0, Types.WithdrawalNetwork.L1))


### PR DESCRIPTION
## Remove Immutable variables
Descopes constructors from FeeVault interfaces (IBaseFeeVault, IL1FeeVault, ISequencerFeeVault, IOperatorFeeVault). Replaces legacy immutables with external view function accessors for backward compatibility.
Changes:
- Remove constructor definitions from FeeVault interfaces
- Maintains backward compatibility by adding view functions that replace legacy `RECIPIENT`, `MIN_WITHDRAWAL_AMOUNT`, `WITHDRAWAL_NETWORK` immutables