### PR TITLE
feat: add L2 Contracts Manager

### DIFF
--- a/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
+++ b/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
+import { IL1ChugSplashProxy } from "interfaces/legacy/IL1ChugSplashProxy.sol";
+import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
+import { Constants } from "src/libraries/Constants.sol";
+
+/// @notice Base contract for L2 Contracts Manager, responsible for orchestrating the upgrades
+///         of the L2 contracts during hardforks.
+abstract contract L2ContractsManager {
+    /// @notice Struct representing the full configuration for an upgrade.
+    ///         Relies on specific L2ContractsManager contracts interpretation of the network config required.
+    /// @param networkConfig The network specific configuration.
+    struct FullConfig {
+        bytes networkConfig;
+    }
+
+    /// @notice Executes the NUT with after hooks.
+    function upgrade() external {
+        FullConfig memory _networkConfig = _gatherNetworkConfig();
+        _upgrade(_networkConfig);
+        _afterUpgrade();
+    }
+
+    /// @notice Gather the network specific configuration.
+    function _gatherNetworkConfig() internal virtual returns (FullConfig memory);
+
+    /// @notice Hook called after execution.
+    function _afterUpgrade() internal virtual;
+
+    /// @notice Performs the proxy upgrades logic.
+    function _upgrade(FullConfig memory _networkConfig) internal virtual { }
+}

--- a/packages/contracts-bedrock/src/L2/XForkContractsManager.sol
+++ b/packages/contracts-bedrock/src/L2/XForkContractsManager.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Contracts
+import { L2ContractsManager } from "src/L2/L2ContractsManager.sol";
+
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// Interfaces
+import { IProxy } from "interfaces/universal/IProxy.sol";
+
+/// @title XForkContractsManager
+/// @notice The XForkContractsManager is responsible for orquestrating the upgrades of the L2 contracts during xFork
+/// hardforks.
+contract XForkContractsManager is L2ContractsManager {
+    /// @notice Configuration for all L2 predeploy implementation addresses.
+    /// @param legacyMessagePasserImplementation Implementation for LegacyMessagePasser.
+    /// @param deployerWhitelistImplementation Implementation for DeployerWhitelist.
+    /// @param l2CrossDomainMessengerImplementation Implementation for L2CrossDomainMessenger.
+    /// @param gasPriceOracleImplementation Implementation for GasPriceOracle.
+    /// @param l2StandardBridgeImplementation Implementation for L2StandardBridge.
+    /// @param sequencerFeeWalletImplementation Implementation for SequencerFeeWallet.
+    /// @param optimismMintableERC20FactoryImplementation Implementation for OptimismMintableERC20Factory.
+    /// @param l1BlockNumberImplementation Implementation for L1BlockNumber.
+    /// @param l2ERC721BridgeImplementation Implementation for L2ERC721Bridge.
+    /// @param l1BlockAttributesImplementation Implementation for L1Block.
+    /// @param l2ToL1MessagePasserImplementation Implementation for L2ToL1MessagePasser.
+    /// @param optimismMintableERC721FactoryImplementation Implementation for OptimismMintableERC721Factory.
+    /// @param baseFeeVaultImplementation Implementation for BaseFeeVault.
+    /// @param l1FeeVaultImplementation Implementation for L1FeeVault.
+    /// @param operatorFeeVaultImplementation Implementation for OperatorFeeVault.
+    /// @param schemaRegistryImplementation Implementation for SchemaRegistry.
+    /// @param easImplementation Implementation for EAS.
+    struct Input {
+        address legacyMessagePasserImplementation;
+        address deployerWhitelistImplementation;
+        address l2CrossDomainMessengerImplementation;
+        address gasPriceOracleImplementation;
+        address l2StandardBridgeImplementation;
+        address sequencerFeeWalletImplementation;
+        address optimismMintableERC20FactoryImplementation;
+        address l1BlockNumberImplementation;
+        address l2ERC721BridgeImplementation;
+        address l1BlockAttributesImplementation;
+        address l2ToL1MessagePasserImplementation;
+        address optimismMintableERC721FactoryImplementation;
+        address baseFeeVaultImplementation;
+        address l1FeeVaultImplementation;
+        address operatorFeeVaultImplementation;
+        address schemaRegistryImplementation;
+        address easImplementation;
+    }
+
+    /// @notice Implementation address for LegacyMessagePasser.
+    address public immutable LEGACY_MESSAGE_PASSER_IMPLEMENTATION;
+
+    /// @notice Implementation address for DeployerWhitelist.
+    address public immutable DEPLOYER_WHITELIST_IMPLEMENTATION;
+
+    /// @notice Implementation address for L2CrossDomainMessenger.
+    address public immutable L2_CROSS_DOMAIN_MESSENGER_IMPLEMENTATION;
+
+    /// @notice Implementation address for GasPriceOracle.
+    address public immutable GAS_PRICE_ORACLE_IMPLEMENTATION;
+
+    /// @notice Implementation address for L2StandardBridge.
+    address public immutable L2_STANDARD_BRIDGE_IMPLEMENTATION;
+
+    /// @notice Implementation address for SequencerFeeWallet.
+    address public immutable SEQUENCER_FEE_WALLET_IMPLEMENTATION;
+
+    /// @notice Implementation address for OptimismMintableERC20Factory.
+    address public immutable OPTIMISM_MINTABLE_ERC20_FACTORY_IMPLEMENTATION;
+
+    /// @notice Implementation address for L1BlockNumber.
+    address public immutable L1_BLOCK_NUMBER_IMPLEMENTATION;
+
+    /// @notice Implementation address for L2ERC721Bridge.
+    address public immutable L2_ERC721_BRIDGE_IMPLEMENTATION;
+
+    /// @notice Implementation address for L1BlockAttributes.
+    address public immutable L1_BLOCK_ATTRIBUTES_IMPLEMENTATION;
+
+    /// @notice Implementation address for L2ToL1MessagePasser.
+    address public immutable L2_TO_L1_MESSAGE_PASSER_IMPLEMENTATION;
+
+    /// @notice Implementation address for OptimismMintableERC721Factory.
+    address public immutable OPTIMISM_MINTABLE_ERC721_FACTORY_IMPLEMENTATION;
+
+    /// @notice Implementation address for BaseFeeVault.
+    address public immutable BASE_FEE_VAULT_IMPLEMENTATION;
+
+    /// @notice Implementation address for L1FeeVault.
+    address public immutable L1_FEE_VAULT_IMPLEMENTATION;
+
+    /// @notice Implementation address for OperatorFeeVault.
+    address public immutable OPERATOR_FEE_VAULT_IMPLEMENTATION;
+
+    /// @notice Implementation address for SchemaRegistry.
+    address public immutable SCHEMA_REGISTRY_IMPLEMENTATION;
+
+    /// @notice Implementation address for EAS.
+    address public immutable EAS_IMPLEMENTATION;
+
+    /// @notice Constructs the XForkContractsManager with implementation addresses.
+    /// @param _input Configuration containing all implementation addresses.
+    constructor(Input memory _input) {
+        LEGACY_MESSAGE_PASSER_IMPLEMENTATION = _input.legacyMessagePasserImplementation;
+        DEPLOYER_WHITELIST_IMPLEMENTATION = _input.deployerWhitelistImplementation;
+        L2_CROSS_DOMAIN_MESSENGER_IMPLEMENTATION = _input.l2CrossDomainMessengerImplementation;
+        GAS_PRICE_ORACLE_IMPLEMENTATION = _input.gasPriceOracleImplementation;
+        L2_STANDARD_BRIDGE_IMPLEMENTATION = _input.l2StandardBridgeImplementation;
+        SEQUENCER_FEE_WALLET_IMPLEMENTATION = _input.sequencerFeeWalletImplementation;
+        OPTIMISM_MINTABLE_ERC20_FACTORY_IMPLEMENTATION = _input.optimismMintableERC20FactoryImplementation;
+        L1_BLOCK_NUMBER_IMPLEMENTATION = _input.l1BlockNumberImplementation;
+        L2_ERC721_BRIDGE_IMPLEMENTATION = _input.l2ERC721BridgeImplementation;
+        L1_BLOCK_ATTRIBUTES_IMPLEMENTATION = _input.l1BlockAttributesImplementation;
+        L2_TO_L1_MESSAGE_PASSER_IMPLEMENTATION = _input.l2ToL1MessagePasserImplementation;
+        OPTIMISM_MINTABLE_ERC721_FACTORY_IMPLEMENTATION = _input.optimismMintableERC721FactoryImplementation;
+        BASE_FEE_VAULT_IMPLEMENTATION = _input.baseFeeVaultImplementation;
+        L1_FEE_VAULT_IMPLEMENTATION = _input.l1FeeVaultImplementation;
+        OPERATOR_FEE_VAULT_IMPLEMENTATION = _input.operatorFeeVaultImplementation;
+        SCHEMA_REGISTRY_IMPLEMENTATION = _input.schemaRegistryImplementation;
+        EAS_IMPLEMENTATION = _input.easImplementation;
+    }
+
+    /// @notice Hook called before execution.
+    function _gatherNetworkConfig() internal override returns (L2ContractsManager.FullConfig memory) { }
+
+    /// @notice Hook called after execution.
+    function _afterUpgrade() internal override { }
+
+    /// @notice Performs upgrades for all L2 predeploy contracts.
+    function _upgrade(L2ContractsManager.FullConfig memory) internal override {
+        IProxy(payable(Predeploys.LEGACY_MESSAGE_PASSER)).upgradeTo(LEGACY_MESSAGE_PASSER_IMPLEMENTATION);
+        IProxy(payable(Predeploys.DEPLOYER_WHITELIST)).upgradeTo(DEPLOYER_WHITELIST_IMPLEMENTATION);
+        IProxy(payable(Predeploys.L2_CROSS_DOMAIN_MESSENGER)).upgradeTo(L2_CROSS_DOMAIN_MESSENGER_IMPLEMENTATION);
+        IProxy(payable(Predeploys.GAS_PRICE_ORACLE)).upgradeTo(GAS_PRICE_ORACLE_IMPLEMENTATION);
+        IProxy(payable(Predeploys.L2_STANDARD_BRIDGE)).upgradeTo(L2_STANDARD_BRIDGE_IMPLEMENTATION);
+        IProxy(payable(Predeploys.SEQUENCER_FEE_WALLET)).upgradeTo(SEQUENCER_FEE_WALLET_IMPLEMENTATION);
+        IProxy(payable(Predeploys.OPTIMISM_MINTABLE_ERC20_FACTORY)).upgradeTo(
+            OPTIMISM_MINTABLE_ERC20_FACTORY_IMPLEMENTATION
+        );
+        IProxy(payable(Predeploys.L1_BLOCK_NUMBER)).upgradeTo(L1_BLOCK_NUMBER_IMPLEMENTATION);
+        IProxy(payable(Predeploys.L2_ERC721_BRIDGE)).upgradeTo(L2_ERC721_BRIDGE_IMPLEMENTATION);
+        IProxy(payable(Predeploys.L1_BLOCK_ATTRIBUTES)).upgradeTo(L1_BLOCK_ATTRIBUTES_IMPLEMENTATION);
+        IProxy(payable(Predeploys.L2_TO_L1_MESSAGE_PASSER)).upgradeTo(L2_TO_L1_MESSAGE_PASSER_IMPLEMENTATION);
+        IProxy(payable(Predeploys.OPTIMISM_MINTABLE_ERC721_FACTORY)).upgradeTo(
+            OPTIMISM_MINTABLE_ERC721_FACTORY_IMPLEMENTATION
+        );
+        IProxy(payable(Predeploys.BASE_FEE_VAULT)).upgradeTo(BASE_FEE_VAULT_IMPLEMENTATION);
+        IProxy(payable(Predeploys.L1_FEE_VAULT)).upgradeTo(L1_FEE_VAULT_IMPLEMENTATION);
+        IProxy(payable(Predeploys.OPERATOR_FEE_VAULT)).upgradeTo(OPERATOR_FEE_VAULT_IMPLEMENTATION);
+        IProxy(payable(Predeploys.SCHEMA_REGISTRY)).upgradeTo(SCHEMA_REGISTRY_IMPLEMENTATION);
+        IProxy(payable(Predeploys.EAS)).upgradeTo(EAS_IMPLEMENTATION);
+    }
+}

--- a/packages/contracts-bedrock/test/L2/XForkContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L2/XForkContractsManager.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+import { XForkContractsManager } from "src/L2/XForkContractsManager.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+/// @title XForkContractsManager_TestInit
+/// @notice Initializes `xForkContractsManager` for testing.
+contract XForkContractsManager_TestInit is Test {
+    XForkContractsManager internal xForkContractsManager;
+
+    function setUp() public {
+        xForkContractsManager = new XForkContractsManager(_getInput());
+    }
+
+    function _getInput() internal returns (XForkContractsManager.Input memory) {
+        return XForkContractsManager.Input({
+            legacyMessagePasserImplementation: makeAddr("legacyMessagePasserImplementation"),
+            deployerWhitelistImplementation: makeAddr("deployerWhitelistImplementation"),
+            l2CrossDomainMessengerImplementation: makeAddr("l2CrossDomainMessengerImplementation"),
+            gasPriceOracleImplementation: makeAddr("gasPriceOracleImplementation"),
+            l2StandardBridgeImplementation: makeAddr("l2StandardBridgeImplementation"),
+            sequencerFeeWalletImplementation: makeAddr("sequencerFeeWalletImplementation"),
+            optimismMintableERC20FactoryImplementation: makeAddr("optimismMintableERC20FactoryImplementation"),
+            l1BlockNumberImplementation: makeAddr("l1BlockNumberImplementation"),
+            l2ERC721BridgeImplementation: makeAddr("l2ERC721BridgeImplementation"),
+            l1BlockAttributesImplementation: makeAddr("l1BlockAttributesImplementation"),
+            l2ToL1MessagePasserImplementation: makeAddr("l2ToL1MessagePasserImplementation"),
+            optimismMintableERC721FactoryImplementation: makeAddr("optimismMintableERC721FactoryImplementation"),
+            baseFeeVaultImplementation: makeAddr("baseFeeVaultImplementation"),
+            l1FeeVaultImplementation: makeAddr("l1FeeVaultImplementation"),
+            operatorFeeVaultImplementation: makeAddr("operatorFeeVaultImplementation"),
+            schemaRegistryImplementation: makeAddr("schemaRegistryImplementation"),
+            easImplementation: makeAddr("easImplementation")
+        });
+    }
+}
+
+/// @title XForkContractsManager_Constructor_Test
+/// @notice Tests the constructor of the `XForkContractsManager` contract.
+contract XForkContractsManager_Constructor_Test is XForkContractsManager_TestInit {
+    /// @notice Tests that the constructor sets the implementation addresses correctly.
+    function test_constructor_succeeds() external {
+        XForkContractsManager.Input memory input = _getInput();
+
+        assertEq(xForkContractsManager.LEGACY_MESSAGE_PASSER_IMPLEMENTATION(), input.legacyMessagePasserImplementation);
+        assertEq(xForkContractsManager.DEPLOYER_WHITELIST_IMPLEMENTATION(), input.deployerWhitelistImplementation);
+        assertEq(
+            xForkContractsManager.L2_CROSS_DOMAIN_MESSENGER_IMPLEMENTATION(), input.l2CrossDomainMessengerImplementation
+        );
+        assertEq(xForkContractsManager.GAS_PRICE_ORACLE_IMPLEMENTATION(), input.gasPriceOracleImplementation);
+        assertEq(xForkContractsManager.L2_STANDARD_BRIDGE_IMPLEMENTATION(), input.l2StandardBridgeImplementation);
+        assertEq(xForkContractsManager.SEQUENCER_FEE_WALLET_IMPLEMENTATION(), input.sequencerFeeWalletImplementation);
+        assertEq(
+            xForkContractsManager.OPTIMISM_MINTABLE_ERC20_FACTORY_IMPLEMENTATION(),
+            input.optimismMintableERC20FactoryImplementation
+        );
+        assertEq(xForkContractsManager.L1_BLOCK_NUMBER_IMPLEMENTATION(), input.l1BlockNumberImplementation);
+        assertEq(xForkContractsManager.L2_ERC721_BRIDGE_IMPLEMENTATION(), input.l2ERC721BridgeImplementation);
+        assertEq(xForkContractsManager.L1_BLOCK_ATTRIBUTES_IMPLEMENTATION(), input.l1BlockAttributesImplementation);
+        assertEq(
+            xForkContractsManager.L2_TO_L1_MESSAGE_PASSER_IMPLEMENTATION(), input.l2ToL1MessagePasserImplementation
+        );
+        assertEq(
+            xForkContractsManager.OPTIMISM_MINTABLE_ERC721_FACTORY_IMPLEMENTATION(),
+            input.optimismMintableERC721FactoryImplementation
+        );
+        assertEq(xForkContractsManager.BASE_FEE_VAULT_IMPLEMENTATION(), input.baseFeeVaultImplementation);
+        assertEq(xForkContractsManager.L1_FEE_VAULT_IMPLEMENTATION(), input.l1FeeVaultImplementation);
+        assertEq(xForkContractsManager.OPERATOR_FEE_VAULT_IMPLEMENTATION(), input.operatorFeeVaultImplementation);
+        assertEq(xForkContractsManager.SCHEMA_REGISTRY_IMPLEMENTATION(), input.schemaRegistryImplementation);
+        assertEq(xForkContractsManager.EAS_IMPLEMENTATION(), input.easImplementation);
+    }
+}
+
+/// @title XForkContractsManager_TestUpgrade
+/// @notice Tests the upgrade function of the `XForkContractsManager` contract.
+contract XForkContractsManager_TestUpgrade is XForkContractsManager_TestInit {
+    /// @notice Tests that the upgrade function successfully upgrades all proxies.
+    function test_upgrade_succeeds() public {
+        XForkContractsManager.Input memory input = _getInput();
+
+        // For each implementation, we expect the proxy to be upgraded to the new implementation.
+        _expectUpgradeTo(Predeploys.LEGACY_MESSAGE_PASSER, input.legacyMessagePasserImplementation);
+        _expectUpgradeTo(Predeploys.DEPLOYER_WHITELIST, input.deployerWhitelistImplementation);
+        _expectUpgradeTo(Predeploys.L2_CROSS_DOMAIN_MESSENGER, input.l2CrossDomainMessengerImplementation);
+        _expectUpgradeTo(Predeploys.GAS_PRICE_ORACLE, input.gasPriceOracleImplementation);
+        _expectUpgradeTo(Predeploys.L2_STANDARD_BRIDGE, input.l2StandardBridgeImplementation);
+        _expectUpgradeTo(Predeploys.SEQUENCER_FEE_WALLET, input.sequencerFeeWalletImplementation);
+        _expectUpgradeTo(Predeploys.OPTIMISM_MINTABLE_ERC20_FACTORY, input.optimismMintableERC20FactoryImplementation);
+        _expectUpgradeTo(Predeploys.L1_BLOCK_NUMBER, input.l1BlockNumberImplementation);
+        _expectUpgradeTo(Predeploys.L2_ERC721_BRIDGE, input.l2ERC721BridgeImplementation);
+        _expectUpgradeTo(Predeploys.L1_BLOCK_ATTRIBUTES, input.l1BlockAttributesImplementation);
+        _expectUpgradeTo(Predeploys.L2_TO_L1_MESSAGE_PASSER, input.l2ToL1MessagePasserImplementation);
+        _expectUpgradeTo(Predeploys.OPTIMISM_MINTABLE_ERC721_FACTORY, input.optimismMintableERC721FactoryImplementation);
+        _expectUpgradeTo(Predeploys.BASE_FEE_VAULT, input.baseFeeVaultImplementation);
+        _expectUpgradeTo(Predeploys.L1_FEE_VAULT, input.l1FeeVaultImplementation);
+        _expectUpgradeTo(Predeploys.OPERATOR_FEE_VAULT, input.operatorFeeVaultImplementation);
+        _expectUpgradeTo(Predeploys.SCHEMA_REGISTRY, input.schemaRegistryImplementation);
+        _expectUpgradeTo(Predeploys.EAS, input.easImplementation);
+
+        // Perform the actual upgrade.
+        xForkContractsManager.upgrade();
+    }
+
+    /// @notice Internal helper to expect an upgrade to a specific implementation.
+    /// @param proxy The proxy address to expect the upgrade to.
+    /// @param implementation The implementation address to expect the upgrade to.
+    function _expectUpgradeTo(address proxy, address implementation) internal {
+        vm.mockCall(proxy, abi.encodeCall(IProxy.upgradeTo, (implementation)), abi.encode(bytes("")));
+        vm.expectCall(proxy, abi.encodeCall(IProxy.upgradeTo, (implementation)));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a base L2 contracts manager and an xFork implementation that upgrades all L2 predeploy proxies, with constructor and upgrade tests.
> 
> - **Contracts**:
>   - Add `packages/contracts-bedrock/src/L2/L2ContractsManager.sol`: abstract manager with `upgrade()` flow and hooks (`_gatherNetworkConfig`, `_afterUpgrade`, `_upgrade`).
>   - Add `packages/contracts-bedrock/src/L2/XForkContractsManager.sol`: implements manager for xFork; accepts `Input` of implementation addresses (stored as `immutable`s) and upgrades all L2 predeploy proxies via `IProxy.upgradeTo` (e.g., `LEGACY_MESSAGE_PASSER`, `L2_CROSS_DOMAIN_MESSENGER`, `GAS_PRICE_ORACLE`, bridges, fee vaults, registries).
> - **Tests**:
>   - Add `packages/contracts-bedrock/test/L2/XForkContractsManager.t.sol`: verifies constructor sets immutables and that `upgrade()` triggers expected `upgradeTo` calls for each predeploy (using `vm.mockCall`/`vm.expectCall`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb5aded91a5dcc867b17100a74d46408b0c56522. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->