### PR TITLE
fix: upgrade OZ version

### DIFF
--- a/packages/contracts-bedrock/src/L1/FeesDepositor.sol
+++ b/packages/contracts-bedrock/src/L1/FeesDepositor.sol
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 import { ProxyAdminOwnedBase } from "src/L1/ProxyAdminOwnedBase.sol";
-import { ReinitializableBase } from "src/universal/ReinitializableBase.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
-import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import { Initializable } from "@openzeppelin/contracts-v5/proxy/utils/Initializable.sol";
 
 /// @custom:proxied true
 /// @title FeesDepositor
 /// @notice A contract that deposits fees to the L2 recipient when the deposit threshold is reached.
-contract FeesDepositor is ProxyAdminOwnedBase, Initializable, ReinitializableBase, ISemver {
+contract FeesDepositor is ProxyAdminOwnedBase, Initializable, ISemver {
     /// @notice The L1CrossDomainMessenger contract.
     IL1CrossDomainMessenger public messenger;
 
@@ -54,7 +53,7 @@ contract FeesDepositor is ProxyAdminOwnedBase, Initializable, ReinitializableBas
     string public constant version = "1.0.0";
 
     /// @notice Constructs the FeesDepositor contract.
-    constructor() ReinitializableBase(1) {
+    constructor() {
         _disableInitializers();
     }
 
@@ -70,7 +69,7 @@ contract FeesDepositor is ProxyAdminOwnedBase, Initializable, ReinitializableBas
         uint32 _gasLimit
     )
         external
-        reinitializer(initVersion())
+        initializer
     {
         // Initialization transactions must come from the ProxyAdmin or its owner.
         _assertOnlyProxyAdminOrProxyAdminOwner();

--- a/packages/contracts-bedrock/src/L2/FeeSplitter.sol
+++ b/packages/contracts-bedrock/src/L2/FeeSplitter.sol
@@ -13,7 +13,7 @@ import { ISharesCalculator } from "interfaces/L2/ISharesCalculator.sol";
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
 
 // OpenZeppelin
-import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { Initializable } from "@openzeppelin/contracts-v5/proxy/utils/Initializable.sol";
 
 /// @custom:proxied
 /// @custom:predeploy 0x420000000000000000000000000000000000002B

--- a/packages/contracts-bedrock/test/L1/FeesDepositor.t.sol
+++ b/packages/contracts-bedrock/test/L1/FeesDepositor.t.sol
@@ -5,7 +5,6 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { ICrossDomainMessenger } from "interfaces/universal/ICrossDomainMessenger.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { IFeesDepositor } from "interfaces/L1/IFeesDepositor.sol";
-import { FeesDepositor } from "src/L1/FeesDepositor.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 import { Features } from "src/libraries/Features.sol";
@@ -20,8 +19,11 @@ contract FeesDepositor_TestInit is CommonTest {
     event L2RecipientUpdated(address oldL2Recipient, address newL2Recipient);
     event GasLimitUpdated(uint32 oldGasLimit, uint32 newGasLimit);
 
+    // Errors
+    error InvalidInitialization();
+
     // Test state
-    FeesDepositor feesDepositor;
+    IFeesDepositor feesDepositor;
     address l2Recipient = makeAddr("l2Recipient");
     uint96 minDepositAmount = 1 ether;
     uint32 gasLimit = 150_000;
@@ -45,7 +47,7 @@ contract FeesDepositor_TestInit is CommonTest {
         Proxy(payable(proxy)).upgradeTo(implementation);
 
         // Cast proxy to FeesDepositor
-        feesDepositor = FeesDepositor(payable(proxy));
+        feesDepositor = IFeesDepositor(payable(proxy));
 
         // Initialize through proxy
         vm.prank(proxyAdminOwner);
@@ -63,7 +65,7 @@ contract FeesDepositor_Initialize_Test is FeesDepositor_TestInit {
     /// @notice This contract is excluded from the Initializable.t.sol test because it is not deployed as part of the
     /// standard deployment script and instead is deployed manually, that's why we have this test.
     function test_cannotReinitialize_succeeds() public {
-        vm.expectRevert("Initializable: contract is already initialized");
+        vm.expectRevert(InvalidInitialization.selector);
         feesDepositor.initialize(minDepositAmount, l2Recipient, l1CrossDomainMessenger, gasLimit);
     }
 }

--- a/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
@@ -90,13 +90,14 @@ contract FeeSplitter_TestInit is CommonTest {
 /// @title FeeSplitter_Initialize_Test
 /// @notice Tests the initialization functions of the `FeeSplitter` contract.
 contract FeeSplitter_Initialize_Test is FeeSplitter_TestInit {
-    event Initialized(uint8 version);
+    event Initialized(uint64 version);
+    error InvalidInitialization();
 
     /// @notice Test that re-initialization fails on the already-initialized predeploy
     function test_feeSplitter_reinitialization_reverts() public {
         // The FeeSplitter at the predeploy address is already initialized through genesis
         vm.prank(_owner);
-        vm.expectRevert("Initializable: contract is already initialized");
+        vm.expectRevert(InvalidInitialization.selector);
         feeSplitter.initialize(ISharesCalculator(address(_defaultSharesCalculator)));
     }
 
@@ -120,7 +121,7 @@ contract FeeSplitter_Initialize_Test is FeeSplitter_TestInit {
 
         // Expect the Initialized event to be emitted
         vm.expectEmit(true, true, true, true);
-        emit Initialized(type(uint8).max);
+        emit Initialized(type(uint64).max);
 
         // Deploy the implementation contract
         assembly {
@@ -131,7 +132,7 @@ contract FeeSplitter_Initialize_Test is FeeSplitter_TestInit {
         assertTrue(implementation != address(0));
 
         // Verify re-initialization fails
-        vm.expectRevert("Initializable: contract is already initialized");
+        vm.expectRevert(InvalidInitialization.selector);
         IFeeSplitter(payable(implementation)).initialize(ISharesCalculator(address(_defaultSharesCalculator)));
     }
 }


### PR DESCRIPTION
Closes OPT-1241

increasing the OZ version requires increasing to sol 0.8.25, this requires stopping the use of reinitializable base. check how much value it adds and if it can be removed