### PR TITLE
test: fix cgt with revenue sharing tests

### DIFF
--- a/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
@@ -13,6 +13,7 @@ import { ReentrantMockFeeVault } from "test/mocks/ReentrantMockFeeVault.sol";
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Types } from "src/libraries/Types.sol";
+import { DevFeatures } from "src/libraries/DevFeatures.sol";
 
 // Interfaces
 import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";
@@ -41,6 +42,10 @@ contract FeeSplitter_TestInit is CommonTest {
 
     /// @notice Test setup.
     function setUp() public virtual override {
+        // Resolve features and skip whole test suite if custom gas token is enabled
+        resolveFeaturesFromEnv();
+        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
+
         // Enable revenue sharing before calling parent setUp
         super.enableRevenueShare();
         super.setUp();

--- a/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
@@ -26,6 +26,10 @@ contract L1Withdrawer_TestInit is CommonTest {
 
     /// @notice Test setup.
     function setUp() public virtual override {
+        // Resolve features and skip whole test suite if custom gas token is enabled
+        resolveFeaturesFromEnv();
+        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
+
         // Enable revenue sharing before calling parent setUp
         super.enableRevenueShare();
         super.setUp();
@@ -76,8 +80,6 @@ contract L1Withdrawer_Receive_Test is L1Withdrawer_TestInit {
     }
 
     function testFuzz_receive_atOrAboveThreshold_succeeds(uint256 _sendAmount) external {
-        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
-
         _sendAmount = bound(_sendAmount, minWithdrawalAmount, type(uint256).max);
 
         vm.deal(address(this), _sendAmount);
@@ -105,8 +107,6 @@ contract L1Withdrawer_Receive_Test is L1Withdrawer_TestInit {
     }
 
     function testFuzz_receive_multipleDeposits_succeeds(uint256 _firstAmount, uint256 _secondAmount) external {
-        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
-
         // First amount should not exceed minWithdrawalAmount (so it doesn't trigger withdrawal)
         _firstAmount = bound(_firstAmount, 0, minWithdrawalAmount - 1);
 

--- a/packages/contracts-bedrock/test/L2/RevenueSharingIntegration.t.sol
+++ b/packages/contracts-bedrock/test/L2/RevenueSharingIntegration.t.sol
@@ -26,6 +26,10 @@ contract RevenueSharingIntegration_Test is CommonTest {
     event FundsReceived(address indexed sender, uint256 amount, uint256 newBalance);
 
     function setUp() public override {
+        // Resolve features and skip whole test suite if custom gas token is enabled
+        resolveFeaturesFromEnv();
+        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
+
         // Enable revenue sharing before calling parent setUp
         super.enableRevenueShare();
         super.setUp();
@@ -135,8 +139,6 @@ contract RevenueSharingIntegration_Test is CommonTest {
     // | 0/0/0/0          | 2.5          | 205.55       | Accumulating                   |
     // |__________________|______________|______________|________________________________|
     function test_revenueSharing_fullFlow_succeeds() public {
-        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
-
         // Configure vaults to withdraw to FeeSplitter
         _configureVaultsForFeeSplitter();
 
@@ -256,8 +258,6 @@ contract RevenueSharingIntegration_Test is CommonTest {
     )
         public
     {
-        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
-
         // Bound inputs to prevent overflow and ensure reasonable test ranges
         _sequencerFees = bound(_sequencerFees, 0, 100 ether);
         _baseFees = bound(_baseFees, 0, 100 ether);

--- a/packages/contracts-bedrock/test/L2/SuperchainRevSharesCalculator.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainRevSharesCalculator.t.sol
@@ -9,6 +9,7 @@ import { ISharesCalculator } from "interfaces/L2/ISharesCalculator.sol";
 import { ISuperchainRevSharesCalculator } from "interfaces/L2/ISuperchainRevSharesCalculator.sol";
 
 // Libraries
+import { DevFeatures } from "src/libraries/DevFeatures.sol";
 
 /// @notice Base setup contract for SuperchainRevSharesCalculator tests.
 contract SuperchainRevSharesCalculator_TestInit is CommonTest {
@@ -23,6 +24,10 @@ contract SuperchainRevSharesCalculator_TestInit is CommonTest {
     event RemainderRecipientUpdated(address indexed oldRemainderRecipient, address indexed newRemainderRecipient);
 
     function setUp() public virtual override {
+        // Resolve features and skip whole test suite if custom gas token is enabled
+        resolveFeaturesFromEnv();
+        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
+
         // Enable revenue sharing before calling parent setUp
         super.enableRevenueShare();
         super.setUp();

--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -215,10 +215,12 @@ contract FeeSplitter_Invariant is CommonTest {
 
     /// @notice Setup: enable the revenue share, deploy handlers and target them.
     function setUp() public override {
+        // Resolve features and skip whole test suite if custom gas token is enabled
+        resolveFeaturesFromEnv();
+        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
+
         super.enableRevenueShare();
         super.setUp();
-
-        skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN);
 
         disburser = new FeeSplitter_Disburser(vm, feeSplitter, l1Withdrawer);
         preconditions = new FeeSplitter_Preconditions();

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -427,7 +427,7 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
     }
 
     /// @notice Tests that enabling both CGT and revenue share reverts.
-    function test_cgt_and_revenueShare_reverts() external {
+    function test_cgt_revenueShare_reverts() external {
         _setInputCGTEnabled();
         input.useRevenueShare = true;
         vm.expectRevert("FeeVault: custom gas token and revenue share cannot be enabled together");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Gates revenue-sharing test suites behind CUSTOM_GAS_TOKEN feature flag, removes redundant skips, and renames a CGT/revenue-share test.
> 
> - **Tests**:
>   - Add suite-level feature gating in `setUp()` using `resolveFeaturesFromEnv()` and `skipIfDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN)` across:
>     - `test/L2/FeeSplitter.t.sol`
>     - `test/L2/L1Withdrawer.t.sol`
>     - `test/L2/RevenueSharingIntegration.t.sol`
>     - `test/L2/SuperchainRevSharesCalculator.t.sol`
>     - `test/invariants/FeeSplit.t.sol`
>   - Remove redundant per-test `skipIfDevFeatureEnabled` calls now covered by suite-level gating.
>   - Import `DevFeatures` where required.
>   - Rename `test_cgt_and_revenueShare_reverts` → `test_cgt_revenueShare_reverts` in `test/scripts/L2Genesis.t.sol`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30577b136201d69536808cce411ad4507f998508. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->