### PR TITLE
feat: add ownable liquidity

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -310,6 +310,8 @@ type GasTokenDeployConfig struct {
 	GasPayingTokenSymbol string `json:"gasPayingTokenSymbol"`
 	// NativeAssetLiquidityAmount represents the amount of liquidity to pre-fund the NativeAssetLiquidity contract with.
 	NativeAssetLiquidityAmount *hexutil.Big `json:"nativeAssetLiquidityAmount"`
+	// LiquidityControllerOwner represents the owner of the LiquidityController.
+	LiquidityControllerOwner common.Address `json:"liquidityControllerOwner"`
 }
 
 var _ ConfigChecker = (*GasTokenDeployConfig)(nil)
@@ -325,7 +327,9 @@ func (d *GasTokenDeployConfig) Check(log log.Logger) error {
 		if d.NativeAssetLiquidityAmount == nil || d.NativeAssetLiquidityAmount.ToInt().Sign() < 0 {
 			return fmt.Errorf("%w: NativeAssetLiquidityAmount cannot be nil or negative", ErrInvalidDeployConfig)
 		}
-
+		if d.LiquidityControllerOwner == (common.Address{}) {
+			return fmt.Errorf("%w: LiquidityControllerOwner cannot be address(0)", ErrInvalidDeployConfig)
+		}
 		log.Info("Using custom gas token", "name", d.GasPayingTokenName, "symbol", d.GasPayingTokenSymbol, "nativeAssetLiquidityAmount", d.NativeAssetLiquidityAmount.ToInt())
 	}
 	return nil

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -314,7 +314,6 @@ func TestEndToEndApply(t *testing.T) {
 		amount := new(big.Int)
 		amount.SetString("1000000000000000000000", 10)
 		intent.Chains[0].CustomGasToken = state.CustomGasToken{
-			Enabled:          true,
 			Name:             "Custom Gas Token",
 			Symbol:           "CGT",
 			InitialLiquidity: (*hexutil.Big)(amount),

--- a/op-deployer/pkg/deployer/integration_test/shared/shared.go
+++ b/op-deployer/pkg/deployer/integration_test/shared/shared.go
@@ -45,11 +45,8 @@ func NewChainIntent(t *testing.T, dk *devkeys.MnemonicDevKeys, l1ChainID *big.In
 		},
 		UseRevenueShare:    false,
 		ChainFeesRecipient: common.Address{},
-		CustomGasToken: state.CustomGasToken{
-			Enabled: false,
-			Name:    "",
-			Symbol:  "",
-		},
+		// CustomGasToken defaults to disabled (all fields nil/empty)
+		CustomGasToken: state.CustomGasToken{},
 	}
 }
 

--- a/op-deployer/pkg/deployer/opcm/l2genesis.go
+++ b/op-deployer/pkg/deployer/opcm/l2genesis.go
@@ -38,6 +38,7 @@ type L2GenesisInput struct {
 	GasPayingTokenName                       string
 	GasPayingTokenSymbol                     string
 	NativeAssetLiquidityAmount               *big.Int
+	LiquidityControllerOwner                 common.Address
 }
 
 type L2GenesisScript script.DeployScriptWithoutOutput[L2GenesisInput]

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -22,14 +22,6 @@ import (
 )
 
 type l2GenesisOverrides struct {
-	// ===== CUSTOM GAS TOKEN (CGT) CONFIGURATION =====
-	UseCustomGasToken          bool           `json:"useCustomGasToken"`          // CGT: Enable custom gas token mode
-	GasPayingTokenName         string         `json:"gasPayingTokenName"`         // CGT: Name of the custom gas token
-	GasPayingTokenSymbol       string         `json:"gasPayingTokenSymbol"`       // CGT: Symbol of the custom gas token
-	NativeAssetLiquidityAmount *hexutil.Big   `json:"nativeAssetLiquidityAmount"` // CGT: Liquidity amount for NativeAssetLiquidity contract
-	LiquidityControllerOwner   common.Address `json:"liquidityControllerOwner"`   // CGT: Owner of the LiquidityController contract
-
-	// ===== GENERAL L2 CONFIGURATION (NON-CGT) =====
 	FundDevAccounts                          bool                      `json:"fundDevAccounts"`
 	BaseFeeVaultMinimumWithdrawalAmount      *hexutil.Big              `json:"baseFeeVaultMinimumWithdrawalAmount"`
 	L1FeeVaultMinimumWithdrawalAmount        *hexutil.Big              `json:"l1FeeVaultMinimumWithdrawalAmount"`
@@ -83,9 +75,6 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 		return fmt.Errorf("failed to calculate L2 genesis overrides: %w", err)
 	}
 
-	// Resolve effective CGT configuration without mutating the intent
-	effectiveCGT := resolveEffectiveCGT(thisIntent, overrides)
-
 	if err := script.Run(opcm.L2GenesisInput{
 		L1ChainID:                                new(big.Int).SetUint64(intent.L1ChainID),
 		L2ChainID:                                chainID.Big(),
@@ -113,12 +102,12 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 		UseRevenueShare:                          thisIntent.UseRevenueShare,
 		ChainFeesRecipient:                       thisIntent.ChainFeesRecipient,
 		L1FeesDepositor:                          standard.L1FeesDepositor,
-		// Custom Gas Token (CGT) configuration passed to L2Genesis script
-		UseCustomGasToken:          effectiveCGT.UseCustomGasToken,          // CGT: Enable/disable custom gas token (inferred from Name/Symbol)
-		GasPayingTokenName:         effectiveCGT.GasPayingTokenName,         // CGT: Token name (e.g., "Custom Gas Token")
-		GasPayingTokenSymbol:       effectiveCGT.GasPayingTokenSymbol,       // CGT: Token symbol (e.g., "CGT")
-		NativeAssetLiquidityAmount: effectiveCGT.NativeAssetLiquidityAmount, // CGT: Liquidity amount (defaults to type(uint248).max)
-		LiquidityControllerOwner:   effectiveCGT.LiquidityControllerOwner,   // CGT: LiquidityController owner (defaults to L2ProxyAdminOwner)
+		// Custom Gas Token (CGT) configuration from intent only (no overrides)
+		UseCustomGasToken:          thisIntent.IsCustomGasTokenEnabled(),
+		GasPayingTokenName:         thisIntent.CustomGasToken.Name,
+		GasPayingTokenSymbol:       thisIntent.CustomGasToken.Symbol,
+		NativeAssetLiquidityAmount: thisIntent.GetInitialLiquidity(),
+		LiquidityControllerOwner:   thisIntent.GetLiquidityControllerOwner(),
 	}); err != nil {
 		return fmt.Errorf("failed to call L2Genesis script: %w", err)
 	}
@@ -167,89 +156,11 @@ func calculateL2GenesisOverrides(intent *state.Intent, thisIntent *state.ChainIn
 		}
 	}
 
-	// Validate that standard chains don't enable custom gas token
-	if intent.ConfigType == state.IntentTypeStandard {
-		// Check both intent and override configurations
-		intentHasCGT := thisIntent.IsCustomGasTokenEnabled()
-		overrideHasCGT := overrides.UseCustomGasToken
-		if intentHasCGT || overrideHasCGT {
-			return l2GenesisOverrides{}, nil, fmt.Errorf(
-				"custom gas token cannot be enabled on standard chain (chainId=%s). "+
-					"Standard chains must use ETH as the native gas token. "+
-					"To use a custom gas token, the intent must be created with configType=\"custom\" or \"standard-overrides\"",
-				thisIntent.ID)
-		}
-	}
-
 	return overrides, schedule, nil
 }
 
 func shouldGenerateL2Genesis(thisChainState *state.ChainState) bool {
 	return thisChainState.Allocs == nil
-}
-
-// effectiveCGTConfig represents the resolved CGT configuration to pass to L2Genesis script.
-type effectiveCGTConfig struct {
-	UseCustomGasToken          bool
-	GasPayingTokenName         string
-	GasPayingTokenSymbol       string
-	NativeAssetLiquidityAmount *big.Int
-	LiquidityControllerOwner   common.Address
-}
-
-// resolveEffectiveCGT computes the effective CGT configuration without mutating the input intent.
-// It prioritizes the intent configuration, but falls back to overrides if the intent doesn't have CGT enabled.
-func resolveEffectiveCGT(thisIntent *state.ChainIntent, overrides l2GenesisOverrides) effectiveCGTConfig {
-	// If intent has CGT enabled, use intent values
-	if thisIntent.IsCustomGasTokenEnabled() {
-		return effectiveCGTConfig{
-			UseCustomGasToken:          true,
-			GasPayingTokenName:         thisIntent.CustomGasToken.Name,
-			GasPayingTokenSymbol:       thisIntent.CustomGasToken.Symbol,
-			NativeAssetLiquidityAmount: thisIntent.GetInitialLiquidity(),
-			LiquidityControllerOwner:   thisIntent.GetLiquidityControllerOwner(),
-		}
-	}
-
-	// If intent doesn't have CGT enabled but overrides do, use override values
-	if overrides.UseCustomGasToken {
-		var liquidity *big.Int
-
-		// Check if liquidity is set in overrides
-		if overrides.NativeAssetLiquidityAmount != nil {
-			liquidity = overrides.NativeAssetLiquidityAmount.ToInt()
-		}
-
-		// If liquidity is not set (nil or 0), use type(uint248).max as default
-		if liquidity == nil || liquidity.Sign() == 0 {
-			maxUint248 := new(big.Int)
-			maxUint248.SetString("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
-			liquidity = maxUint248
-		}
-
-		// Use override value if set, otherwise fall back to L2ProxyAdminOwner
-		owner := overrides.LiquidityControllerOwner
-		if owner == (common.Address{}) {
-			owner = thisIntent.Roles.L2ProxyAdminOwner
-		}
-
-		return effectiveCGTConfig{
-			UseCustomGasToken:          true,
-			GasPayingTokenName:         overrides.GasPayingTokenName,
-			GasPayingTokenSymbol:       overrides.GasPayingTokenSymbol,
-			NativeAssetLiquidityAmount: liquidity,
-			LiquidityControllerOwner:   owner,
-		}
-	}
-
-	// CGT not enabled in either intent or overrides
-	return effectiveCGTConfig{
-		UseCustomGasToken:          false,
-		GasPayingTokenName:         "",
-		GasPayingTokenSymbol:       "",
-		NativeAssetLiquidityAmount: big.NewInt(0),
-		LiquidityControllerOwner:   common.Address{},
-	}
 }
 
 func wdNetworkToBig(wd genesis.WithdrawalNetwork) *big.Int {
@@ -259,7 +170,6 @@ func wdNetworkToBig(wd genesis.WithdrawalNetwork) *big.Int {
 
 func defaultOverrides() l2GenesisOverrides {
 	return l2GenesisOverrides{
-		// ===== GENERAL L2 DEFAULTS =====
 		FundDevAccounts:                          false,
 		BaseFeeVaultMinimumWithdrawalAmount:      standard.VaultMinWithdrawalAmount,
 		L1FeeVaultMinimumWithdrawalAmount:        standard.VaultMinWithdrawalAmount,
@@ -271,11 +181,5 @@ func defaultOverrides() l2GenesisOverrides {
 		OperatorFeeVaultWithdrawalNetwork:        "local",
 		EnableGovernance:                         false,
 		GovernanceTokenOwner:                     standard.GovernanceTokenOwner,
-		// ===== CGT DEFAULTS =====
-		UseCustomGasToken:          false,           // CGT disabled by default
-		GasPayingTokenName:         "",              // Empty when CGT disabled
-		GasPayingTokenSymbol:       "",              // Empty when CGT disabled
-		NativeAssetLiquidityAmount: nil,             // nil triggers type(uint248).max fallback when CGT enabled
-		LiquidityControllerOwner:   common.Address{}, // Empty address triggers L2ProxyAdminOwner fallback when CGT enabled
 	}
 }

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -110,10 +110,11 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 		ChainFeesRecipient:                       thisIntent.ChainFeesRecipient,
 		L1FeesDepositor:                          standard.L1FeesDepositor,
 		// Custom Gas Token (CGT) configuration passed to L2Genesis script
-		UseCustomGasToken:          thisIntent.CustomGasToken.Enabled, // CGT: Enable/disable custom gas token
-		GasPayingTokenName:         thisIntent.CustomGasToken.Name,    // CGT: Token name (e.g., "Custom Gas Token")
-		GasPayingTokenSymbol:       thisIntent.CustomGasToken.Symbol,  // CGT: Token symbol (e.g., "CGT")
-		NativeAssetLiquidityAmount: thisIntent.GetInitialLiquidity(),  // CGT: Liquidity amount for NativeAssetLiquidity contract
+		UseCustomGasToken:          thisIntent.IsCustomGasTokenEnabled(),    // CGT: Enable/disable custom gas token (inferred from Name/Symbol)
+		GasPayingTokenName:         thisIntent.CustomGasToken.Name,          // CGT: Token name (e.g., "Custom Gas Token")
+		GasPayingTokenSymbol:       thisIntent.CustomGasToken.Symbol,        // CGT: Token symbol (e.g., "CGT")
+		NativeAssetLiquidityAmount: thisIntent.GetInitialLiquidity(),        // CGT: Liquidity amount (defaults to type(uint248).max)
+		LiquidityControllerOwner:   thisIntent.GetLiquidityControllerOwner(), // CGT: LiquidityController owner (defaults to L2ProxyAdminOwner)
 	}); err != nil {
 		return fmt.Errorf("failed to call L2Genesis script: %w", err)
 	}
@@ -162,10 +163,9 @@ func calculateL2GenesisOverrides(intent *state.Intent, thisIntent *state.ChainIn
 		}
 	}
 
-	// If CustomGasToken is not enabled, update it with override values
-	if !thisIntent.CustomGasToken.Enabled {
+	// If CustomGasToken is not enabled in intent, update it with override values
+	if !thisIntent.IsCustomGasTokenEnabled() && overrides.UseCustomGasToken {
 		thisIntent.CustomGasToken = state.CustomGasToken{
-			Enabled:          overrides.UseCustomGasToken,
 			Name:             overrides.GasPayingTokenName,
 			Symbol:           overrides.GasPayingTokenSymbol,
 			InitialLiquidity: overrides.NativeAssetLiquidityAmount,

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -102,7 +102,7 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 		UseRevenueShare:                          thisIntent.UseRevenueShare,
 		ChainFeesRecipient:                       thisIntent.ChainFeesRecipient,
 		L1FeesDepositor:                          standard.L1FeesDepositor,
-		// Custom Gas Token (CGT) configuration from intent only (no overrides)
+		// Custom Gas Token (CGT) configuration from intent
 		UseCustomGasToken:          thisIntent.IsCustomGasTokenEnabled(),
 		GasPayingTokenName:         thisIntent.CustomGasToken.Name,
 		GasPayingTokenSymbol:       thisIntent.CustomGasToken.Symbol,

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -82,6 +82,9 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 		return fmt.Errorf("failed to calculate L2 genesis overrides: %w", err)
 	}
 
+	// Resolve effective CGT configuration without mutating the intent
+	effectiveCGT := resolveEffectiveCGT(thisIntent, overrides)
+
 	if err := script.Run(opcm.L2GenesisInput{
 		L1ChainID:                                new(big.Int).SetUint64(intent.L1ChainID),
 		L2ChainID:                                chainID.Big(),
@@ -110,11 +113,11 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 		ChainFeesRecipient:                       thisIntent.ChainFeesRecipient,
 		L1FeesDepositor:                          standard.L1FeesDepositor,
 		// Custom Gas Token (CGT) configuration passed to L2Genesis script
-		UseCustomGasToken:          thisIntent.IsCustomGasTokenEnabled(),    // CGT: Enable/disable custom gas token (inferred from Name/Symbol)
-		GasPayingTokenName:         thisIntent.CustomGasToken.Name,          // CGT: Token name (e.g., "Custom Gas Token")
-		GasPayingTokenSymbol:       thisIntent.CustomGasToken.Symbol,        // CGT: Token symbol (e.g., "CGT")
-		NativeAssetLiquidityAmount: thisIntent.GetInitialLiquidity(),        // CGT: Liquidity amount (defaults to type(uint248).max)
-		LiquidityControllerOwner:   thisIntent.GetLiquidityControllerOwner(), // CGT: LiquidityController owner (defaults to L2ProxyAdminOwner)
+		UseCustomGasToken:          effectiveCGT.UseCustomGasToken,          // CGT: Enable/disable custom gas token (inferred from Name/Symbol)
+		GasPayingTokenName:         effectiveCGT.GasPayingTokenName,         // CGT: Token name (e.g., "Custom Gas Token")
+		GasPayingTokenSymbol:       effectiveCGT.GasPayingTokenSymbol,       // CGT: Token symbol (e.g., "CGT")
+		NativeAssetLiquidityAmount: effectiveCGT.NativeAssetLiquidityAmount, // CGT: Liquidity amount (defaults to type(uint248).max)
+		LiquidityControllerOwner:   effectiveCGT.LiquidityControllerOwner,   // CGT: LiquidityController owner (defaults to L2ProxyAdminOwner)
 	}); err != nil {
 		return fmt.Errorf("failed to call L2Genesis script: %w", err)
 	}
@@ -163,20 +166,14 @@ func calculateL2GenesisOverrides(intent *state.Intent, thisIntent *state.ChainIn
 		}
 	}
 
-	// If CustomGasToken is not enabled in intent, update it with override values
-	if !thisIntent.IsCustomGasTokenEnabled() && overrides.UseCustomGasToken {
-		thisIntent.CustomGasToken = state.CustomGasToken{
-			Name:             overrides.GasPayingTokenName,
-			Symbol:           overrides.GasPayingTokenSymbol,
-			InitialLiquidity: overrides.NativeAssetLiquidityAmount,
-		}
-	}
-
-	// If the intent is a standard chain, and the custom gas token is enabled, return an error
+	// Validate that standard chains don't enable custom gas token
 	if intent.ConfigType == state.IntentTypeStandard {
-		if thisIntent.IsCustomGasTokenEnabled() {
+		// Check both intent and override configurations
+		intentHasCGT := thisIntent.IsCustomGasTokenEnabled()
+		overrideHasCGT := overrides.UseCustomGasToken
+		if intentHasCGT || overrideHasCGT {
 			return l2GenesisOverrides{}, nil, fmt.Errorf(
-				"override attempted to enable custom gas token on standard chain (chainId=%s). "+
+				"custom gas token cannot be enabled on standard chain (chainId=%s). "+
 					"Standard chains must use ETH as the native gas token. "+
 					"To use a custom gas token, the intent must be created with configType=\"custom\" or \"standard-overrides\"",
 				thisIntent.ID)
@@ -188,6 +185,62 @@ func calculateL2GenesisOverrides(intent *state.Intent, thisIntent *state.ChainIn
 
 func shouldGenerateL2Genesis(thisChainState *state.ChainState) bool {
 	return thisChainState.Allocs == nil
+}
+
+// effectiveCGTConfig represents the resolved CGT configuration to pass to L2Genesis script.
+type effectiveCGTConfig struct {
+	UseCustomGasToken          bool
+	GasPayingTokenName         string
+	GasPayingTokenSymbol       string
+	NativeAssetLiquidityAmount *big.Int
+	LiquidityControllerOwner   common.Address
+}
+
+// resolveEffectiveCGT computes the effective CGT configuration without mutating the input intent.
+// It prioritizes the intent configuration, but falls back to overrides if the intent doesn't have CGT enabled.
+func resolveEffectiveCGT(thisIntent *state.ChainIntent, overrides l2GenesisOverrides) effectiveCGTConfig {
+	// If intent has CGT enabled, use intent values
+	if thisIntent.IsCustomGasTokenEnabled() {
+		return effectiveCGTConfig{
+			UseCustomGasToken:          true,
+			GasPayingTokenName:         thisIntent.CustomGasToken.Name,
+			GasPayingTokenSymbol:       thisIntent.CustomGasToken.Symbol,
+			NativeAssetLiquidityAmount: thisIntent.GetInitialLiquidity(),
+			LiquidityControllerOwner:   thisIntent.GetLiquidityControllerOwner(),
+		}
+	}
+
+	// If intent doesn't have CGT enabled but overrides do, use override values
+	if overrides.UseCustomGasToken {
+		liquidity := overrides.NativeAssetLiquidityAmount.ToInt()
+
+		// If liquidity is not set (nil or 0), use type(uint248).max as default
+		if liquidity == nil || liquidity.Sign() == 0 {
+			maxUint248 := new(big.Int)
+			maxUint248.SetString("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
+			liquidity = maxUint248
+		}
+
+		// Use L2ProxyAdminOwner as default for LiquidityControllerOwner
+		owner := thisIntent.Roles.L2ProxyAdminOwner
+
+		return effectiveCGTConfig{
+			UseCustomGasToken:          true,
+			GasPayingTokenName:         overrides.GasPayingTokenName,
+			GasPayingTokenSymbol:       overrides.GasPayingTokenSymbol,
+			NativeAssetLiquidityAmount: liquidity,
+			LiquidityControllerOwner:   owner,
+		}
+	}
+
+	// CGT not enabled in either intent or overrides
+	return effectiveCGTConfig{
+		UseCustomGasToken:          false,
+		GasPayingTokenName:         "",
+		GasPayingTokenSymbol:       "",
+		NativeAssetLiquidityAmount: big.NewInt(0),
+		LiquidityControllerOwner:   common.Address{},
+	}
 }
 
 func wdNetworkToBig(wd genesis.WithdrawalNetwork) *big.Int {

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -23,10 +23,11 @@ import (
 
 type l2GenesisOverrides struct {
 	// ===== CUSTOM GAS TOKEN (CGT) CONFIGURATION =====
-	UseCustomGasToken          bool         `json:"useCustomGasToken"`          // CGT: Enable custom gas token mode
-	GasPayingTokenName         string       `json:"gasPayingTokenName"`         // CGT: Name of the custom gas token
-	GasPayingTokenSymbol       string       `json:"gasPayingTokenSymbol"`       // CGT: Symbol of the custom gas token
-	NativeAssetLiquidityAmount *hexutil.Big `json:"nativeAssetLiquidityAmount"` // CGT: Liquidity amount for NativeAssetLiquidity contract
+	UseCustomGasToken          bool           `json:"useCustomGasToken"`          // CGT: Enable custom gas token mode
+	GasPayingTokenName         string         `json:"gasPayingTokenName"`         // CGT: Name of the custom gas token
+	GasPayingTokenSymbol       string         `json:"gasPayingTokenSymbol"`       // CGT: Symbol of the custom gas token
+	NativeAssetLiquidityAmount *hexutil.Big   `json:"nativeAssetLiquidityAmount"` // CGT: Liquidity amount for NativeAssetLiquidity contract
+	LiquidityControllerOwner   common.Address `json:"liquidityControllerOwner"`   // CGT: Owner of the LiquidityController contract
 
 	// ===== GENERAL L2 CONFIGURATION (NON-CGT) =====
 	FundDevAccounts                          bool                      `json:"fundDevAccounts"`
@@ -212,7 +213,12 @@ func resolveEffectiveCGT(thisIntent *state.ChainIntent, overrides l2GenesisOverr
 
 	// If intent doesn't have CGT enabled but overrides do, use override values
 	if overrides.UseCustomGasToken {
-		liquidity := overrides.NativeAssetLiquidityAmount.ToInt()
+		var liquidity *big.Int
+
+		// Check if liquidity is set in overrides
+		if overrides.NativeAssetLiquidityAmount != nil {
+			liquidity = overrides.NativeAssetLiquidityAmount.ToInt()
+		}
 
 		// If liquidity is not set (nil or 0), use type(uint248).max as default
 		if liquidity == nil || liquidity.Sign() == 0 {
@@ -221,8 +227,11 @@ func resolveEffectiveCGT(thisIntent *state.ChainIntent, overrides l2GenesisOverr
 			liquidity = maxUint248
 		}
 
-		// Use L2ProxyAdminOwner as default for LiquidityControllerOwner
-		owner := thisIntent.Roles.L2ProxyAdminOwner
+		// Use override value if set, otherwise fall back to L2ProxyAdminOwner
+		owner := overrides.LiquidityControllerOwner
+		if owner == (common.Address{}) {
+			owner = thisIntent.Roles.L2ProxyAdminOwner
+		}
 
 		return effectiveCGTConfig{
 			UseCustomGasToken:          true,
@@ -263,9 +272,10 @@ func defaultOverrides() l2GenesisOverrides {
 		EnableGovernance:                         false,
 		GovernanceTokenOwner:                     standard.GovernanceTokenOwner,
 		// ===== CGT DEFAULTS =====
-		UseCustomGasToken:          false,                         // CGT disabled by default
-		GasPayingTokenName:         "",                            // Empty when CGT disabled
-		GasPayingTokenSymbol:       "",                            // Empty when CGT disabled
-		NativeAssetLiquidityAmount: (*hexutil.Big)(big.NewInt(0)), // Default to 0 when CGT disabled (consistent with "" and false)
+		UseCustomGasToken:          false,           // CGT disabled by default
+		GasPayingTokenName:         "",              // Empty when CGT disabled
+		GasPayingTokenSymbol:       "",              // Empty when CGT disabled
+		NativeAssetLiquidityAmount: nil,             // nil triggers type(uint248).max fallback when CGT enabled
+		LiquidityControllerOwner:   common.Address{}, // Empty address triggers L2ProxyAdminOwner fallback when CGT enabled
 	}
 }

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -172,6 +172,17 @@ func calculateL2GenesisOverrides(intent *state.Intent, thisIntent *state.ChainIn
 		}
 	}
 
+	// If the intent is a standard chain, and the custom gas token is enabled, return an error
+	if intent.ConfigType == state.IntentTypeStandard {
+		if thisIntent.IsCustomGasTokenEnabled() {
+			return l2GenesisOverrides{}, nil, fmt.Errorf(
+				"override attempted to enable custom gas token on standard chain (chainId=%s). "+
+					"Standard chains must use ETH as the native gas token. "+
+					"To use a custom gas token, the intent must be created with configType=\"custom\" or \"standard-overrides\"",
+				thisIntent.ID)
+		}
+	}
+
 	return overrides, schedule, nil
 }
 

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -35,6 +35,14 @@ type l2GenesisOverrides struct {
 	GovernanceTokenOwner                     common.Address            `json:"governanceTokenOwner"`
 }
 
+type cgtConfig struct {
+	UseCustomGasToken          bool
+	GasPayingTokenName         string
+	GasPayingTokenSymbol       string
+	NativeAssetLiquidityAmount *big.Int
+	LiquidityControllerOwner   common.Address
+}
+
 func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, st *state.State, chainID common.Hash) error {
 	lgr := pEnv.Logger.New("stage", "generate-l2-genesis")
 
@@ -75,6 +83,8 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 		return fmt.Errorf("failed to calculate L2 genesis overrides: %w", err)
 	}
 
+	cgt := buildCGTConfig(thisIntent)
+
 	if err := script.Run(opcm.L2GenesisInput{
 		L1ChainID:                                new(big.Int).SetUint64(intent.L1ChainID),
 		L2ChainID:                                chainID.Big(),
@@ -103,11 +113,11 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 		ChainFeesRecipient:                       thisIntent.ChainFeesRecipient,
 		L1FeesDepositor:                          standard.L1FeesDepositor,
 		// Custom Gas Token (CGT) configuration from intent
-		UseCustomGasToken:          thisIntent.IsCustomGasTokenEnabled(),
-		GasPayingTokenName:         thisIntent.CustomGasToken.Name,
-		GasPayingTokenSymbol:       thisIntent.CustomGasToken.Symbol,
-		NativeAssetLiquidityAmount: thisIntent.GetInitialLiquidity(),
-		LiquidityControllerOwner:   thisIntent.GetLiquidityControllerOwner(),
+		UseCustomGasToken:          cgt.UseCustomGasToken,
+		GasPayingTokenName:         cgt.GasPayingTokenName,
+		GasPayingTokenSymbol:       cgt.GasPayingTokenSymbol,
+		NativeAssetLiquidityAmount: cgt.NativeAssetLiquidityAmount,
+		LiquidityControllerOwner:   cgt.LiquidityControllerOwner,
 	}); err != nil {
 		return fmt.Errorf("failed to call L2Genesis script: %w", err)
 	}
@@ -157,6 +167,26 @@ func calculateL2GenesisOverrides(intent *state.Intent, thisIntent *state.ChainIn
 	}
 
 	return overrides, schedule, nil
+}
+
+// buildCGTConfig returns the CGT configuration when enabled, otherwise an empty config.
+func buildCGTConfig(intent *state.ChainIntent) cgtConfig {
+	if !intent.IsCustomGasTokenEnabled() {
+		return cgtConfig{
+			UseCustomGasToken:          false,
+			GasPayingTokenName:         "",
+			GasPayingTokenSymbol:       "",
+			NativeAssetLiquidityAmount: big.NewInt(0),
+			LiquidityControllerOwner:   common.Address{},
+		}
+	}
+	return cgtConfig{
+		UseCustomGasToken:          true,
+		GasPayingTokenName:         intent.CustomGasToken.Name,
+		GasPayingTokenSymbol:       intent.CustomGasToken.Symbol,
+		NativeAssetLiquidityAmount: intent.GetInitialLiquidity(),
+		LiquidityControllerOwner:   intent.GetLiquidityControllerOwner(),
+	}
 }
 
 func shouldGenerateL2Genesis(thisChainState *state.ChainState) bool {

--- a/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
@@ -71,10 +70,6 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 					"governanceTokenOwner":                     "0x1111111111111111111111111111111111111111",
 					"l2GenesisInteropTimeOffset":               "0x1234",
 					"chainFeesRecipient":                       "0x0000000000000000000000000000000000005678",
-					"useCustomGasToken":                        false,
-					"gasPayingTokenName":                       "",
-					"gasPayingTokenSymbol":                     "",
-					"nativeAssetLiquidityAmount":               "0x0",
 				},
 			},
 			chainIntent: &state.ChainIntent{},
@@ -91,7 +86,6 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				OperatorFeeVaultWithdrawalNetwork:        "remote",
 				EnableGovernance:                         true,
 				GovernanceTokenOwner:                     common.HexToAddress("0x1111111111111111111111111111111111111111"),
-				NativeAssetLiquidityAmount:               (*hexutil.Big)(hexutil.MustDecodeBig("0x0")),
 			},
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
 				sched := standard.DefaultHardforkScheduleForTag("")
@@ -120,10 +114,6 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 					"enableGovernance":                         true,
 					"governanceTokenOwner":                     "0x1111111111111111111111111111111111111111",
 					"l2GenesisInteropTimeOffset":               "0x1234",
-					"useCustomGasToken":                        false,
-					"gasPayingTokenName":                       "",
-					"gasPayingTokenSymbol":                     "",
-					"nativeAssetLiquidityAmount":               "0x0",
 				},
 			},
 			expectError: false,
@@ -139,7 +129,6 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				OperatorFeeVaultWithdrawalNetwork:        "remote",
 				EnableGovernance:                         true,
 				GovernanceTokenOwner:                     common.HexToAddress("0x1111111111111111111111111111111111111111"),
-				NativeAssetLiquidityAmount:               (*hexutil.Big)(hexutil.MustDecodeBig("0x0")),
 			},
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
 				sched := standard.DefaultHardforkScheduleForTag("")
@@ -153,104 +142,15 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				L1ContractsLocator: &artifacts.Locator{},
 				GlobalDeployOverrides: map[string]any{
 					"l2GenesisInteropTimeOffset": "0x0",
-					"nativeAssetLiquidityAmount": "0x0",
 				},
 			},
 			chainIntent: &state.ChainIntent{},
 			expectError: false,
-			expectedOverrides: func() l2GenesisOverrides {
-				defaults := defaultOverrides()
-				// Override with the same value that comes from JSON merge to match internal representation
-				defaults.NativeAssetLiquidityAmount = (*hexutil.Big)(hexutil.MustDecodeBig("0x0"))
-				return defaults
-			}(),
+			expectedOverrides: defaultOverrides(),
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
 				schedule := standard.DefaultHardforkScheduleForTag("")
 				schedule.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0)
 				return schedule
-			},
-		},
-		{
-			name: "SECURITY: reject CGT override on standard chain",
-			intent: &state.Intent{
-				ConfigType:         state.IntentTypeStandard,
-				L1ContractsLocator: &artifacts.Locator{},
-				GlobalDeployOverrides: map[string]any{
-					"useCustomGasToken":          true,
-					"gasPayingTokenName":         "MaliciousToken",
-					"gasPayingTokenSymbol":       "MAL",
-					"nativeAssetLiquidityAmount": "0x1000000",
-				},
-			},
-			chainIntent: &state.ChainIntent{
-				ID: common.HexToHash("0x1234"),
-				// CustomGasToken is intentionally NOT enabled in the base intent
-				CustomGasToken: state.CustomGasToken{},
-			},
-			expectError:       true, // Should fail security check
-			expectedOverrides: l2GenesisOverrides{},
-			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				return nil
-			},
-		},
-		{
-			name: "allow CGT override on custom chain",
-			intent: &state.Intent{
-				ConfigType:         state.IntentTypeCustom,
-				L1ContractsLocator: &artifacts.Locator{},
-				GlobalDeployOverrides: map[string]any{
-					"useCustomGasToken":          true,
-					"gasPayingTokenName":         "CustomToken",
-					"gasPayingTokenSymbol":       "CTK",
-					"nativeAssetLiquidityAmount": "0x1000000",
-				},
-			},
-			chainIntent: &state.ChainIntent{
-				// CustomGasToken is NOT enabled in base intent, but should be allowed for custom chains
-				CustomGasToken: state.CustomGasToken{},
-			},
-			expectError: false, // Should succeed for custom chains
-			expectedOverrides: func() l2GenesisOverrides {
-				defaults := defaultOverrides()
-				defaults.UseCustomGasToken = true
-				defaults.GasPayingTokenName = "CustomToken"
-				defaults.GasPayingTokenSymbol = "CTK"
-				defaults.NativeAssetLiquidityAmount = (*hexutil.Big)(hexutil.MustDecodeBig("0x1000000"))
-				return defaults
-			}(),
-			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				return standard.DefaultHardforkScheduleForTag("")
-			},
-		},
-		{
-			name: "allow CGT override on standard-overrides chain",
-			intent: &state.Intent{
-				ConfigType:         state.IntentTypeStandardOverrides,
-				L1ContractsLocator: &artifacts.Locator{},
-				GlobalDeployOverrides: map[string]any{
-					"useCustomGasToken":          true,
-					"gasPayingTokenName":         "OverrideToken",
-					"gasPayingTokenSymbol":       "OVR",
-					"nativeAssetLiquidityAmount": "0x2000000",
-					"liquidityControllerOwner":   "0x1111111111111111111111111111111111111111",
-				},
-			},
-			chainIntent: &state.ChainIntent{
-				// CustomGasToken is NOT enabled in base intent, but should be allowed for standard-overrides
-				CustomGasToken: state.CustomGasToken{},
-			},
-			expectError: false, // Should succeed for standard-overrides chains
-		expectedOverrides: func() l2GenesisOverrides {
-			defaults := defaultOverrides()
-			defaults.UseCustomGasToken = true
-			defaults.GasPayingTokenName = "OverrideToken"
-			defaults.GasPayingTokenSymbol = "OVR"
-			defaults.NativeAssetLiquidityAmount = (*hexutil.Big)(hexutil.MustDecodeBig("0x2000000"))
-			defaults.LiquidityControllerOwner = common.HexToAddress("0x1111111111111111111111111111111111111111")
-			return defaults
-		}(),
-			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				return standard.DefaultHardforkScheduleForTag("")
 			},
 		},
 	}
@@ -264,222 +164,6 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedOverrides, overrides)
 				require.Equal(t, tc.expectedSchedule(), schedule)
-			}
-		})
-	}
-}
-
-func TestResolveEffectiveCGT(t *testing.T) {
-	testCases := []struct {
-		name           string
-		chainIntent    *state.ChainIntent
-		overrides      l2GenesisOverrides
-		expectedConfig effectiveCGTConfig
-		shouldNotMutate bool
-	}{
-		{
-			name: "CGT enabled in intent - use intent values",
-			chainIntent: &state.ChainIntent{
-				CustomGasToken: state.CustomGasToken{
-					Name:             "Intent Token",
-					Symbol:           "ITK",
-					InitialLiquidity: (*hexutil.Big)(hexutil.MustDecodeBig("0x1000000")),
-				},
-				Roles: state.ChainRoles{
-					L2ProxyAdminOwner: common.HexToAddress("0x1234"),
-				},
-			},
-			overrides: l2GenesisOverrides{
-				UseCustomGasToken:          true,
-				GasPayingTokenName:         "Override Token",
-				GasPayingTokenSymbol:       "OTK",
-				NativeAssetLiquidityAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x2000000")),
-			},
-			expectedConfig: effectiveCGTConfig{
-				UseCustomGasToken:          true,
-				GasPayingTokenName:         "Intent Token",
-				GasPayingTokenSymbol:       "ITK",
-				NativeAssetLiquidityAmount: hexutil.MustDecodeBig("0x1000000"),
-				LiquidityControllerOwner:   common.HexToAddress("0x1234"),
-			},
-			shouldNotMutate: true,
-		},
-		{
-			name: "CGT not in intent but enabled in overrides - use override values",
-			chainIntent: &state.ChainIntent{
-				CustomGasToken: state.CustomGasToken{},
-				Roles: state.ChainRoles{
-					L2ProxyAdminOwner: common.HexToAddress("0x5678"),
-				},
-			},
-			overrides: l2GenesisOverrides{
-				UseCustomGasToken:          true,
-				GasPayingTokenName:         "Override Token",
-				GasPayingTokenSymbol:       "OTK",
-				NativeAssetLiquidityAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x3000000")),
-			},
-			expectedConfig: effectiveCGTConfig{
-				UseCustomGasToken:          true,
-				GasPayingTokenName:         "Override Token",
-				GasPayingTokenSymbol:       "OTK",
-				NativeAssetLiquidityAmount: hexutil.MustDecodeBig("0x3000000"),
-				LiquidityControllerOwner:   common.HexToAddress("0x5678"),
-			},
-			shouldNotMutate: true,
-		},
-		{
-			name: "CGT not in intent, override with zero liquidity - use type(uint248).max",
-			chainIntent: &state.ChainIntent{
-				CustomGasToken: state.CustomGasToken{},
-				Roles: state.ChainRoles{
-					L2ProxyAdminOwner: common.HexToAddress("0xabcd"),
-				},
-			},
-			overrides: l2GenesisOverrides{
-				UseCustomGasToken:          true,
-				GasPayingTokenName:         "Zero Liquidity Token",
-				GasPayingTokenSymbol:       "ZLT",
-				NativeAssetLiquidityAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x0")),
-			},
-			expectedConfig: effectiveCGTConfig{
-				UseCustomGasToken:    true,
-				GasPayingTokenName:   "Zero Liquidity Token",
-				GasPayingTokenSymbol: "ZLT",
-				NativeAssetLiquidityAmount: func() *big.Int {
-					maxUint248 := new(big.Int)
-					maxUint248.SetString("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
-					return maxUint248
-				}(),
-				LiquidityControllerOwner: common.HexToAddress("0xabcd"),
-			},
-			shouldNotMutate: true,
-		},
-		{
-			name: "CGT not in intent, override with nil liquidity - use type(uint248).max",
-			chainIntent: &state.ChainIntent{
-				CustomGasToken: state.CustomGasToken{},
-				Roles: state.ChainRoles{
-					L2ProxyAdminOwner: common.HexToAddress("0xbeef"),
-				},
-			},
-			overrides: l2GenesisOverrides{
-				UseCustomGasToken:          true,
-				GasPayingTokenName:         "Nil Liquidity Token",
-				GasPayingTokenSymbol:       "NLT",
-				NativeAssetLiquidityAmount: nil,
-			},
-			expectedConfig: effectiveCGTConfig{
-				UseCustomGasToken:    true,
-				GasPayingTokenName:   "Nil Liquidity Token",
-				GasPayingTokenSymbol: "NLT",
-				NativeAssetLiquidityAmount: func() *big.Int {
-					maxUint248 := new(big.Int)
-					maxUint248.SetString("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
-					return maxUint248
-				}(),
-				LiquidityControllerOwner: common.HexToAddress("0xbeef"),
-			},
-			shouldNotMutate: true,
-		},
-		{
-			name: "CGT disabled in both intent and overrides",
-			chainIntent: &state.ChainIntent{
-				CustomGasToken: state.CustomGasToken{},
-				Roles: state.ChainRoles{
-					L2ProxyAdminOwner: common.HexToAddress("0xdead"),
-				},
-			},
-			overrides: l2GenesisOverrides{
-				UseCustomGasToken:          false,
-				GasPayingTokenName:         "",
-				GasPayingTokenSymbol:       "",
-				NativeAssetLiquidityAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x0")),
-			},
-			expectedConfig: effectiveCGTConfig{
-				UseCustomGasToken:          false,
-				GasPayingTokenName:         "",
-				GasPayingTokenSymbol:       "",
-				NativeAssetLiquidityAmount: big.NewInt(0),
-				LiquidityControllerOwner:   common.Address{},
-			},
-			shouldNotMutate: true,
-		},
-		{
-			name: "CGT enabled in intent with LiquidityControllerOwner set",
-			chainIntent: &state.ChainIntent{
-				CustomGasToken: state.CustomGasToken{
-					Name:                     "Custom Owner Token",
-					Symbol:                   "COT",
-					InitialLiquidity:         (*hexutil.Big)(hexutil.MustDecodeBig("0x5000000")),
-					LiquidityControllerOwner: common.HexToAddress("0x9999"),
-				},
-				Roles: state.ChainRoles{
-					L2ProxyAdminOwner: common.HexToAddress("0x8888"),
-				},
-			},
-			overrides: l2GenesisOverrides{
-				UseCustomGasToken:          false,
-				GasPayingTokenName:         "",
-				GasPayingTokenSymbol:       "",
-				NativeAssetLiquidityAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x0")),
-			},
-			expectedConfig: effectiveCGTConfig{
-				UseCustomGasToken:          true,
-				GasPayingTokenName:         "Custom Owner Token",
-				GasPayingTokenSymbol:       "COT",
-				NativeAssetLiquidityAmount: hexutil.MustDecodeBig("0x5000000"),
-				LiquidityControllerOwner:   common.HexToAddress("0x9999"),
-			},
-			shouldNotMutate: true,
-		},
-		{
-			name: "CGT not in intent but enabled in overrides with explicit LiquidityControllerOwner",
-			chainIntent: &state.ChainIntent{
-				CustomGasToken: state.CustomGasToken{},
-				Roles: state.ChainRoles{
-					L2ProxyAdminOwner: common.HexToAddress("0x8888"),
-				},
-			},
-			overrides: l2GenesisOverrides{
-				UseCustomGasToken:          true,
-				GasPayingTokenName:         "Override Token",
-				GasPayingTokenSymbol:       "OTK",
-				NativeAssetLiquidityAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x3000000")),
-				LiquidityControllerOwner:   common.HexToAddress("0x7777"),
-			},
-			expectedConfig: effectiveCGTConfig{
-				UseCustomGasToken:          true,
-				GasPayingTokenName:         "Override Token",
-				GasPayingTokenSymbol:       "OTK",
-				NativeAssetLiquidityAmount: hexutil.MustDecodeBig("0x3000000"),
-				LiquidityControllerOwner:   common.HexToAddress("0x7777"),
-			},
-			shouldNotMutate: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Clone the original intent to check for mutations
-			originalCGT := tc.chainIntent.CustomGasToken
-
-			// Call resolveEffectiveCGT
-			result := resolveEffectiveCGT(tc.chainIntent, tc.overrides)
-
-			// Verify result matches expected
-			require.Equal(t, tc.expectedConfig.UseCustomGasToken, result.UseCustomGasToken)
-			require.Equal(t, tc.expectedConfig.GasPayingTokenName, result.GasPayingTokenName)
-			require.Equal(t, tc.expectedConfig.GasPayingTokenSymbol, result.GasPayingTokenSymbol)
-			// Compare big.Int values numerically (not deep equality) to avoid internal representation differences
-			require.True(t, tc.expectedConfig.NativeAssetLiquidityAmount.Cmp(result.NativeAssetLiquidityAmount) == 0,
-				"NativeAssetLiquidityAmount mismatch: expected %s, got %s",
-				tc.expectedConfig.NativeAssetLiquidityAmount.String(),
-				result.NativeAssetLiquidityAmount.String())
-			require.Equal(t, tc.expectedConfig.LiquidityControllerOwner, result.LiquidityControllerOwner)
-
-			// Verify no mutation occurred
-			if tc.shouldNotMutate {
-				require.Equal(t, originalCGT, tc.chainIntent.CustomGasToken, "resolveEffectiveCGT should not mutate the input intent")
 			}
 		})
 	}

--- a/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
@@ -43,19 +43,11 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 			},
 			chainIntent: &state.ChainIntent{},
 			expectError: false,
-			expectedOverrides: l2GenesisOverrides{
-				FundDevAccounts:                          true,
-				BaseFeeVaultMinimumWithdrawalAmount:      standard.VaultMinWithdrawalAmount,
-				L1FeeVaultMinimumWithdrawalAmount:        standard.VaultMinWithdrawalAmount,
-				SequencerFeeVaultMinimumWithdrawalAmount: standard.VaultMinWithdrawalAmount,
-				OperatorFeeVaultMinimumWithdrawalAmount:  standard.VaultMinWithdrawalAmount,
-				BaseFeeVaultWithdrawalNetwork:            "local",
-				L1FeeVaultWithdrawalNetwork:              "local",
-				SequencerFeeVaultWithdrawalNetwork:       "local",
-				OperatorFeeVaultWithdrawalNetwork:        "local",
-				EnableGovernance:                         false,
-				GovernanceTokenOwner:                     standard.GovernanceTokenOwner,
-			},
+			expectedOverrides: func() l2GenesisOverrides {
+				defaults := defaultOverrides()
+				defaults.FundDevAccounts = true
+				return defaults
+			}(),
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
 				return standard.DefaultHardforkScheduleForTag("")
 			},
@@ -175,6 +167,88 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				schedule := standard.DefaultHardforkScheduleForTag("")
 				schedule.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0)
 				return schedule
+			},
+		},
+		{
+			name: "SECURITY: reject CGT override on standard chain",
+			intent: &state.Intent{
+				ConfigType:         state.IntentTypeStandard,
+				L1ContractsLocator: &artifacts.Locator{},
+				GlobalDeployOverrides: map[string]any{
+					"useCustomGasToken":          true,
+					"gasPayingTokenName":         "MaliciousToken",
+					"gasPayingTokenSymbol":       "MAL",
+					"nativeAssetLiquidityAmount": "0x1000000",
+				},
+			},
+			chainIntent: &state.ChainIntent{
+				ID: common.HexToHash("0x1234"),
+				// CustomGasToken is intentionally NOT enabled in the base intent
+				CustomGasToken: state.CustomGasToken{},
+			},
+			expectError:       true, // Should fail security check
+			expectedOverrides: l2GenesisOverrides{},
+			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
+				return nil
+			},
+		},
+		{
+			name: "allow CGT override on custom chain",
+			intent: &state.Intent{
+				ConfigType:         state.IntentTypeCustom,
+				L1ContractsLocator: &artifacts.Locator{},
+				GlobalDeployOverrides: map[string]any{
+					"useCustomGasToken":          true,
+					"gasPayingTokenName":         "CustomToken",
+					"gasPayingTokenSymbol":       "CTK",
+					"nativeAssetLiquidityAmount": "0x1000000",
+				},
+			},
+			chainIntent: &state.ChainIntent{
+				// CustomGasToken is NOT enabled in base intent, but should be allowed for custom chains
+				CustomGasToken: state.CustomGasToken{},
+			},
+			expectError: false, // Should succeed for custom chains
+			expectedOverrides: func() l2GenesisOverrides {
+				defaults := defaultOverrides()
+				defaults.UseCustomGasToken = true
+				defaults.GasPayingTokenName = "CustomToken"
+				defaults.GasPayingTokenSymbol = "CTK"
+				defaults.NativeAssetLiquidityAmount = (*hexutil.Big)(hexutil.MustDecodeBig("0x1000000"))
+				return defaults
+			}(),
+			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
+				return standard.DefaultHardforkScheduleForTag("")
+			},
+		},
+		{
+			name: "allow CGT override on standard-overrides chain",
+			intent: &state.Intent{
+				ConfigType:         state.IntentTypeStandardOverrides,
+				L1ContractsLocator: &artifacts.Locator{},
+				GlobalDeployOverrides: map[string]any{
+					"useCustomGasToken":          true,
+					"gasPayingTokenName":         "OverrideToken",
+					"gasPayingTokenSymbol":       "OVR",
+					"nativeAssetLiquidityAmount": "0x2000000",
+					"liquidityControllerOwner":   "0x1111111111111111111111111111111111111111",
+				},
+			},
+			chainIntent: &state.ChainIntent{
+				// CustomGasToken is NOT enabled in base intent, but should be allowed for standard-overrides
+				CustomGasToken: state.CustomGasToken{},
+			},
+			expectError: false, // Should succeed for standard-overrides chains
+			expectedOverrides: func() l2GenesisOverrides {
+				defaults := defaultOverrides()
+				defaults.UseCustomGasToken = true
+				defaults.GasPayingTokenName = "OverrideToken"
+				defaults.GasPayingTokenSymbol = "OVR"
+				defaults.NativeAssetLiquidityAmount = (*hexutil.Big)(hexutil.MustDecodeBig("0x2000000"))
+				return defaults
+			}(),
+			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
+				return standard.DefaultHardforkScheduleForTag("")
 			},
 		},
 	}

--- a/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
@@ -240,14 +240,15 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				CustomGasToken: state.CustomGasToken{},
 			},
 			expectError: false, // Should succeed for standard-overrides chains
-			expectedOverrides: func() l2GenesisOverrides {
-				defaults := defaultOverrides()
-				defaults.UseCustomGasToken = true
-				defaults.GasPayingTokenName = "OverrideToken"
-				defaults.GasPayingTokenSymbol = "OVR"
-				defaults.NativeAssetLiquidityAmount = (*hexutil.Big)(hexutil.MustDecodeBig("0x2000000"))
-				return defaults
-			}(),
+		expectedOverrides: func() l2GenesisOverrides {
+			defaults := defaultOverrides()
+			defaults.UseCustomGasToken = true
+			defaults.GasPayingTokenName = "OverrideToken"
+			defaults.GasPayingTokenSymbol = "OVR"
+			defaults.NativeAssetLiquidityAmount = (*hexutil.Big)(hexutil.MustDecodeBig("0x2000000"))
+			defaults.LiquidityControllerOwner = common.HexToAddress("0x1111111111111111111111111111111111111111")
+			return defaults
+		}(),
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
 				return standard.DefaultHardforkScheduleForTag("")
 			},
@@ -354,6 +355,33 @@ func TestResolveEffectiveCGT(t *testing.T) {
 			shouldNotMutate: true,
 		},
 		{
+			name: "CGT not in intent, override with nil liquidity - use type(uint248).max",
+			chainIntent: &state.ChainIntent{
+				CustomGasToken: state.CustomGasToken{},
+				Roles: state.ChainRoles{
+					L2ProxyAdminOwner: common.HexToAddress("0xbeef"),
+				},
+			},
+			overrides: l2GenesisOverrides{
+				UseCustomGasToken:          true,
+				GasPayingTokenName:         "Nil Liquidity Token",
+				GasPayingTokenSymbol:       "NLT",
+				NativeAssetLiquidityAmount: nil,
+			},
+			expectedConfig: effectiveCGTConfig{
+				UseCustomGasToken:    true,
+				GasPayingTokenName:   "Nil Liquidity Token",
+				GasPayingTokenSymbol: "NLT",
+				NativeAssetLiquidityAmount: func() *big.Int {
+					maxUint248 := new(big.Int)
+					maxUint248.SetString("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
+					return maxUint248
+				}(),
+				LiquidityControllerOwner: common.HexToAddress("0xbeef"),
+			},
+			shouldNotMutate: true,
+		},
+		{
 			name: "CGT disabled in both intent and overrides",
 			chainIntent: &state.ChainIntent{
 				CustomGasToken: state.CustomGasToken{},
@@ -401,6 +429,30 @@ func TestResolveEffectiveCGT(t *testing.T) {
 				GasPayingTokenSymbol:       "COT",
 				NativeAssetLiquidityAmount: hexutil.MustDecodeBig("0x5000000"),
 				LiquidityControllerOwner:   common.HexToAddress("0x9999"),
+			},
+			shouldNotMutate: true,
+		},
+		{
+			name: "CGT not in intent but enabled in overrides with explicit LiquidityControllerOwner",
+			chainIntent: &state.ChainIntent{
+				CustomGasToken: state.CustomGasToken{},
+				Roles: state.ChainRoles{
+					L2ProxyAdminOwner: common.HexToAddress("0x8888"),
+				},
+			},
+			overrides: l2GenesisOverrides{
+				UseCustomGasToken:          true,
+				GasPayingTokenName:         "Override Token",
+				GasPayingTokenSymbol:       "OTK",
+				NativeAssetLiquidityAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x3000000")),
+				LiquidityControllerOwner:   common.HexToAddress("0x7777"),
+			},
+			expectedConfig: effectiveCGTConfig{
+				UseCustomGasToken:          true,
+				GasPayingTokenName:         "Override Token",
+				GasPayingTokenSymbol:       "OTK",
+				NativeAssetLiquidityAmount: hexutil.MustDecodeBig("0x3000000"),
+				LiquidityControllerOwner:   common.HexToAddress("0x7777"),
 			},
 			shouldNotMutate: true,
 		},

--- a/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
@@ -262,6 +263,171 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedOverrides, overrides)
 				require.Equal(t, tc.expectedSchedule(), schedule)
+			}
+		})
+	}
+}
+
+func TestResolveEffectiveCGT(t *testing.T) {
+	testCases := []struct {
+		name           string
+		chainIntent    *state.ChainIntent
+		overrides      l2GenesisOverrides
+		expectedConfig effectiveCGTConfig
+		shouldNotMutate bool
+	}{
+		{
+			name: "CGT enabled in intent - use intent values",
+			chainIntent: &state.ChainIntent{
+				CustomGasToken: state.CustomGasToken{
+					Name:             "Intent Token",
+					Symbol:           "ITK",
+					InitialLiquidity: (*hexutil.Big)(hexutil.MustDecodeBig("0x1000000")),
+				},
+				Roles: state.ChainRoles{
+					L2ProxyAdminOwner: common.HexToAddress("0x1234"),
+				},
+			},
+			overrides: l2GenesisOverrides{
+				UseCustomGasToken:          true,
+				GasPayingTokenName:         "Override Token",
+				GasPayingTokenSymbol:       "OTK",
+				NativeAssetLiquidityAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x2000000")),
+			},
+			expectedConfig: effectiveCGTConfig{
+				UseCustomGasToken:          true,
+				GasPayingTokenName:         "Intent Token",
+				GasPayingTokenSymbol:       "ITK",
+				NativeAssetLiquidityAmount: hexutil.MustDecodeBig("0x1000000"),
+				LiquidityControllerOwner:   common.HexToAddress("0x1234"),
+			},
+			shouldNotMutate: true,
+		},
+		{
+			name: "CGT not in intent but enabled in overrides - use override values",
+			chainIntent: &state.ChainIntent{
+				CustomGasToken: state.CustomGasToken{},
+				Roles: state.ChainRoles{
+					L2ProxyAdminOwner: common.HexToAddress("0x5678"),
+				},
+			},
+			overrides: l2GenesisOverrides{
+				UseCustomGasToken:          true,
+				GasPayingTokenName:         "Override Token",
+				GasPayingTokenSymbol:       "OTK",
+				NativeAssetLiquidityAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x3000000")),
+			},
+			expectedConfig: effectiveCGTConfig{
+				UseCustomGasToken:          true,
+				GasPayingTokenName:         "Override Token",
+				GasPayingTokenSymbol:       "OTK",
+				NativeAssetLiquidityAmount: hexutil.MustDecodeBig("0x3000000"),
+				LiquidityControllerOwner:   common.HexToAddress("0x5678"),
+			},
+			shouldNotMutate: true,
+		},
+		{
+			name: "CGT not in intent, override with zero liquidity - use type(uint248).max",
+			chainIntent: &state.ChainIntent{
+				CustomGasToken: state.CustomGasToken{},
+				Roles: state.ChainRoles{
+					L2ProxyAdminOwner: common.HexToAddress("0xabcd"),
+				},
+			},
+			overrides: l2GenesisOverrides{
+				UseCustomGasToken:          true,
+				GasPayingTokenName:         "Zero Liquidity Token",
+				GasPayingTokenSymbol:       "ZLT",
+				NativeAssetLiquidityAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x0")),
+			},
+			expectedConfig: effectiveCGTConfig{
+				UseCustomGasToken:    true,
+				GasPayingTokenName:   "Zero Liquidity Token",
+				GasPayingTokenSymbol: "ZLT",
+				NativeAssetLiquidityAmount: func() *big.Int {
+					maxUint248 := new(big.Int)
+					maxUint248.SetString("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
+					return maxUint248
+				}(),
+				LiquidityControllerOwner: common.HexToAddress("0xabcd"),
+			},
+			shouldNotMutate: true,
+		},
+		{
+			name: "CGT disabled in both intent and overrides",
+			chainIntent: &state.ChainIntent{
+				CustomGasToken: state.CustomGasToken{},
+				Roles: state.ChainRoles{
+					L2ProxyAdminOwner: common.HexToAddress("0xdead"),
+				},
+			},
+			overrides: l2GenesisOverrides{
+				UseCustomGasToken:          false,
+				GasPayingTokenName:         "",
+				GasPayingTokenSymbol:       "",
+				NativeAssetLiquidityAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x0")),
+			},
+			expectedConfig: effectiveCGTConfig{
+				UseCustomGasToken:          false,
+				GasPayingTokenName:         "",
+				GasPayingTokenSymbol:       "",
+				NativeAssetLiquidityAmount: big.NewInt(0),
+				LiquidityControllerOwner:   common.Address{},
+			},
+			shouldNotMutate: true,
+		},
+		{
+			name: "CGT enabled in intent with LiquidityControllerOwner set",
+			chainIntent: &state.ChainIntent{
+				CustomGasToken: state.CustomGasToken{
+					Name:                     "Custom Owner Token",
+					Symbol:                   "COT",
+					InitialLiquidity:         (*hexutil.Big)(hexutil.MustDecodeBig("0x5000000")),
+					LiquidityControllerOwner: common.HexToAddress("0x9999"),
+				},
+				Roles: state.ChainRoles{
+					L2ProxyAdminOwner: common.HexToAddress("0x8888"),
+				},
+			},
+			overrides: l2GenesisOverrides{
+				UseCustomGasToken:          false,
+				GasPayingTokenName:         "",
+				GasPayingTokenSymbol:       "",
+				NativeAssetLiquidityAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x0")),
+			},
+			expectedConfig: effectiveCGTConfig{
+				UseCustomGasToken:          true,
+				GasPayingTokenName:         "Custom Owner Token",
+				GasPayingTokenSymbol:       "COT",
+				NativeAssetLiquidityAmount: hexutil.MustDecodeBig("0x5000000"),
+				LiquidityControllerOwner:   common.HexToAddress("0x9999"),
+			},
+			shouldNotMutate: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clone the original intent to check for mutations
+			originalCGT := tc.chainIntent.CustomGasToken
+
+			// Call resolveEffectiveCGT
+			result := resolveEffectiveCGT(tc.chainIntent, tc.overrides)
+
+			// Verify result matches expected
+			require.Equal(t, tc.expectedConfig.UseCustomGasToken, result.UseCustomGasToken)
+			require.Equal(t, tc.expectedConfig.GasPayingTokenName, result.GasPayingTokenName)
+			require.Equal(t, tc.expectedConfig.GasPayingTokenSymbol, result.GasPayingTokenSymbol)
+			// Compare big.Int values numerically (not deep equality) to avoid internal representation differences
+			require.True(t, tc.expectedConfig.NativeAssetLiquidityAmount.Cmp(result.NativeAssetLiquidityAmount) == 0,
+				"NativeAssetLiquidityAmount mismatch: expected %s, got %s",
+				tc.expectedConfig.NativeAssetLiquidityAmount.String(),
+				result.NativeAssetLiquidityAmount.String())
+			require.Equal(t, tc.expectedConfig.LiquidityControllerOwner, result.LiquidityControllerOwner)
+
+			// Verify no mutation occurred
+			if tc.shouldNotMutate {
+				require.Equal(t, originalCGT, tc.chainIntent.CustomGasToken, "resolveEffectiveCGT should not mutate the input intent")
 			}
 		})
 	}

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -58,10 +58,10 @@ type L2DevGenesisParams struct {
 }
 
 type CustomGasToken struct {
-	Enabled          bool         `json:"enabled" toml:"enabled"`
-	Name             string       `json:"name,omitempty" toml:"name,omitempty"`
-	Symbol           string       `json:"symbol,omitempty" toml:"symbol,omitempty"`
-	InitialLiquidity *hexutil.Big `json:"initialLiquidity,omitempty" toml:"initialLiquidity,omitempty"`
+	Name             string          `json:"name,omitempty" toml:"name,omitempty"`
+	Symbol           string          `json:"symbol,omitempty" toml:"symbol,omitempty"`
+	InitialLiquidity *hexutil.Big    `json:"initialLiquidity,omitempty" toml:"initialLiquidity,omitempty"`
+	Owner            *common.Address `json:"owner,omitempty" toml:"owner,omitempty"` // LiquidityController owner, defaults to L2ProxyAdminOwner if not set
 }
 
 type ChainIntent struct {
@@ -134,16 +134,23 @@ func (c *ChainIntent) Check() error {
 		return fmt.Errorf("%w: chainId=%s", ErrFeeVaultZeroAddress, c.ID)
 	}
 
-	if c.CustomGasToken.Enabled {
-		if c.CustomGasToken.Name == "" {
-			return fmt.Errorf("%w: CustomGasToken.Name cannot be empty when enabled, chainId=%s", ErrIncompatibleValue, c.ID)
+	// Validate CustomGasToken: if any field is set, both Name and Symbol must be present
+	hasName := c.CustomGasToken.Name != ""
+	hasSymbol := c.CustomGasToken.Symbol != ""
+	hasAnyCustomGasTokenField := hasName || hasSymbol || c.CustomGasToken.InitialLiquidity != nil || c.CustomGasToken.Owner != nil
+
+	if hasAnyCustomGasTokenField {
+		if !hasName {
+			return fmt.Errorf("%w: CustomGasToken.Name must be set when using custom gas token, chainId=%s", ErrIncompatibleValue, c.ID)
 		}
-		if c.CustomGasToken.Symbol == "" {
-			return fmt.Errorf("%w: CustomGasToken.Symbol cannot be empty when enabled, chainId=%s", ErrIncompatibleValue, c.ID)
+		if !hasSymbol {
+			return fmt.Errorf("%w: CustomGasToken.Symbol must be set when using custom gas token, chainId=%s", ErrIncompatibleValue, c.ID)
 		}
 
-		if c.CustomGasToken.InitialLiquidity == nil || c.CustomGasToken.InitialLiquidity.ToInt().Sign() < 0 {
-			return fmt.Errorf("%w: CustomGasToken.InitialLiquidity must be set and non-negative when custom gas token is enabled, chainId=%s", ErrIncompatibleValue, c.ID)
+		// InitialLiquidity is optional - if not set, type(uint248).max will be used as default
+		// But if it IS set, it must be non-negative
+		if c.CustomGasToken.InitialLiquidity != nil && c.CustomGasToken.InitialLiquidity.ToInt().Sign() < 0 {
+			return fmt.Errorf("%w: CustomGasToken.InitialLiquidity must be non-negative when custom gas token is enabled, chainId=%s", ErrIncompatibleValue, c.ID)
 		}
 	}
 
@@ -161,11 +168,35 @@ func (c *ChainIntent) Check() error {
 }
 
 // GetInitialLiquidity returns the native asset liquidity amount for the chain.
-// If not set, returns the default value of zero.
+// If not set and custom gas token is enabled, returns type(uint248).max as the default.
+// Otherwise returns zero.
 func (c *ChainIntent) GetInitialLiquidity() *big.Int {
 	if c.CustomGasToken.InitialLiquidity != nil {
 		return c.CustomGasToken.InitialLiquidity.ToInt()
 	}
 
+	// If custom gas token is enabled but no liquidity specified, use type(uint248).max
+	// This is the safe default: large enough to never go to 0, small enough to never overflow
+	if c.IsCustomGasTokenEnabled() {
+		maxUint248 := new(big.Int)
+		maxUint248.SetString("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
+		return maxUint248
+	}
+
 	return (*hexutil.Big)(big.NewInt(0)).ToInt()
+}
+
+// GetLiquidityControllerOwner returns the owner of the LiquidityController.
+// If not set in CustomGasToken config, defaults to L2ProxyAdminOwner.
+func (c *ChainIntent) GetLiquidityControllerOwner() common.Address {
+	if c.CustomGasToken.Owner != nil {
+		return *c.CustomGasToken.Owner
+	}
+	return c.Roles.L2ProxyAdminOwner
+}
+
+// IsCustomGasTokenEnabled returns true if custom gas token is enabled.
+// It's enabled when both Name and Symbol are provided.
+func (c *ChainIntent) IsCustomGasTokenEnabled() bool {
+	return c.CustomGasToken.Name != "" && c.CustomGasToken.Symbol != ""
 }

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -184,7 +184,8 @@ func (c *ChainIntent) GetInitialLiquidity() *big.Int {
 		return maxUint248
 	}
 
-	return (*hexutil.Big)(big.NewInt(0)).ToInt()
+	// Return nil when CGT is not enabled so that overrides can properly set it later
+	return nil
 }
 
 // GetLiquidityControllerOwner returns the owner of the LiquidityController.

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -184,8 +184,8 @@ func (c *ChainIntent) GetInitialLiquidity() *big.Int {
 		return maxUint248
 	}
 
-	// Return nil when CGT is not enabled so that overrides can properly set it later
-	return nil
+	// When CGT is not enabled, return zero to indicate no liquidity
+	return big.NewInt(0)
 }
 
 // GetLiquidityControllerOwner returns the owner of the LiquidityController.

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -60,8 +60,8 @@ type L2DevGenesisParams struct {
 type CustomGasToken struct {
 	Name             string          `json:"name,omitempty" toml:"name,omitempty"`
 	Symbol           string          `json:"symbol,omitempty" toml:"symbol,omitempty"`
-	InitialLiquidity *hexutil.Big    `json:"initialLiquidity,omitempty" toml:"initialLiquidity,omitempty"`
-	Owner            *common.Address `json:"owner,omitempty" toml:"owner,omitempty"` // LiquidityController owner, defaults to L2ProxyAdminOwner if not set
+	InitialLiquidity *hexutil.Big    `json:"initialLiquidity" toml:"initialLiquidity"`
+	LiquidityControllerOwner common.Address `json:"liquidityControllerOwner" toml:"liquidityControllerOwner"`
 }
 
 type ChainIntent struct {
@@ -137,7 +137,7 @@ func (c *ChainIntent) Check() error {
 	// Validate CustomGasToken: if any field is set, both Name and Symbol must be present
 	hasName := c.CustomGasToken.Name != ""
 	hasSymbol := c.CustomGasToken.Symbol != ""
-	hasAnyCustomGasTokenField := hasName || hasSymbol || c.CustomGasToken.InitialLiquidity != nil || c.CustomGasToken.Owner != nil
+	hasAnyCustomGasTokenField := hasName || hasSymbol || c.CustomGasToken.InitialLiquidity != nil || c.CustomGasToken.LiquidityControllerOwner != (common.Address{})
 
 	if hasAnyCustomGasTokenField {
 		if !hasName {
@@ -152,6 +152,7 @@ func (c *ChainIntent) Check() error {
 		if c.CustomGasToken.InitialLiquidity != nil && c.CustomGasToken.InitialLiquidity.ToInt().Sign() < 0 {
 			return fmt.Errorf("%w: CustomGasToken.InitialLiquidity must be non-negative when custom gas token is enabled, chainId=%s", ErrIncompatibleValue, c.ID)
 		}
+		// LiquidityControllerOwner is optional - if not set, L2ProxyAdminOwner will be used as default
 	}
 
 	if c.DangerousAltDAConfig.UseAltDA {
@@ -189,8 +190,8 @@ func (c *ChainIntent) GetInitialLiquidity() *big.Int {
 // GetLiquidityControllerOwner returns the owner of the LiquidityController.
 // If not set in CustomGasToken config, defaults to L2ProxyAdminOwner.
 func (c *ChainIntent) GetLiquidityControllerOwner() common.Address {
-	if c.CustomGasToken.Owner != nil {
-		return *c.CustomGasToken.Owner
+	if c.CustomGasToken.LiquidityControllerOwner != (common.Address{}) {
+		return c.CustomGasToken.LiquidityControllerOwner
 	}
 	return c.Roles.L2ProxyAdminOwner
 }

--- a/op-deployer/pkg/deployer/state/chain_intent_test.go
+++ b/op-deployer/pkg/deployer/state/chain_intent_test.go
@@ -38,13 +38,13 @@ func TestGetInitialLiquidity(t *testing.T) {
 			expected: big.NewInt(1000),
 		},
 		{
-			name: "returns zero when CustomGasToken is not enabled",
+			name: "returns nil when CustomGasToken is not enabled",
 			cgt: CustomGasToken{
 				Name:             "",
 				Symbol:           "",
 				InitialLiquidity: nil,
 			},
-			expected: big.NewInt(0),
+			expected: nil,
 		},
 	}
 

--- a/op-deployer/pkg/deployer/state/chain_intent_test.go
+++ b/op-deployer/pkg/deployer/state/chain_intent_test.go
@@ -1,0 +1,169 @@
+package state
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetInitialLiquidity(t *testing.T) {
+	tests := []struct {
+		name     string
+		cgt      CustomGasToken
+		expected *big.Int
+	}{
+		{
+			name: "returns type(uint248).max when CustomGasToken is enabled and InitialLiquidity is not set",
+			cgt: CustomGasToken{
+				Name:             "Custom Gas Token",
+				Symbol:           "CGT",
+				InitialLiquidity: nil,
+			},
+			expected: func() *big.Int {
+				maxUint248 := new(big.Int)
+				maxUint248.SetString("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
+				return maxUint248
+			}(),
+		},
+		{
+			name: "returns custom value when InitialLiquidity is explicitly set",
+			cgt: CustomGasToken{
+				Name:             "Custom Gas Token",
+				Symbol:           "CGT",
+				InitialLiquidity: (*hexutil.Big)(big.NewInt(1000)),
+			},
+			expected: big.NewInt(1000),
+		},
+		{
+			name: "returns zero when CustomGasToken is not enabled",
+			cgt: CustomGasToken{
+				Name:             "",
+				Symbol:           "",
+				InitialLiquidity: nil,
+			},
+			expected: big.NewInt(0),
+		},
+		{
+			name: "respects explicit InitialLiquidity even when Name/Symbol are not set",
+			cgt: CustomGasToken{
+				Name:             "",
+				Symbol:           "",
+				InitialLiquidity: (*hexutil.Big)(big.NewInt(5000)),
+			},
+			expected: big.NewInt(5000),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chainIntent := &ChainIntent{
+				CustomGasToken: tt.cgt,
+			}
+			result := chainIntent.GetInitialLiquidity()
+			require.Equal(t, tt.expected, result, "GetInitialLiquidity() should return the expected value")
+		})
+	}
+}
+
+func TestGetLiquidityControllerOwner(t *testing.T) {
+	defaultOwner := common.HexToAddress("0x1234")
+	customOwner := common.HexToAddress("0x5678")
+
+	tests := []struct {
+		name     string
+		cgt      CustomGasToken
+		roles    ChainRoles
+		expected common.Address
+	}{
+		{
+			name: "returns L2ProxyAdminOwner when CustomGasToken.Owner is not set",
+			cgt: CustomGasToken{
+				Name:   "Custom Gas Token",
+				Symbol: "CGT",
+				Owner:  nil,
+			},
+			roles: ChainRoles{
+				L2ProxyAdminOwner: defaultOwner,
+			},
+			expected: defaultOwner,
+		},
+		{
+			name: "returns custom owner when CustomGasToken.Owner is set",
+			cgt: CustomGasToken{
+				Name:   "Custom Gas Token",
+				Symbol: "CGT",
+				Owner:  &customOwner,
+			},
+			roles: ChainRoles{
+				L2ProxyAdminOwner: defaultOwner,
+			},
+			expected: customOwner,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chainIntent := &ChainIntent{
+				CustomGasToken: tt.cgt,
+				Roles:          tt.roles,
+			}
+			result := chainIntent.GetLiquidityControllerOwner()
+			require.Equal(t, tt.expected, result, "GetLiquidityControllerOwner() should return the expected address")
+		})
+	}
+}
+
+func TestIsCustomGasTokenEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		cgt      CustomGasToken
+		expected bool
+	}{
+		{
+			name: "returns true when both Name and Symbol are set",
+			cgt: CustomGasToken{
+				Name:   "Custom Gas Token",
+				Symbol: "CGT",
+			},
+			expected: true,
+		},
+		{
+			name: "returns false when Name is empty",
+			cgt: CustomGasToken{
+				Name:   "",
+				Symbol: "CGT",
+			},
+			expected: false,
+		},
+		{
+			name: "returns false when Symbol is empty",
+			cgt: CustomGasToken{
+				Name:   "Custom Gas Token",
+				Symbol: "",
+			},
+			expected: false,
+		},
+		{
+			name: "returns false when both Name and Symbol are empty",
+			cgt: CustomGasToken{
+				Name:   "",
+				Symbol: "",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chainIntent := &ChainIntent{
+				CustomGasToken: tt.cgt,
+			}
+			result := chainIntent.IsCustomGasTokenEnabled()
+			require.Equal(t, tt.expected, result, "IsCustomGasTokenEnabled() should return the expected value")
+		})
+	}
+}
+

--- a/op-deployer/pkg/deployer/state/chain_intent_test.go
+++ b/op-deployer/pkg/deployer/state/chain_intent_test.go
@@ -38,13 +38,13 @@ func TestGetInitialLiquidity(t *testing.T) {
 			expected: big.NewInt(1000),
 		},
 		{
-			name: "returns nil when CustomGasToken is not enabled",
+			name: "returns zero when CustomGasToken is not enabled",
 			cgt: CustomGasToken{
 				Name:             "",
 				Symbol:           "",
 				InitialLiquidity: nil,
 			},
-			expected: nil,
+			expected: big.NewInt(0),
 		},
 	}
 

--- a/op-deployer/pkg/deployer/state/chain_intent_test.go
+++ b/op-deployer/pkg/deployer/state/chain_intent_test.go
@@ -46,15 +46,6 @@ func TestGetInitialLiquidity(t *testing.T) {
 			},
 			expected: big.NewInt(0),
 		},
-		{
-			name: "respects explicit InitialLiquidity even when Name/Symbol are not set",
-			cgt: CustomGasToken{
-				Name:             "",
-				Symbol:           "",
-				InitialLiquidity: (*hexutil.Big)(big.NewInt(5000)),
-			},
-			expected: big.NewInt(5000),
-		},
 	}
 
 	for _, tt := range tests {

--- a/op-deployer/pkg/deployer/state/chain_intent_test.go
+++ b/op-deployer/pkg/deployer/state/chain_intent_test.go
@@ -79,11 +79,10 @@ func TestGetLiquidityControllerOwner(t *testing.T) {
 		expected common.Address
 	}{
 		{
-			name: "returns L2ProxyAdminOwner when CustomGasToken.Owner is not set",
+			name: "returns L2ProxyAdminOwner when CustomGasToken.LiquidityControllerOwner is not set",
 			cgt: CustomGasToken{
 				Name:   "Custom Gas Token",
 				Symbol: "CGT",
-				Owner:  nil,
 			},
 			roles: ChainRoles{
 				L2ProxyAdminOwner: defaultOwner,
@@ -91,11 +90,11 @@ func TestGetLiquidityControllerOwner(t *testing.T) {
 			expected: defaultOwner,
 		},
 		{
-			name: "returns custom owner when CustomGasToken.Owner is set",
+			name: "returns custom owner when CustomGasToken.LiquidityControllerOwner is set",
 			cgt: CustomGasToken{
-				Name:   "Custom Gas Token",
-				Symbol: "CGT",
-				Owner:  &customOwner,
+				Name:                     "Custom Gas Token",
+				Symbol:                   "CGT",
+				LiquidityControllerOwner: customOwner,
 			},
 			roles: ChainRoles{
 				L2ProxyAdminOwner: defaultOwner,

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -78,12 +78,13 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 				ChainFeesRecipient: chainIntent.ChainFeesRecipient,
 			},
 
-		GasTokenDeployConfig: genesis.GasTokenDeployConfig{
-			UseCustomGasToken:          chainIntent.IsCustomGasTokenEnabled(),
-			GasPayingTokenName:         chainIntent.CustomGasToken.Name,
-			GasPayingTokenSymbol:       chainIntent.CustomGasToken.Symbol,
-			NativeAssetLiquidityAmount: chainIntent.CustomGasToken.InitialLiquidity,
-		},
+	GasTokenDeployConfig: genesis.GasTokenDeployConfig{
+		UseCustomGasToken:          chainIntent.IsCustomGasTokenEnabled(),
+		GasPayingTokenName:         chainIntent.CustomGasToken.Name,
+		GasPayingTokenSymbol:       chainIntent.CustomGasToken.Symbol,
+		NativeAssetLiquidityAmount: chainIntent.CustomGasToken.InitialLiquidity,
+		LiquidityControllerOwner:   chainIntent.GetLiquidityControllerOwner(),
+	},
 
 			// STOP! This struct sets the _default_ upgrade schedule for all chains.
 			// Any upgrades you enable here will be enabled for all new deployments.

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -174,6 +174,20 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 		}
 	}
 
+	// After applying overrides, if CGT is enabled but NativeAssetLiquidityAmount is nil or 0,
+	// set it to type(uint248).max as the default
+	if cfg.UseCustomGasToken {
+		if cfg.NativeAssetLiquidityAmount == nil || cfg.NativeAssetLiquidityAmount.ToInt().Sign() == 0 {
+			maxUint248 := new(big.Int)
+			maxUint248.SetString("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
+			cfg.NativeAssetLiquidityAmount = (*hexutil.Big)(maxUint248)
+		}
+		// If LiquidityControllerOwner is not set, default to L2ProxyAdminOwner
+		if cfg.LiquidityControllerOwner == (common.Address{}) {
+			cfg.LiquidityControllerOwner = chainIntent.Roles.L2ProxyAdminOwner
+		}
+	}
+
 	if err := cfg.Check(log.New(log.DiscardHandler())); err != nil {
 		return cfg, fmt.Errorf("combined deploy config failed validation: %w", err)
 	}

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -82,7 +82,7 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 		UseCustomGasToken:          chainIntent.IsCustomGasTokenEnabled(),
 		GasPayingTokenName:         chainIntent.CustomGasToken.Name,
 		GasPayingTokenSymbol:       chainIntent.CustomGasToken.Symbol,
-		NativeAssetLiquidityAmount: chainIntent.CustomGasToken.InitialLiquidity,
+		NativeAssetLiquidityAmount: (*hexutil.Big)(chainIntent.GetInitialLiquidity()),
 		LiquidityControllerOwner:   chainIntent.GetLiquidityControllerOwner(),
 	},
 

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -174,20 +174,6 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 		}
 	}
 
-	// After applying overrides, if CGT is enabled but NativeAssetLiquidityAmount is nil or 0,
-	// set it to type(uint248).max as the default
-	if cfg.UseCustomGasToken {
-		if cfg.NativeAssetLiquidityAmount == nil || cfg.NativeAssetLiquidityAmount.ToInt().Sign() == 0 {
-			maxUint248 := new(big.Int)
-			maxUint248.SetString("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
-			cfg.NativeAssetLiquidityAmount = (*hexutil.Big)(maxUint248)
-		}
-		// If LiquidityControllerOwner is not set, default to L2ProxyAdminOwner
-		if cfg.LiquidityControllerOwner == (common.Address{}) {
-			cfg.LiquidityControllerOwner = chainIntent.Roles.L2ProxyAdminOwner
-		}
-	}
-
 	if err := cfg.Check(log.New(log.DiscardHandler())); err != nil {
 		return cfg, fmt.Errorf("combined deploy config failed validation: %w", err)
 	}

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -78,12 +78,12 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 				ChainFeesRecipient: chainIntent.ChainFeesRecipient,
 			},
 
-			GasTokenDeployConfig: genesis.GasTokenDeployConfig{
-				UseCustomGasToken:          chainIntent.CustomGasToken.Enabled,
-				GasPayingTokenName:         chainIntent.CustomGasToken.Name,
-				GasPayingTokenSymbol:       chainIntent.CustomGasToken.Symbol,
-				NativeAssetLiquidityAmount: chainIntent.CustomGasToken.InitialLiquidity,
-			},
+		GasTokenDeployConfig: genesis.GasTokenDeployConfig{
+			UseCustomGasToken:          chainIntent.IsCustomGasTokenEnabled(),
+			GasPayingTokenName:         chainIntent.CustomGasToken.Name,
+			GasPayingTokenSymbol:       chainIntent.CustomGasToken.Symbol,
+			NativeAssetLiquidityAmount: chainIntent.CustomGasToken.InitialLiquidity,
+		},
 
 			// STOP! This struct sets the _default_ upgrade schedule for all chains.
 			// Any upgrades you enable here will be enabled for all new deployments.

--- a/op-deployer/pkg/deployer/state/deploy_config_test.go
+++ b/op-deployer/pkg/deployer/state/deploy_config_test.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
@@ -37,12 +36,8 @@ func TestCombineDeployConfig(t *testing.T) {
 		},
 		UseRevenueShare:    true,
 		ChainFeesRecipient: common.HexToAddress("0x123"),
-		CustomGasToken: CustomGasToken{
-			Enabled:          false,
-			Name:             "",
-			Symbol:           "",
-			InitialLiquidity: (*hexutil.Big)(big.NewInt(0)),
-		},
+		// CustomGasToken defaults to disabled (all fields nil/empty)
+		CustomGasToken: CustomGasToken{},
 	}
 	state := State{
 		SuperchainDeployment: &addresses.SuperchainContracts{ProtocolVersionsProxy: common.HexToAddress("0x123")},

--- a/op-deployer/pkg/deployer/state/deploy_config_test.go
+++ b/op-deployer/pkg/deployer/state/deploy_config_test.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
@@ -62,63 +61,4 @@ func TestCombineDeployConfig(t *testing.T) {
 	require.Equal(t, *out.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisIsthmusTimeOffset, hexutil.Uint64(4))
 	require.Equal(t, *out.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisJovianTimeOffset, hexutil.Uint64(5))
 	require.Equal(t, *out.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisInteropTimeOffset, hexutil.Uint64(6))
-}
-
-// TestCombineDeployConfig_CGTViaOverrides tests that when custom gas token is enabled via
-// GlobalDeployOverrides (without specifying nativeAssetLiquidityAmount), the default value
-// of type(uint248).max is correctly applied.
-func TestCombineDeployConfig_CGTViaOverrides(t *testing.T) {
-	intent := Intent{
-		L1ChainID:          1,
-		L1ContractsLocator: artifacts.EmbeddedLocator,
-		// Enable CGT via GlobalDeployOverrides without specifying nativeAssetLiquidityAmount
-		GlobalDeployOverrides: map[string]any{
-			"useCustomGasToken":    true,
-			"gasPayingTokenName":   "Custom Token",
-			"gasPayingTokenSymbol": "CT",
-		},
-	}
-	chainState := ChainState{
-		ID: common.HexToHash("0x123"),
-	}
-	chainIntent := ChainIntent{
-		Eip1559Denominator:         1,
-		Eip1559Elasticity:          2,
-		GasLimit:                   standard.GasLimit,
-		BaseFeeVaultRecipient:      common.HexToAddress("0x123"),
-		L1FeeVaultRecipient:        common.HexToAddress("0x456"),
-		SequencerFeeVaultRecipient: common.HexToAddress("0x789"),
-		OperatorFeeVaultRecipient:  common.HexToAddress("0xabc"),
-		Roles: ChainRoles{
-			SystemConfigOwner: common.HexToAddress("0x123"),
-			L1ProxyAdminOwner: common.HexToAddress("0x456"),
-			L2ProxyAdminOwner: common.HexToAddress("0x789"),
-			UnsafeBlockSigner: common.HexToAddress("0xabc"),
-			Batcher:           common.HexToAddress("0xdef"),
-		},
-		UseRevenueShare:    false,
-		ChainFeesRecipient: common.Address{},
-		// CGT not enabled in intent
-		CustomGasToken: CustomGasToken{},
-	}
-	state := State{
-		SuperchainDeployment: &addresses.SuperchainContracts{ProtocolVersionsProxy: common.HexToAddress("0x123")},
-	}
-
-	out, err := CombineDeployConfig(&intent, &chainIntent, &state, &chainState)
-	require.NoError(t, err)
-
-	// Verify CGT is enabled
-	require.True(t, out.UseCustomGasToken, "CGT should be enabled via overrides")
-	require.Equal(t, "Custom Token", out.GasPayingTokenName)
-	require.Equal(t, "CT", out.GasPayingTokenSymbol)
-
-	// Verify NativeAssetLiquidityAmount is set to type(uint248).max (the default)
-	expectedMaxUint248 := new(big.Int)
-	expectedMaxUint248.SetString("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
-	require.NotNil(t, out.NativeAssetLiquidityAmount, "NativeAssetLiquidityAmount should not be nil")
-	require.Equal(t, expectedMaxUint248, out.NativeAssetLiquidityAmount.ToInt(), "NativeAssetLiquidityAmount should be type(uint248).max")
-
-	// Verify LiquidityControllerOwner is set to L2ProxyAdminOwner (the default)
-	require.Equal(t, chainIntent.Roles.L2ProxyAdminOwner, out.LiquidityControllerOwner, "LiquidityControllerOwner should default to L2ProxyAdminOwner")
 }

--- a/op-deployer/pkg/deployer/state/deploy_config_test.go
+++ b/op-deployer/pkg/deployer/state/deploy_config_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
@@ -61,4 +62,63 @@ func TestCombineDeployConfig(t *testing.T) {
 	require.Equal(t, *out.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisIsthmusTimeOffset, hexutil.Uint64(4))
 	require.Equal(t, *out.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisJovianTimeOffset, hexutil.Uint64(5))
 	require.Equal(t, *out.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisInteropTimeOffset, hexutil.Uint64(6))
+}
+
+// TestCombineDeployConfig_CGTViaOverrides tests that when custom gas token is enabled via
+// GlobalDeployOverrides (without specifying nativeAssetLiquidityAmount), the default value
+// of type(uint248).max is correctly applied.
+func TestCombineDeployConfig_CGTViaOverrides(t *testing.T) {
+	intent := Intent{
+		L1ChainID:          1,
+		L1ContractsLocator: artifacts.EmbeddedLocator,
+		// Enable CGT via GlobalDeployOverrides without specifying nativeAssetLiquidityAmount
+		GlobalDeployOverrides: map[string]any{
+			"useCustomGasToken":    true,
+			"gasPayingTokenName":   "Custom Token",
+			"gasPayingTokenSymbol": "CT",
+		},
+	}
+	chainState := ChainState{
+		ID: common.HexToHash("0x123"),
+	}
+	chainIntent := ChainIntent{
+		Eip1559Denominator:         1,
+		Eip1559Elasticity:          2,
+		GasLimit:                   standard.GasLimit,
+		BaseFeeVaultRecipient:      common.HexToAddress("0x123"),
+		L1FeeVaultRecipient:        common.HexToAddress("0x456"),
+		SequencerFeeVaultRecipient: common.HexToAddress("0x789"),
+		OperatorFeeVaultRecipient:  common.HexToAddress("0xabc"),
+		Roles: ChainRoles{
+			SystemConfigOwner: common.HexToAddress("0x123"),
+			L1ProxyAdminOwner: common.HexToAddress("0x456"),
+			L2ProxyAdminOwner: common.HexToAddress("0x789"),
+			UnsafeBlockSigner: common.HexToAddress("0xabc"),
+			Batcher:           common.HexToAddress("0xdef"),
+		},
+		UseRevenueShare:    false,
+		ChainFeesRecipient: common.Address{},
+		// CGT not enabled in intent
+		CustomGasToken: CustomGasToken{},
+	}
+	state := State{
+		SuperchainDeployment: &addresses.SuperchainContracts{ProtocolVersionsProxy: common.HexToAddress("0x123")},
+	}
+
+	out, err := CombineDeployConfig(&intent, &chainIntent, &state, &chainState)
+	require.NoError(t, err)
+
+	// Verify CGT is enabled
+	require.True(t, out.UseCustomGasToken, "CGT should be enabled via overrides")
+	require.Equal(t, "Custom Token", out.GasPayingTokenName)
+	require.Equal(t, "CT", out.GasPayingTokenSymbol)
+
+	// Verify NativeAssetLiquidityAmount is set to type(uint248).max (the default)
+	expectedMaxUint248 := new(big.Int)
+	expectedMaxUint248.SetString("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
+	require.NotNil(t, out.NativeAssetLiquidityAmount, "NativeAssetLiquidityAmount should not be nil")
+	require.Equal(t, expectedMaxUint248, out.NativeAssetLiquidityAmount.ToInt(), "NativeAssetLiquidityAmount should be type(uint248).max")
+
+	// Verify LiquidityControllerOwner is set to L2ProxyAdminOwner (the default)
+	require.Equal(t, chainIntent.Roles.L2ProxyAdminOwner, out.LiquidityControllerOwner, "LiquidityControllerOwner should default to L2ProxyAdminOwner")
 }

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -178,7 +178,7 @@ func (c *Intent) validateStandardValues() error {
 				return fmt.Errorf("%w: chainId=%s", ErrRevenueShareZeroAddress, chain.ID)
 			}
 		}
-		if chain.CustomGasToken.Enabled {
+		if chain.IsCustomGasTokenEnabled() {
 			return fmt.Errorf("%w: chainId=%s custom gas token must be disabled for standard chains", ErrNonStandardValue, chain.ID)
 		}
 	}
@@ -322,12 +322,8 @@ func NewIntentCustom(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, error)
 		intent.Chains = append(intent.Chains, &ChainIntent{
 			ID:       l2ChainID,
 			GasLimit: standard.GasLimit,
-			CustomGasToken: CustomGasToken{
-				Enabled:          false,
-				Name:             "",
-				Symbol:           "",
-				InitialLiquidity: (*hexutil.Big)(big.NewInt(0)),
-			},
+			// CustomGasToken defaults to disabled (all fields nil/empty)
+			CustomGasToken: CustomGasToken{},
 		})
 	}
 	return intent, nil
@@ -373,12 +369,8 @@ func NewIntentStandard(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, erro
 				L2ProxyAdminOwner: l2ProxyAdminOwner,
 			},
 			UseRevenueShare: standard.UseRevenueShare,
-			CustomGasToken: CustomGasToken{
-				Enabled:          false,
-				Name:             "",
-				Symbol:           "",
-				InitialLiquidity: (*hexutil.Big)(big.NewInt(0)),
-			},
+			// CustomGasToken defaults to disabled (all fields nil/empty)
+			CustomGasToken: CustomGasToken{},
 		})
 	}
 	return intent, nil

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -69,7 +69,6 @@ func TestValidateStandardValues(t *testing.T) {
 			"CustomGasToken",
 			func(intent *Intent) {
 				intent.Chains[0].CustomGasToken = CustomGasToken{
-					Enabled:          true,
 					Name:             "Custom Gas Token",
 					Symbol:           "CGT",
 					InitialLiquidity: (*hexutil.Big)(big.NewInt(1000)),
@@ -199,9 +198,8 @@ func TestValidateCustomValues(t *testing.T) {
 			"empty custom gas token name when enabled",
 			func(intent *Intent) {
 				intent.Chains[0].CustomGasToken = CustomGasToken{
-					Enabled: true,
-					Name:    "",
-					Symbol:  "CGT",
+					Name:   "",
+					Symbol: "CGT",
 				}
 			},
 			ErrIncompatibleValue,
@@ -210,9 +208,8 @@ func TestValidateCustomValues(t *testing.T) {
 			"empty custom gas token symbol when enabled",
 			func(intent *Intent) {
 				intent.Chains[0].CustomGasToken = CustomGasToken{
-					Enabled: true,
-					Name:    "Custom Gas Token",
-					Symbol:  "",
+					Name:   "Custom Gas Token",
+					Symbol: "",
 				}
 			},
 			ErrIncompatibleValue,
@@ -286,7 +283,6 @@ func setCustomGasToken(intent *Intent) {
 	amount.SetString("1000000000000000000000", 10)
 
 	intent.Chains[0].CustomGasToken = CustomGasToken{
-		Enabled:          true,
 		Name:             "Custom Gas Token",
 		Symbol:           "CGT",
 		InitialLiquidity: (*hexutil.Big)(amount),

--- a/packages/contracts-bedrock/interfaces/L2/ILiquidityController.sol
+++ b/packages/contracts-bedrock/interfaces/L2/ILiquidityController.sol
@@ -7,6 +7,7 @@ interface ILiquidityController is ISemver {
     error LiquidityController_Unauthorized();
 
     event Initialized(uint8 version);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     event MinterAuthorized(address indexed minter);
     event MinterDeauthorized(address indexed minter);
@@ -17,10 +18,18 @@ interface ILiquidityController is ISemver {
     function deauthorizeMinter(address _minter) external;
     function mint(address _to, uint256 _amount) external;
     function burn() external payable;
+    function owner() external view returns (address);
+    function transferOwnership(address newOwner) external;
+    function renounceOwnership() external;
     function minters(address) external view returns (bool);
     function gasPayingTokenName() external view returns (string memory);
     function gasPayingTokenSymbol() external view returns (string memory);
-    function initialize(string memory _gasPayingTokenName, string memory _gasPayingTokenSymbol) external;
+    function initialize(
+        address _owner,
+        string memory _gasPayingTokenName,
+        string memory _gasPayingTokenSymbol
+    )
+        external;
 
     function __constructor__() external;
 }

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -551,7 +551,11 @@ contract L2Genesis is Script {
     function setLiquidityController(Input memory _input) internal {
         address impl = _setImplementationCode(Predeploys.LIQUIDITY_CONTROLLER);
 
-        ILiquidityController(impl).initialize({ _owner: address(0), _gasPayingTokenName: "", _gasPayingTokenSymbol: "" });
+        ILiquidityController(impl).initialize({
+            _owner: _input.liquidityControllerOwner,
+            _gasPayingTokenName: "",
+            _gasPayingTokenSymbol: ""
+        });
 
         ILiquidityController(Predeploys.LIQUIDITY_CONTROLLER).initialize({
             _owner: _input.liquidityControllerOwner,

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -80,6 +80,7 @@ contract L2Genesis is Script {
         string gasPayingTokenName;
         string gasPayingTokenSymbol;
         uint256 nativeAssetLiquidityAmount;
+        address liquidityControllerOwner;
     }
 
     using ForkUtils for Fork;
@@ -550,9 +551,10 @@ contract L2Genesis is Script {
     function setLiquidityController(Input memory _input) internal {
         address impl = _setImplementationCode(Predeploys.LIQUIDITY_CONTROLLER);
 
-        ILiquidityController(impl).initialize({ _gasPayingTokenName: "", _gasPayingTokenSymbol: "" });
+        ILiquidityController(impl).initialize({ _owner: address(0), _gasPayingTokenName: "", _gasPayingTokenSymbol: "" });
 
         ILiquidityController(Predeploys.LIQUIDITY_CONTROLLER).initialize({
+            _owner: _input.liquidityControllerOwner,
             _gasPayingTokenName: _input.gasPayingTokenName,
             _gasPayingTokenSymbol: _input.gasPayingTokenSymbol
         });

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -84,6 +84,7 @@ contract DeployConfig is Script {
     string public gasPayingTokenName;
     string public gasPayingTokenSymbol;
     uint256 public nativeAssetLiquidityAmount;
+    address public liquidityControllerOwner;
 
     // V2 Dispute Game Configuration
     uint256 public faultGameV2MaxGameDepth;
@@ -150,6 +151,7 @@ contract DeployConfig is Script {
         gasPayingTokenName = _readOr(_json, "$.gasPayingTokenName", "");
         gasPayingTokenSymbol = _readOr(_json, "$.gasPayingTokenSymbol", "");
         nativeAssetLiquidityAmount = _readOr(_json, "$.nativeAssetLiquidityAmount", 0);
+        liquidityControllerOwner = _readOr(_json, "$.liquidityControllerOwner", finalSystemOwner);
 
         enableGovernance = _readOr(_json, "$.enableGovernance", false);
         systemConfigStartBlock = stdJson.readUint(_json, "$.systemConfigStartBlock");

--- a/packages/contracts-bedrock/snapshots/abi/LiquidityController.json
+++ b/packages/contracts-bedrock/snapshots/abi/LiquidityController.json
@@ -66,6 +66,11 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
         "internalType": "string",
         "name": "_gasPayingTokenName",
         "type": "string"
@@ -116,6 +121,39 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -212,6 +250,25 @@
       }
     ],
     "name": "MinterDeauthorized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
     "type": "event"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -117,7 +117,7 @@
   },
   "src/L2/LiquidityController.sol:LiquidityController": {
     "initCodeHash": "0xe492fe75e3c0a8a80ede7b50271263c42a2c7616a101861e892dba76f9771e34",
-    "sourceCodeHash": "0x1799c048c4207d54d4a164258b6eb5079a542f9679f16400ff436b4245459cf0"
+    "sourceCodeHash": "0x7118aa0a3da50fede0a376cb0664e9146147daa7eb1f75bcd45a5606fd6d3afa"
   },
   "src/L2/NativeAssetLiquidity.sol:NativeAssetLiquidity": {
     "initCodeHash": "0x04b176e5d484e54173a5644c833117c5fd9f055dce8678be9ec4cf07c0f01f00",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x6bf74671476f7a6c5d35cad90e16c7d0c1b1e7c4d33fb5f8e0966e1e3ca9cfe8",
-    "sourceCodeHash": "0x7f439c296c4698b1bb3b670b88ab0b91d88c27c771453aa1a04735ffd41c057c"
+    "initCodeHash": "0xe8e631329469bd7779cbe948975dfbca3f2b19620f28cda81522a2d18557b5d1",
+    "sourceCodeHash": "0x41dd4624df4b5e25be054d868aa2bd439dc2f9935e064f09058b90ebe5d11d92"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0x0c8b15453d0f0bc5d9af07f104505e0bbb2b358f0df418289822fb73a8652b30",
@@ -116,8 +116,8 @@
     "sourceCodeHash": "0xbea4229c5c6988243dbc7cf5a086ddd412fe1f2903b8e20d56699fec8de0c2c9"
   },
   "src/L2/LiquidityController.sol:LiquidityController": {
-    "initCodeHash": "0x19ce7a691d1f8631bfce9fea002c385c418fc69c2e9a9aa5d44ee0cf348c1026",
-    "sourceCodeHash": "0x87351013f5bcca917dfdd916b06b8ece6bd447acae146f004a33d88f59ce2487"
+    "initCodeHash": "0xe492fe75e3c0a8a80ede7b50271263c42a2c7616a101861e892dba76f9771e34",
+    "sourceCodeHash": "0x1799c048c4207d54d4a164258b6eb5079a542f9679f16400ff436b4245459cf0"
   },
   "src/L2/NativeAssetLiquidity.sol:NativeAssetLiquidity": {
     "initCodeHash": "0x04b176e5d484e54173a5644c833117c5fd9f055dce8678be9ec4cf07c0f01f00",

--- a/packages/contracts-bedrock/snapshots/storageLayout/LiquidityController.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/LiquidityController.json
@@ -14,24 +14,45 @@
     "type": "bool"
   },
   {
+    "bytes": "1600",
+    "label": "__gap",
+    "offset": 0,
+    "slot": "1",
+    "type": "uint256[50]"
+  },
+  {
+    "bytes": "20",
+    "label": "_owner",
+    "offset": 0,
+    "slot": "51",
+    "type": "address"
+  },
+  {
+    "bytes": "1568",
+    "label": "__gap",
+    "offset": 0,
+    "slot": "52",
+    "type": "uint256[49]"
+  },
+  {
     "bytes": "32",
     "label": "minters",
     "offset": 0,
-    "slot": "1",
+    "slot": "101",
     "type": "mapping(address => bool)"
   },
   {
     "bytes": "32",
     "label": "gasPayingTokenName",
     "offset": 0,
-    "slot": "2",
+    "slot": "102",
     "type": "string"
   },
   {
     "bytes": "32",
     "label": "gasPayingTokenSymbol",
     "offset": 0,
-    "slot": "3",
+    "slot": "103",
     "type": "string"
   }
 ]

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -2229,9 +2229,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 5.6.0
+    /// @custom:semver 5.6.1
     function version() public pure virtual returns (string memory) {
-        return "5.6.0";
+        return "5.6.1";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/src/L2/LiquidityController.sol
+++ b/packages/contracts-bedrock/src/L2/LiquidityController.sol
@@ -70,10 +70,9 @@ contract LiquidityController is ISemver, Initializable, OwnableUpgradeable {
         external
         initializer
     {
-        if (_owner != address(0)) {
-            __Ownable_init();
-            transferOwnership(_owner);
-        }
+        __Ownable_init();
+        transferOwnership(_owner);
+
         gasPayingTokenName = _gasPayingTokenName;
         gasPayingTokenSymbol = _gasPayingTokenSymbol;
     }

--- a/packages/contracts-bedrock/src/L2/LiquidityController.sol
+++ b/packages/contracts-bedrock/src/L2/LiquidityController.sol
@@ -70,8 +70,10 @@ contract LiquidityController is ISemver, Initializable, OwnableUpgradeable {
         external
         initializer
     {
-        __Ownable_init();
-        transferOwnership(_owner);
+        if (_owner != address(0)) {
+            __Ownable_init();
+            transferOwnership(_owner);
+        }
         gasPayingTokenName = _gasPayingTokenName;
         gasPayingTokenSymbol = _gasPayingTokenSymbol;
     }

--- a/packages/contracts-bedrock/src/L2/LiquidityController.sol
+++ b/packages/contracts-bedrock/src/L2/LiquidityController.sol
@@ -2,7 +2,8 @@
 pragma solidity 0.8.15;
 
 // Contracts
-import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { SafeSend } from "src/universal/SafeSend.sol";
 
 // Libraries
@@ -10,7 +11,6 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 
 // Interfaces
 import { INativeAssetLiquidity } from "interfaces/L2/INativeAssetLiquidity.sol";
-import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
 /// @custom:proxied true
@@ -18,7 +18,7 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 /// @title LiquidityController
 /// @notice The LiquidityController contract is responsible for controlling the liquidity of the native asset on the L2
 ///         chain.
-contract LiquidityController is ISemver, Initializable {
+contract LiquidityController is ISemver, Initializable, OwnableUpgradeable {
     /// @notice Emitted when an address is authorized to mint/burn liquidity
     /// @param minter The address that was authorized
     event MinterAuthorized(address indexed minter);
@@ -59,25 +59,33 @@ contract LiquidityController is ISemver, Initializable {
     }
 
     /// @notice Initializer.
+    /// @param _owner The owner of the LiquidityController
     /// @param _gasPayingTokenName The name of the native asset
     /// @param _gasPayingTokenSymbol The symbol of the native asset
-    function initialize(string memory _gasPayingTokenName, string memory _gasPayingTokenSymbol) external initializer {
+    function initialize(
+        address _owner,
+        string memory _gasPayingTokenName,
+        string memory _gasPayingTokenSymbol
+    )
+        external
+        initializer
+    {
+        __Ownable_init();
+        transferOwnership(_owner);
         gasPayingTokenName = _gasPayingTokenName;
         gasPayingTokenSymbol = _gasPayingTokenSymbol;
     }
 
     /// @notice Authorizes an address to perform liquidity control operations
     /// @param _minter The address to authorize as a minter
-    function authorizeMinter(address _minter) external {
-        if (msg.sender != IProxyAdmin(Predeploys.PROXY_ADMIN).owner()) revert LiquidityController_Unauthorized();
+    function authorizeMinter(address _minter) external onlyOwner {
         minters[_minter] = true;
         emit MinterAuthorized(_minter);
     }
 
     /// @notice Deauthorizes an address from performing liquidity control operations
     /// @param _minter The address to deauthorize as a minter
-    function deauthorizeMinter(address _minter) external {
-        if (msg.sender != IProxyAdmin(Predeploys.PROXY_ADMIN).owner()) revert LiquidityController_Unauthorized();
+    function deauthorizeMinter(address _minter) external onlyOwner {
         delete minters[_minter];
         emit MinterDeauthorized(_minter);
     }

--- a/packages/contracts-bedrock/test/L2/LiquidityController.t.sol
+++ b/packages/contracts-bedrock/test/L2/LiquidityController.t.sol
@@ -264,6 +264,7 @@ contract LiquidityController_Burn_Test is LiquidityController_TestInit {
 contract LiquidityController_Initialize_Test is LiquidityController_TestInit {
     /// @notice Tests that calling initialize on the implementation contract reverts.
     function testFuzz_initialize_implementation_reverts(address _owner) public {
+        vm.assume(_owner != address(0));
         // Deploy a new implementation contract directly (not through proxy)
         LiquidityController implementation = new LiquidityController();
 

--- a/packages/contracts-bedrock/test/L2/LiquidityController.t.sol
+++ b/packages/contracts-bedrock/test/L2/LiquidityController.t.sol
@@ -263,13 +263,16 @@ contract LiquidityController_Burn_Test is LiquidityController_TestInit {
 /// @notice Tests the `initialize` function of the `LiquidityController` contract.
 contract LiquidityController_Initialize_Test is LiquidityController_TestInit {
     /// @notice Tests that calling initialize on the implementation contract reverts.
-    function test_initialize_implementation_reverts() public {
+    function testFuzz_initialize_implementation_reverts(address _owner) public {
         // Deploy a new implementation contract directly (not through proxy)
         LiquidityController implementation = new LiquidityController();
 
         // Try to initialize the implementation contract directly
         // This should revert because _disableInitializers() was called in the constructor
         vm.expectRevert("Initializable: contract is already initialized");
-        implementation.initialize(address(this), "Test Token", "TEST");
+        implementation.initialize(_owner, "Test Token", "TEST");
+
+        // Assert owner is set correctly
+        assertNotEq(implementation.owner(), _owner);
     }
 }

--- a/packages/contracts-bedrock/test/L2/LiquidityController.t.sol
+++ b/packages/contracts-bedrock/test/L2/LiquidityController.t.sol
@@ -92,7 +92,7 @@ contract LiquidityController_AuthorizeMinter_Test is LiquidityController_TestIni
         vm.expectEmit(address(liquidityController));
         emit MinterAuthorized(_minter);
         // Call the authorizeMinter function with owner as the caller
-        vm.prank(IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
+        vm.prank(liquidityController.owner());
         liquidityController.authorizeMinter(_minter);
 
         // Assert minter is authorized
@@ -101,11 +101,11 @@ contract LiquidityController_AuthorizeMinter_Test is LiquidityController_TestIni
 
     /// @notice Tests that the authorizeMinter function reverts when called by non-owner.
     function testFuzz_authorizeMinter_fromNonOwner_fails(address _caller, address _minter) public {
-        vm.assume(_caller != IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
+        vm.assume(_caller != liquidityController.owner());
 
         // Call the authorizeMinter function with non-owner as the caller
         vm.prank(_caller);
-        vm.expectRevert(LiquidityController.LiquidityController_Unauthorized.selector);
+        vm.expectRevert("Ownable: caller is not the owner");
         liquidityController.authorizeMinter(_minter);
 
         // Assert minter is not authorized
@@ -125,7 +125,7 @@ contract LiquidityController_DeauthorizeMinter_Test is LiquidityController_TestI
         vm.expectEmit(address(liquidityController));
         emit MinterDeauthorized(_minter);
         // Call the deauthorizeMinter function with owner as the caller
-        vm.prank(IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
+        vm.prank(liquidityController.owner());
         liquidityController.deauthorizeMinter(_minter);
 
         // Assert minter is deauthorized
@@ -134,14 +134,14 @@ contract LiquidityController_DeauthorizeMinter_Test is LiquidityController_TestI
 
     /// @notice Tests that the deauthorizeMinter function reverts when called by non-owner.
     function testFuzz_deauthorizeMinter_fromNonOwner_fails(address _caller, address _minter) public {
-        vm.assume(_caller != IProxyAdmin(Predeploys.PROXY_ADMIN).owner());
+        vm.assume(_caller != liquidityController.owner());
 
         // Set minter to authorized
         _authorizeMinter(_minter);
 
         // Call the deauthorizeMinter function with non-owner as the caller
         vm.prank(_caller);
-        vm.expectRevert(LiquidityController.LiquidityController_Unauthorized.selector);
+        vm.expectRevert("Ownable: caller is not the owner");
         liquidityController.deauthorizeMinter(_minter);
 
         // Assert minter is still authorized
@@ -274,6 +274,6 @@ contract LiquidityController_Initialize_Test is LiquidityController_TestInit {
         // Try to initialize the implementation contract directly
         // This should revert because _disableInitializers() was called in the constructor
         vm.expectRevert("Initializable: contract is already initialized");
-        implementation.initialize("Test Token", "TEST");
+        implementation.initialize(address(this), "Test Token", "TEST");
     }
 }

--- a/packages/contracts-bedrock/test/L2/LiquidityController.t.sol
+++ b/packages/contracts-bedrock/test/L2/LiquidityController.t.sol
@@ -6,15 +6,11 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { stdStorage, StdStorage } from "forge-std/Test.sol";
 
 // Libraries
-import { Predeploys } from "src/libraries/Predeploys.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 
 // Contracts
 import { LiquidityController } from "src/L2/LiquidityController.sol";
 import { NativeAssetLiquidity } from "src/L2/NativeAssetLiquidity.sol";
-
-// Interfaces
-import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 
 /// @title LiquidityController_TestInit
 /// @notice Reusable test initialization for `LiquidityController` tests.

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -202,6 +202,7 @@ abstract contract L2Genesis_TestInit is Test {
     function testCGT() internal view {
         // Test LiquidityController deployment
         ILiquidityController controller = ILiquidityController(Predeploys.LIQUIDITY_CONTROLLER);
+        assertEq(controller.owner(), input.liquidityControllerOwner);
         assertEq(controller.gasPayingTokenName(), input.gasPayingTokenName);
         assertEq(controller.gasPayingTokenSymbol(), input.gasPayingTokenSymbol);
 
@@ -251,7 +252,8 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
             useCustomGasToken: false,
             gasPayingTokenName: "",
             gasPayingTokenSymbol: "",
-            nativeAssetLiquidityAmount: type(uint248).max
+            nativeAssetLiquidityAmount: type(uint248).max,
+            liquidityControllerOwner: address(0x000000000000000000000000000000000000000d)
         });
     }
 

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -346,7 +346,8 @@ abstract contract Setup is FeatureFlags {
                 useCustomGasToken: deploy.cfg().useCustomGasToken(),
                 gasPayingTokenName: deploy.cfg().gasPayingTokenName(),
                 gasPayingTokenSymbol: deploy.cfg().gasPayingTokenSymbol(),
-                nativeAssetLiquidityAmount: deploy.cfg().nativeAssetLiquidityAmount()
+                nativeAssetLiquidityAmount: deploy.cfg().nativeAssetLiquidityAmount(),
+                liquidityControllerOwner: deploy.cfg().liquidityControllerOwner()
             })
         );
 


### PR DESCRIPTION
CLOSES OPT-1297
CLOSES OPT-1286
CLOSES OPT-1316

https://cantina.xyz/code/940ca124-08fb-4789-8dc4-5c677d3997f2/findings?finding=10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Ownable LiquidityController with configurable owner, refactor custom gas token enablement/defaults, and wire through deploy/genesis, ABI, and tests.
> 
> - **Contracts (L2)**:
>   - `LiquidityController` now `OwnableUpgradeable`; `initialize` takes `_owner`; `authorize/deauthorize` gated by `onlyOwner`.
>   - Update `ILiquidityController` interface/ABI and storage layout; add ownership events/functions.
>   - Bump `OPContractsManager` version to 5.6.1.
> - **Genesis/Deploy Scripts**:
>   - `L2Genesis.Input` adds `liquidityControllerOwner`; initialize controller with owner; assert owner in tests.
>   - Deploy config reads `liquidityControllerOwner` (default `finalSystemOwner`).
> - **Deployer (Go)**:
>   - Refactor CGT: remove boolean flag in intent; CGT enabled when both `name` and `symbol` set.
>   - Defaults: if CGT enabled and no `initialLiquidity`, use `type(uint248).max`; provide `GetLiquidityControllerOwner()` (defaults to `L2ProxyAdminOwner`).
>   - Pass CGT config (incl. `liquidityControllerOwner`) to L2 genesis; validate non-zero owner in `GasTokenDeployConfig`.
> - **Tests**:
>   - Update unit/integration tests for new ownership semantics, CGT defaults/enablement, and config plumbing.
>   - Snapshot updates for ABI/semver/storage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d0c373f68c00527e4d09692e1025b5ea942ca74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->