### PR TITLE
fix: sync develop

### DIFF
--- a/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
@@ -263,7 +263,7 @@ func TestL2CLSyncP2P(gt *testing.T) {
 	sys.L2CLA2.Stop()
 
 	logger.Info("Make sure verifier EL does not advance")
-	sys.L2ELA2.NotAdvanced(eth.Unsafe)
+	sys.L2ELA2.NotAdvanced(eth.Unsafe, 5)
 
 	logger.Info("Restart verifier CL")
 	sys.L2CLA2.Start()

--- a/op-acceptance-tests/tests/interop/sync/simple_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/simple_interop/interop_sync_test.go
@@ -31,8 +31,8 @@ func TestL2CLResync(gt *testing.T) {
 
 	logger.Info("Make sure L2ELs does not advance")
 	dsl.CheckAll(t,
-		sys.L2ELA.NotAdvancedFn(eth.Unsafe),
-		sys.L2ELB.NotAdvancedFn(eth.Unsafe),
+		sys.L2ELA.NotAdvancedFn(eth.Unsafe, 5),
+		sys.L2ELB.NotAdvancedFn(eth.Unsafe, 5),
 	)
 
 	logger.Info("Restart L2CL nodes")

--- a/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
@@ -70,7 +70,7 @@ func TestCLUnsafeNotRewoundOnInvalidDuringELSync(gt *testing.T) {
 	for _, gap := range []uint64{3, 5} {
 		targetNum := startNum + gap
 		sys.L2CLB.SignalTarget(sys.L2EL, targetNum)
-		sys.L2ELB.NotAdvanced(eth.Unsafe)
+		sys.L2ELB.NotAdvanced(eth.Unsafe, 5)
 		sys.L2ELB.UnsafeHead().NumEqualTo(startNum)
 		// Check FCU returns SYNCING
 		sys.L2ELB.ForkchoiceUpdate(sys.L2EL, targetNum, startNum, startNum, nil).Retry(attempts).ResultAllSyncing()
@@ -95,7 +95,7 @@ func TestCLUnsafeNotRewoundOnInvalidDuringELSync(gt *testing.T) {
 	require.True(ok)
 	sys.L2CLB.PostUnsafePayload(payload)
 	sys.L2CLB.NotAdvanced(types.LocalUnsafe, attempts)
-	sys.L2ELB.NotAdvanced(eth.Unsafe)
+	sys.L2ELB.NotAdvanced(eth.Unsafe, attempts)
 	// EL did not advance
 	sys.L2ELB.UnsafeHead().NumEqualTo(startNum)
 	// CL did not advance

--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -445,7 +445,7 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	sys.L2CLB.PostUnsafePayload(payload)
 	// ex) op-geth error msg: "ignoring bad block: invalid merkle root"
 	sys.L2CLB.NotAdvanced(types.LocalUnsafe, attempts)
-	sys.L2ELB.NotAdvanced(eth.Unsafe)
+	sys.L2ELB.NotAdvanced(eth.Unsafe, attempts)
 	// EL did not advance
 	sys.L2ELB.UnsafeHead().NumEqualTo(startNum + 1)
 	// CL did not advance
@@ -466,7 +466,7 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	sys.L2CLB.PostUnsafePayload(payload)
 	// ex) op-geth error msg: "ignoring bad block: links to previously rejected block"
 	sys.L2CLB.NotAdvanced(types.LocalUnsafe, attempts)
-	sys.L2ELB.NotAdvanced(eth.Unsafe)
+	sys.L2ELB.NotAdvanced(eth.Unsafe, attempts)
 	// EL did not advance
 	sys.L2ELB.UnsafeHead().NumEqualTo(startNum + 1)
 	// CL did not advance

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/bootstrap"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
@@ -33,6 +34,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
+	opbindings "github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -46,6 +48,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -722,6 +725,18 @@ func runEndToEndBootstrapAndApplyUpgradeTest(t *testing.T, afactsFS foundry.Stat
 	impls, err := bootstrap.Implementations(ctx, implementationsConfig)
 	require.NoError(t, err)
 
+	versionClient, err := ethclient.Dial(implementationsConfig.L1RPCUrl)
+	require.NoError(t, err)
+	defer versionClient.Close()
+
+	shouldUpgradeSuperchainConfig, err := needsSuperchainConfigUpgrade(
+		ctx,
+		versionClient,
+		implementationsConfig.SuperchainConfigProxy,
+		impls.SuperchainConfigImpl,
+	)
+	require.NoError(t, err)
+
 	// Now test the OPCM upgrade using the deployed impls.Opcm
 	t.Run("opcm upgrade test", func(t *testing.T) {
 		// Create script host for the upgrade
@@ -738,18 +753,22 @@ func runEndToEndBootstrapAndApplyUpgradeTest(t *testing.T, afactsFS foundry.Stat
 		)
 		require.NoError(t, err)
 
-		// First run upgradeSuperchainConfig because the version on the fork is < than that
-		// of the contracts-bedrock folder so upgrading directly would revert.
-		t.Run("upgrade superchain config", func(t *testing.T) {
-			upgradeConfig := embedded.UpgradeSuperchainConfigInput{
-				Prank:            superchainProxyAdminOwner,
-				Opcm:             impls.Opcm,
-				SuperchainConfig: implementationsConfig.SuperchainConfigProxy,
-			}
+		// Only run the superchain config upgrade if the live superchain config is behind the freshly deployed
+		// implementation. Running the script when versions match will revert and panic the test harness.
+		if shouldUpgradeSuperchainConfig {
+			t.Run("upgrade superchain config", func(t *testing.T) {
+				upgradeConfig := embedded.UpgradeSuperchainConfigInput{
+					Prank:            superchainProxyAdminOwner,
+					Opcm:             impls.Opcm,
+					SuperchainConfig: implementationsConfig.SuperchainConfigProxy,
+				}
 
-			err = embedded.UpgradeSuperchainConfig(host, upgradeConfig)
-			require.NoError(t, err, "Superchain config upgrade should succeed")
-		})
+				err = embedded.UpgradeSuperchainConfig(host, upgradeConfig)
+				require.NoError(t, err, "Superchain config upgrade should succeed")
+			})
+		} else {
+			t.Log("Skipping superchain config upgrade; onchain version is already up to date")
+		}
 
 		// Then run the OPCM upgrade
 		var cannonKonaPrestate common.Hash
@@ -775,6 +794,44 @@ func runEndToEndBootstrapAndApplyUpgradeTest(t *testing.T, afactsFS foundry.Stat
 			require.NoError(t, err, "OPCM upgrade should succeed")
 		})
 	})
+}
+
+func needsSuperchainConfigUpgrade(
+	ctx context.Context,
+	client *ethclient.Client,
+	currentProxy, targetImpl common.Address,
+) (bool, error) {
+	currentVersion, err := superchainConfigVersion(ctx, client, currentProxy)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch proxy superchain config version: %w", err)
+	}
+
+	targetVersion, err := superchainConfigVersion(ctx, client, targetImpl)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch implementation superchain config version: %w", err)
+	}
+
+	return currentVersion.LessThan(targetVersion), nil
+}
+
+func superchainConfigVersion(
+	ctx context.Context,
+	client *ethclient.Client,
+	addr common.Address,
+) (*semver.Version, error) {
+	contract, err := opbindings.NewSuperchainConfig(addr, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to bind superchain config at %s: %w", addr.Hex(), err)
+	}
+	versionStr, err := contract.Version(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read version from %s: %w", addr.Hex(), err)
+	}
+	version, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse version %q from %s: %w", versionStr, addr.Hex(), err)
+	}
+	return version, nil
 }
 
 func setupGenesisChain(t *testing.T, l1ChainID uint64) (deployer.ApplyPipelineOpts, *state.Intent, *state.State) {

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -120,7 +120,7 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 				ProtocolVersionsProxy:    superCfg.ProtocolVersionsAddr,
 				ProtocolVersionsImpl:     common.HexToAddress("0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C"),
 				SuperchainConfigProxy:    superCfg.SuperchainConfigAddr,
-				SuperchainConfigImpl:     common.HexToAddress("0xCe28685EB204186b557133766eCA00334EB441E4"),
+				SuperchainConfigImpl:     common.HexToAddress("0xb08Cc720F511062537ca78BdB0AE691F04F5a957"),
 			}
 
 			// Tagged locator will reuse the existing superchain and OPCM

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -83,11 +83,10 @@ func (el *L2ELNode) AdvancedFn(label eth.BlockLabel, block uint64) CheckFunc {
 	}
 }
 
-func (el *L2ELNode) NotAdvancedFn(label eth.BlockLabel) CheckFunc {
+func (el *L2ELNode) NotAdvancedFn(label eth.BlockLabel, attempts int) CheckFunc {
 	return func() error {
 		el.log.Info("expecting chain not to advance", "chain", el.inner.ChainID(), "label", label)
 		initial := el.BlockRefByLabel(label)
-		attempts := 5 // check few times to make sure head does not advance
 		for range attempts {
 			time.Sleep(2 * time.Second)
 			head := el.BlockRefByLabel(label)
@@ -167,8 +166,8 @@ func (el *L2ELNode) Reached(label eth.BlockLabel, block uint64, attempts int) {
 	el.require.NoError(el.ReachedFn(label, block, attempts)())
 }
 
-func (el *L2ELNode) NotAdvanced(label eth.BlockLabel) {
-	el.require.NoError(el.NotAdvancedFn(label)())
+func (el *L2ELNode) NotAdvanced(label eth.BlockLabel, attempts int) {
+	el.require.NoError(el.NotAdvancedFn(label, attempts)())
 }
 
 func (el *L2ELNode) ReorgTriggered(target eth.L2BlockRef, attempts int) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Require an explicit attempts parameter for L2EL NotAdvanced and update tests; add onchain version check to conditionally skip SuperchainConfig upgrade in deployer upgrade tests.
> 
> - **DSL / API**:
>   - `L2ELNode.NotAdvancedFn` now requires `attempts` and `NotAdvanced` forwards it; removed internal default.
> - **Tests**:
>   - Update interop and EL sync tests to pass attempts to `NotAdvanced`/`NotAdvancedFn`.
>   - Minor expected address casing fix in `pipeline/init_test.go`.
> - **Deployer (integration tests)**:
>   - Add version-gated SuperchainConfig upgrade in `runEndToEndBootstrapAndApplyUpgradeTest`.
>   - Introduce `needsSuperchainConfigUpgrade` and `superchainConfigVersion` (via `op-e2e` bindings + `semver`) and wire an `ethclient` to read versions.
>   - Skip SuperchainConfig upgrade when versions match; proceed with OPCM upgrade as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67705cccf0bdff76e67064a7c684d1a027b91a27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->