### PR TITLE
test: fix cgt fork tests

### DIFF
--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -168,7 +168,7 @@ abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
     /// @notice Checks if the Custom Gas Token feature is enabled.
     /// @return bool True if the Custom Gas Token feature is enabled.
     function isUsingCustomGasToken() public view returns (bool) {
-        return isDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
+        return systemConfig.isFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
     }
 
     /// @notice Enables the ETHLockbox feature if not enabled.
@@ -242,12 +242,10 @@ contract OptimismPortal2_Initialize_Test is OptimismPortal2_TestInit {
             assertEq(address(optimismPortal2.ethLockbox()), address(0));
         }
 
-        if (!isForkTest()) {
-            if (isUsingCustomGasToken()) {
-                assertTrue(optimismPortal2.systemConfig().isFeatureEnabled(Features.CUSTOM_GAS_TOKEN));
-            } else if (!isUsingLockbox()) {
-                assertFalse(optimismPortal2.systemConfig().isFeatureEnabled(Features.CUSTOM_GAS_TOKEN));
-            }
+        if (isUsingCustomGasToken()) {
+            assertTrue(optimismPortal2.systemConfig().isFeatureEnabled(Features.CUSTOM_GAS_TOKEN));
+        } else if (!isUsingLockbox()) {
+            assertFalse(optimismPortal2.systemConfig().isFeatureEnabled(Features.CUSTOM_GAS_TOKEN));
         }
 
         returnIfForkTest(
@@ -645,7 +643,7 @@ contract OptimismPortal2_NumProofSubmitters_Test is OptimismPortal2_TestInit {
 contract OptimismPortal2_Receive_Test is OptimismPortal2_TestInit {
     /// @notice Tests that `receive` successfully deposits ETH.
     function testFuzz_receive_succeeds(uint256 _value) external {
-        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
         // Prevent overflow on an upgrade context
         _value = bound(_value, 0, type(uint256).max - address(ethLockbox).balance);
         uint256 balanceBefore = address(optimismPortal2).balance;
@@ -684,7 +682,7 @@ contract OptimismPortal2_Receive_Test is OptimismPortal2_TestInit {
     }
 
     function testFuzz_receive_withLockbox_succeeds(uint256 _value) external {
-        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
         // Prevent overflow on an upgrade context.
         // We use a dummy lockbox here because the real one won't work for upgrade tests.
         address dummyLockbox = address(0xdeadbeef);
@@ -723,11 +721,7 @@ contract OptimismPortal2_Receive_Test is OptimismPortal2_TestInit {
 
     /// @notice Tests that `receive` reverts when custom gas token is enabled
     function testFuzz_receive_customGasToken_reverts(uint256 _value) external {
-        skipIfDevFeatureDisabled(DevFeatures.CUSTOM_GAS_TOKEN);
-
-        if (isForkTest()) {
-            skipIfSysFeatureDisabled(Features.CUSTOM_GAS_TOKEN);
-        }
+        skipIfSysFeatureDisabled(Features.CUSTOM_GAS_TOKEN);
 
         _value = bound(_value, 1, type(uint128).max);
         vm.deal(alice, _value);
@@ -1414,10 +1408,7 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
     /// @notice Tests that `proveWithdrawalTransaction` reverts when the custom gas token mode
     ///         is enabled and the withdrawal transaction has a value.
     function test_proveWithdrawalTransaction_withValueAndCustomGasToken_reverts() external {
-        skipIfDevFeatureDisabled(DevFeatures.CUSTOM_GAS_TOKEN);
-        skipIfForkTest(
-            "OptimismPortal2_ProveWithdrawalTransaction_Test: isCustomGasToken() not available on forked networks"
-        );
+        skipIfSysFeatureDisabled(Features.CUSTOM_GAS_TOKEN);
         // Set the withdrawal transaction value to a non-zero value.
         _defaultTx.value = bound(uint256(1), 1, type(uint256).max);
 
@@ -1919,10 +1910,7 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
     /// @notice Tests that `finalizeWithdrawalTransaction` reverts when the custom gas token mode
     ///         is enabled and the withdrawal transaction has a value.
     function test_finalizeWithdrawalTransaction_withValueAndCustomGasToken_reverts() external {
-        skipIfDevFeatureDisabled(DevFeatures.CUSTOM_GAS_TOKEN);
-        skipIfForkTest(
-            "OptimismPortal2_FinalizeWithdrawalTransaction_Test: isCustomGasToken() not available on forked networks"
-        );
+        skipIfSysFeatureDisabled(Features.CUSTOM_GAS_TOKEN);
         // Set the withdrawal transaction value to a non-zero value.
         _defaultTx.value = bound(uint256(1), 1, type(uint256).max);
 
@@ -2525,8 +2513,7 @@ contract OptimismPortal2_DepositTransaction_Test is OptimismPortal2_TestInit {
     /// @notice Tests that `depositTransaction` reverts when the value is greater than 0 and the
     ///         custom gas token is active.
     function test_depositTransaction_withCustomGasTokenAndValue_reverts(bytes memory _data, uint256 _value) external {
-        skipIfDevFeatureDisabled(DevFeatures.CUSTOM_GAS_TOKEN);
-        skipIfForkTest("OptimismPortal2_DepositTransaction_Test: isCustomGasToken() not available on forked networks");
+        skipIfSysFeatureDisabled(Features.CUSTOM_GAS_TOKEN);
 
         // Prevent overflow on an upgrade context
         _value = bound(_value, 1, type(uint256).max - address(optimismPortal2).balance);

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -241,10 +241,13 @@ contract OptimismPortal2_Initialize_Test is OptimismPortal2_TestInit {
         } else {
             assertEq(address(optimismPortal2.ethLockbox()), address(0));
         }
-        if (isUsingCustomGasToken()) {
-            assertTrue(optimismPortal2.systemConfig().isFeatureEnabled(Features.CUSTOM_GAS_TOKEN));
-        } else if (!isUsingLockbox()) {
-            assertFalse(optimismPortal2.systemConfig().isFeatureEnabled(Features.CUSTOM_GAS_TOKEN));
+
+        if (!isForkTest()) {
+            if (isUsingCustomGasToken()) {
+                assertTrue(optimismPortal2.systemConfig().isFeatureEnabled(Features.CUSTOM_GAS_TOKEN));
+            } else if (!isUsingLockbox()) {
+                assertFalse(optimismPortal2.systemConfig().isFeatureEnabled(Features.CUSTOM_GAS_TOKEN));
+            }
         }
 
         returnIfForkTest(
@@ -721,6 +724,11 @@ contract OptimismPortal2_Receive_Test is OptimismPortal2_TestInit {
     /// @notice Tests that `receive` reverts when custom gas token is enabled
     function testFuzz_receive_customGasToken_reverts(uint256 _value) external {
         skipIfDevFeatureDisabled(DevFeatures.CUSTOM_GAS_TOKEN);
+
+        if (isForkTest()) {
+            skipIfSysFeatureDisabled(Features.CUSTOM_GAS_TOKEN);
+        }
+
         _value = bound(_value, 1, type(uint128).max);
         vm.deal(alice, _value);
 

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -11,7 +11,6 @@ import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.so
 import { Constants } from "src/libraries/Constants.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { Features } from "src/libraries/Features.sol";
-import { DevFeatures } from "src/libraries/DevFeatures.sol";
 
 // Interfaces
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
@@ -934,15 +933,13 @@ contract SystemConfig_SetDAFootprintGasScalar_Test is SystemConfig_TestInit {
 contract SystemConfig_IsCustomGasToken_Test is SystemConfig_TestInit {
     /// @notice Tests that `isCustomGasToken` returns the correct value.
     function test_isCustomGasToken_enabled_succeeds() external {
-        skipIfForkTest("Skipping on forked tests because CGT is not available");
-        skipIfDevFeatureDisabled(DevFeatures.CUSTOM_GAS_TOKEN);
+        skipIfSysFeatureDisabled(Features.CUSTOM_GAS_TOKEN);
         assertTrue(systemConfig.isCustomGasToken());
     }
 
     /// @notice Tests that `isCustomGasToken` returns the correct value.
     function test_isCustomGasToken_disabled_succeeds() external {
-        skipIfForkTest("Skipping on forked tests because CGT is not available");
-        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
         assertFalse(systemConfig.isCustomGasToken());
     }
 }

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -934,12 +934,14 @@ contract SystemConfig_SetDAFootprintGasScalar_Test is SystemConfig_TestInit {
 contract SystemConfig_IsCustomGasToken_Test is SystemConfig_TestInit {
     /// @notice Tests that `isCustomGasToken` returns the correct value.
     function test_isCustomGasToken_enabled_succeeds() external {
+        skipIfForkTest("Skipping on forked tests because CGT is not available");
         skipIfDevFeatureDisabled(DevFeatures.CUSTOM_GAS_TOKEN);
         assertTrue(systemConfig.isCustomGasToken());
     }
 
     /// @notice Tests that `isCustomGasToken` returns the correct value.
     function test_isCustomGasToken_disabled_succeeds() external {
+        skipIfForkTest("Skipping on forked tests because CGT is not available");
         skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
         assertFalse(systemConfig.isCustomGasToken());
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrate L1 tests to use `Features.CUSTOM_GAS_TOKEN` and sys skip helpers, updating CGT checks and removing legacy dev-feature/fork guards.
> 
> - **OptimismPortal2 tests**:
>   - Use `Features.CUSTOM_GAS_TOKEN` for CGT checks (`isUsingCustomGasToken`) and replace `skipIfDevFeature*` with `skipIfSysFeature*` across `receive`, `depositTransaction`, `proveWithdrawalTransaction`, and `finalizeWithdrawalTransaction` tests.
>   - Drop fork-only skips tied to legacy dev-feature availability; assertions now rely on `systemConfig.isFeatureEnabled`.
> - **SystemConfig tests**:
>   - Remove `DevFeatures` import; gate CGT tests with `Features.CUSTOM_GAS_TOKEN` and sys skip helpers in `SystemConfig_IsCustomGasToken_Test`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 378aaadb424f0c09cab45bcf7a3aa0380240237b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->