### PR TITLE
test: fix go fuzz

### DIFF
--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -418,11 +418,6 @@ func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address,
 				},
 				UseRevenueShare:    true,
 				ChainFeesRecipient: common.HexToAddress("0xBcd4042DE499D14e55001CcbB24a551F3b954096"),
-				CustomGasToken: state.CustomGasToken{
-					Name:             "",
-					Symbol:           "",
-					InitialLiquidity: (*hexutil.Big)(big.NewInt(0)),
-				},
 				AdditionalDisputeGames: []state.AdditionalDisputeGame{
 					{
 						ChainProofParams: state.ChainProofParams{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the `CustomGasToken` configuration from the default chain intent in `op-e2e/config/init.go`.
> 
> - **Config (op-e2e)**:
>   - Remove `CustomGasToken` field (empty defaults) from `defaultIntent` chain configuration in `op-e2e/config/init.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 602a5b8318249fccc16e634448db76453772dc0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->