### PR TITLE
test: skip fee split invariant when CGT enabled

### DIFF
--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -10,6 +10,7 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";
 import { IL1Withdrawer } from "interfaces/L2/IL1Withdrawer.sol";
 import { ISuperchainRevSharesCalculator } from "interfaces/L2/ISuperchainRevSharesCalculator.sol";
+import { DevFeatures } from "src/libraries/DevFeatures.sol";
 
 /// @notice A struct to keep track of the state when a disburse call fails
 struct DisburseFailureState {
@@ -216,6 +217,8 @@ contract FeeSplitter_Invariant is CommonTest {
     function setUp() public override {
         super.enableRevenueShare();
         super.setUp();
+
+        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
 
         disburser = new FeeSplitter_Disburser(vm, feeSplitter, l1Withdrawer);
         preconditions = new FeeSplitter_Preconditions();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Skips FeeSplitter invariant tests when the CUSTOM_GAS_TOKEN dev feature is enabled by importing `DevFeatures` and adding a guard in `setUp()`.
> 
> - **Tests**:
>   - Update `packages/contracts-bedrock/test/invariants/FeeSplit.t.sol`:
>     - Import `DevFeatures` and call `skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN)` in `setUp()` to conditionally skip FeeSplitter invariants when custom gas token is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5800632c0ebf4ca3c1ec67051c2992089819d8c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->