### PR TITLE
fix: go linter

### DIFF
--- a/op-acceptance-tests/tests/custom_gas_token/init_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/init_test.go
@@ -4,6 +4,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
@@ -16,7 +18,7 @@ func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithMinimal(),
 		stack.MakeCommon(sysgo.WithDeployerOptions(
-			sysgo.WithCustomGasToken(true, "Custom Gas Token", "CGT", liq),
+			sysgo.WithCustomGasToken("Custom Gas Token", "CGT", liq, common.Address{}),
 		)),
 	)
 }

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -345,6 +345,7 @@ func GenesisL2(l2Host *script.Host, cfg *L2Config, deployment *L2Deployment, mul
 		GasPayingTokenName:                       cfg.GasPayingTokenName,
 		GasPayingTokenSymbol:                     cfg.GasPayingTokenSymbol,
 		NativeAssetLiquidityAmount:               cfg.NativeAssetLiquidityAmount.ToInt(),
+		LiquidityControllerOwner:                 cfg.LiquidityControllerOwner,
 	}); err != nil {
 		return fmt.Errorf("failed L2 genesis: %w", err)
 	}

--- a/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
@@ -144,8 +144,8 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 					"l2GenesisInteropTimeOffset": "0x0",
 				},
 			},
-			chainIntent: &state.ChainIntent{},
-			expectError: false,
+			chainIntent:       &state.ChainIntent{},
+			expectError:       false,
 			expectedOverrides: defaultOverrides(),
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
 				schedule := standard.DefaultHardforkScheduleForTag("")

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -55,9 +55,9 @@ type L2DevGenesisParams struct {
 }
 
 type CustomGasToken struct {
-	Name             string          `json:"name,omitempty" toml:"name,omitempty"`
-	Symbol           string          `json:"symbol,omitempty" toml:"symbol,omitempty"`
-	InitialLiquidity *hexutil.Big    `json:"initialLiquidity" toml:"initialLiquidity"`
+	Name                     string         `json:"name,omitempty" toml:"name,omitempty"`
+	Symbol                   string         `json:"symbol,omitempty" toml:"symbol,omitempty"`
+	InitialLiquidity         *hexutil.Big   `json:"initialLiquidity" toml:"initialLiquidity"`
 	LiquidityControllerOwner common.Address `json:"liquidityControllerOwner" toml:"liquidityControllerOwner"`
 }
 

--- a/op-deployer/pkg/deployer/state/chain_intent_test.go
+++ b/op-deployer/pkg/deployer/state/chain_intent_test.go
@@ -156,4 +156,3 @@ func TestIsCustomGasTokenEnabled(t *testing.T) {
 		})
 	}
 }
-

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -78,13 +78,13 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 				ChainFeesRecipient: chainIntent.ChainFeesRecipient,
 			},
 
-	GasTokenDeployConfig: genesis.GasTokenDeployConfig{
-		UseCustomGasToken:          chainIntent.IsCustomGasTokenEnabled(),
-		GasPayingTokenName:         chainIntent.CustomGasToken.Name,
-		GasPayingTokenSymbol:       chainIntent.CustomGasToken.Symbol,
-		NativeAssetLiquidityAmount: (*hexutil.Big)(chainIntent.GetInitialLiquidity()),
-		LiquidityControllerOwner:   chainIntent.GetLiquidityControllerOwner(),
-	},
+			GasTokenDeployConfig: genesis.GasTokenDeployConfig{
+				UseCustomGasToken:          chainIntent.IsCustomGasTokenEnabled(),
+				GasPayingTokenName:         chainIntent.CustomGasToken.Name,
+				GasPayingTokenSymbol:       chainIntent.CustomGasToken.Symbol,
+				NativeAssetLiquidityAmount: (*hexutil.Big)(chainIntent.GetInitialLiquidity()),
+				LiquidityControllerOwner:   chainIntent.GetLiquidityControllerOwner(),
+			},
 
 			// STOP! This struct sets the _default_ upgrade schedule for all chains.
 			// Any upgrades you enable here will be enabled for all new deployments.

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -404,10 +404,10 @@ func WithDisputeGameFinalityDelaySeconds(seconds uint64) DeployerOption {
 	}
 }
 
-func WithCustomGasToken(enabled bool, name, symbol string, initialLiquidity *big.Int) DeployerOption {
+func WithCustomGasToken(name, symbol string, initialLiquidity *big.Int, liquidityControllerOwner common.Address) DeployerOption {
 	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
 		for _, l2Cfg := range builder.L2s() {
-			l2Cfg.WithCustomGasToken(enabled, name, symbol, initialLiquidity)
+			l2Cfg.WithCustomGasToken(name, symbol, initialLiquidity, liquidityControllerOwner)
 		}
 	}
 }

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -419,7 +419,6 @@ func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address,
 				UseRevenueShare:    true,
 				ChainFeesRecipient: common.HexToAddress("0xBcd4042DE499D14e55001CcbB24a551F3b954096"),
 				CustomGasToken: state.CustomGasToken{
-					Enabled:          false,
 					Name:             "",
 					Symbol:           "",
 					InitialLiquidity: (*hexutil.Big)(big.NewInt(0)),

--- a/op-e2e/e2eutils/intentbuilder/builder.go
+++ b/op-e2e/e2eutils/intentbuilder/builder.go
@@ -472,7 +472,6 @@ func (c *l2Configurator) WithEIP1559Denominator(value uint64) {
 
 func (c *l2Configurator) WithCustomGasToken(enabled bool, name, symbol string, initialLiquidity *big.Int) {
 	c.builder.intent.Chains[c.chainIndex].CustomGasToken = state.CustomGasToken{
-		Enabled:          enabled,
 		Name:             name,
 		Symbol:           symbol,
 		InitialLiquidity: (*hexutil.Big)(initialLiquidity),

--- a/op-e2e/e2eutils/intentbuilder/builder.go
+++ b/op-e2e/e2eutils/intentbuilder/builder.go
@@ -54,7 +54,7 @@ type L2Configurator interface {
 	WithAdditionalDisputeGames(games []state.AdditionalDisputeGame)
 	WithFinalizationPeriodSeconds(value uint64)
 	WithRevenueShare(enabled bool, chainFeesRecipient common.Address)
-	WithCustomGasToken(enabled bool, name string, symbol string, initialLiquidity *big.Int)
+	WithCustomGasToken(name string, symbol string, initialLiquidity *big.Int, liquidityControllerOwner common.Address)
 	ContractsConfigurator
 	L2VaultsConfigurator
 	L2RolesConfigurator
@@ -470,11 +470,12 @@ func (c *l2Configurator) WithEIP1559Denominator(value uint64) {
 	c.builder.intent.Chains[c.chainIndex].Eip1559Denominator = value
 }
 
-func (c *l2Configurator) WithCustomGasToken(enabled bool, name, symbol string, initialLiquidity *big.Int) {
+func (c *l2Configurator) WithCustomGasToken(name, symbol string, initialLiquidity *big.Int, liquidityControllerOwner common.Address) {
 	c.builder.intent.Chains[c.chainIndex].CustomGasToken = state.CustomGasToken{
-		Name:             name,
-		Symbol:           symbol,
-		InitialLiquidity: (*hexutil.Big)(initialLiquidity),
+		Name:                     name,
+		Symbol:                   symbol,
+		InitialLiquidity:         (*hexutil.Big)(initialLiquidity),
+		LiquidityControllerOwner: liquidityControllerOwner,
 	}
 }
 

--- a/op-e2e/e2eutils/intentbuilder/builder_test.go
+++ b/op-e2e/e2eutils/intentbuilder/builder_test.go
@@ -2,7 +2,6 @@ package intentbuilder
 
 import (
 	"encoding/json"
-	"math/big"
 	"net/url"
 	"testing"
 
@@ -74,7 +73,7 @@ func TestBuilder(t *testing.T) {
 	require.Equal(t, eth.ChainIDFromUInt64(420), l2Config.ChainID())
 	l2Config.WithBlockTime(2)
 	l2Config.WithL1StartBlockHash(common.HexToHash("0x5678"))
-	l2Config.WithCustomGasToken(false, "", "", (*big.Int)(big.NewInt(0)))
+	l2Config.WithCustomGasToken("", "", nil, common.Address{})
 
 	// Test ContractsConfigurator methods
 	l2Config.WithL1ContractsLocator("http://l1.example.com")
@@ -176,9 +175,10 @@ func TestBuilder(t *testing.T) {
 				OperatorFeeScalar:        100,
 				OperatorFeeConstant:      200,
 				CustomGasToken: state.CustomGasToken{
-					Name:             "",
-					Symbol:           "",
-					InitialLiquidity: (*hexutil.Big)(big.NewInt(0)),
+					Name:                     "",
+					Symbol:                   "",
+					InitialLiquidity:         nil,
+					LiquidityControllerOwner: common.Address{},
 				},
 				DeployOverrides: map[string]any{
 					"l2BlockTime":                 uint64(2),

--- a/op-e2e/e2eutils/intentbuilder/builder_test.go
+++ b/op-e2e/e2eutils/intentbuilder/builder_test.go
@@ -176,7 +176,6 @@ func TestBuilder(t *testing.T) {
 				OperatorFeeScalar:        100,
 				OperatorFeeConstant:      200,
 				CustomGasToken: state.CustomGasToken{
-					Enabled:          false,
 					Name:             "",
 					Symbol:           "",
 					InitialLiquidity: (*hexutil.Big)(big.NewInt(0)),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors custom gas token config to be enabled by presence of name/symbol, adds LiquidityControllerOwner throughout, and updates deploy APIs and tests accordingly.
> 
> - **Custom Gas Token config**:
>   - Enablement inferred via `CustomGasToken.Name` and `Symbol`; remove explicit `Enabled` flag and boolean params.
>   - Add `CustomGasToken.LiquidityControllerOwner` with default to `Roles.L2ProxyAdminOwner` via `GetLiquidityControllerOwner`.
>   - `GetInitialLiquidity` defaults to `uint248.max` when enabled and unspecified.
>   - Validation in `ChainIntent.Check` updated for CGT fields.
> - **APIs updated**:
>   - `sysgo.WithCustomGasToken` and `intentbuilder.L2Configurator.WithCustomGasToken` signatures changed to `(name, symbol, initialLiquidity, liquidityControllerOwner)`.
>   - `genesis.GasTokenDeployConfig` now populated with `LiquidityControllerOwner` and inferred enablement.
>   - Interop L2 genesis (`interopgen.GenesisL2`) accepts and forwards `LiquidityControllerOwner`.
> - **Tests and configs**:
>   - Update e2e/acceptance tests and defaults to new CGT model and method signatures.
>   - Minor formatting/expectation tweaks in related tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dfd566c5be43a490d712b6fdd030f5604ea60aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->