### PR TITLE
test: fix l2 genesis override test

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
@@ -55,6 +56,7 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				OperatorFeeVaultWithdrawalNetwork:        "local",
 				EnableGovernance:                         false,
 				GovernanceTokenOwner:                     standard.GovernanceTokenOwner,
+				NativeAssetLiquidityAmount: 			  (*hexutil.Big)(big.NewInt(0)),
 			},
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
 				return standard.DefaultHardforkScheduleForTag("")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extend L2 genesis overrides test to include and assert zero `NativeAssetLiquidityAmount` (adds `math/big` import).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97aed5b4b8b2f0629fc3879cde1c3eae480c0c07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->