### PR TITLE
fix: sync

### DIFF
--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -30,7 +30,6 @@ cannon64-impl:
 # Each embed is suffixed with the latest `StateVersion` number corresponding to the target VM and architecture.
 cannon-embeds: cannon64-impl
 	# 64-bit multithreaded vm
-	@cp bin/cannon64-impl ./multicannon/embeds/cannon-7
 	@cp bin/cannon64-impl ./multicannon/embeds/cannon-8
 
 cannon: cannon-embeds

--- a/cannon/multicannon/exec.go
+++ b/cannon/multicannon/exec.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
+	"github.com/urfave/cli/v2"
 )
 
 // use the all directive to ensure the .gitkeep file is retained and avoid compiler errors
@@ -31,14 +32,12 @@ func ExecuteCannon(ctx context.Context, args []string, ver versions.StateVersion
 	}
 	cannonProgramPath, err := extractTempFile(filepath.Base(cannonProgramName), cannonProgramBin)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error extracting %s: %v\n", cannonProgramName, err)
-		os.Exit(1)
+		return cli.Exit(fmt.Sprintf("Error extracting %s: %v\n", cannonProgramName, err), 1)
 	}
 	defer os.Remove(cannonProgramPath)
 
 	if err := os.Chmod(cannonProgramPath, 0755); err != nil {
-		fmt.Fprintf(os.Stderr, "Error setting execute permission for %s: %v\n", cannonProgramName, err)
-		os.Exit(1)
+		return cli.Exit(fmt.Sprintf("Error setting execute permission for %s: %v\n", cannonProgramName, err), 1)
 	}
 
 	// nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
@@ -52,8 +51,7 @@ func ExecuteCannon(ctx context.Context, args []string, ver versions.StateVersion
 	if err := cmd.Wait(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			// relay exit code to the parent process
-			os.Exit(exitErr.ExitCode())
+			return cli.Exit("", exitErr.ExitCode())
 		} else {
 			return fmt.Errorf("failed to wait for cannon-impl program: %w", err)
 		}

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -217,6 +217,20 @@ var (
 		Value:    time.Second * 10,
 		Category: RollupCategory,
 	}
+	L2UnsafeOnly = &cli.BoolFlag{
+		Name:     "l2.unsafe-only",
+		Usage:    "Disable derivation",
+		EnvVars:  prefixEnvVars("L2_UNSAFE_ONLY"),
+		Category: RollupCategory,
+		Required: false,
+	}
+	L2FollowSource = &cli.StringFlag{
+		Name:     "l2.follow.source",
+		Usage:    "Address of L2 EL RPC HTTP endpoint to fetch safe/finalized blocks",
+		EnvVars:  prefixEnvVars("L2_FOLLOW_SOURCE"),
+		Category: RollupCategory,
+		Required: false,
+	}
 	VerifierL1Confs = &cli.Uint64Flag{
 		Name:     "verifier.l1-confs",
 		Usage:    "Number of L1 blocks to keep distance from the L1 head before deriving L2 data from. Reorgs are supported, but may be slow to perform.",
@@ -486,6 +500,8 @@ var optionalFlags = []cli.Flag{
 	L1ChainConfig,
 	L2EngineKind,
 	L2EngineRpcTimeout,
+	L2UnsafeOnly,
+	L2FollowSource,
 	InteropRPCAddr,
 	InteropRPCPort,
 	InteropJWTSecret,

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -201,8 +201,15 @@ type InitializationOverrides struct {
 // some later initialization steps depend on the node being partially initialized with other components,
 // so order is important to ensure that all resources are available when needed.
 func (n *OpNode) init(ctx context.Context, cfg *config.Config, overrides InitializationOverrides) error {
-
 	n.log.Info("Initializing rollup node", "version", n.appVersion)
+	safe := "enabled"
+	if cfg.Sync.UnsafeOnly {
+		safe = cfg.Sync.L2FollowSourceEndpoint
+		if safe == "" {
+			safe = "disabled"
+		}
+	}
+	n.log.Info("Safety levels", "unsafe", "enabled", "safe", safe)
 
 	var err error
 

--- a/op-node/rollup/sync/config.go
+++ b/op-node/rollup/sync/config.go
@@ -74,4 +74,11 @@ type Config struct {
 	SkipSyncStartCheck bool `json:"skip_sync_start_check"`
 
 	SupportsPostFinalizationELSync bool `json:"supports_post_finalization_elsync"`
+
+	UnsafeOnly             bool   `json:"unsafe_only"`
+	L2FollowSourceEndpoint string `json:"l2_follow_source_endpoint"`
+}
+
+func (c *Config) L2FollowSourceEnabled() bool {
+	return c.L2FollowSourceEndpoint != ""
 }

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -340,25 +340,49 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 	} else if ctx.IsSet(flags.L2EngineSyncEnabled.Name) {
 		log.Error("l2.engine-sync is deprecated and will be removed in a future release. Use --syncmode=execution-layer instead.")
 	}
+	unsafeOnly := ctx.Bool(flags.L2UnsafeOnly.Name)
+	l2FollowSourceEndpoint := ctx.String(flags.L2FollowSource.Name)
+	if !unsafeOnly && l2FollowSourceEndpoint != "" {
+		return nil, errors.New("cannot follow external safe/finalized with derivation enabled (--l2.unsafe-only=false): " +
+			"Either remove --l2.follow.source or set --l2.unsafe-only=true to disable derivation")
+	}
+	rrSyncEnabled := ctx.Bool(flags.SyncModeReqRespFlag.Name)
 	// p2p.sync.req-resp=false && syncmode.req-resp=true is not allowed
-	if !ctx.Bool(flags.SyncReqRespName) && ctx.Bool(flags.SyncModeReqRespFlag.Name) {
+	if !ctx.Bool(flags.SyncReqRespName) && rrSyncEnabled {
 		return nil, errors.New("cannot set --p2p.sync.req-resp=false and --syncmode.req-resp=true at the same time")
 	}
 	mode, err := sync.StringToMode(ctx.String(flags.SyncModeFlag.Name))
 	if err != nil {
 		return nil, err
 	}
-
+	isSequencer := ctx.Bool(flags.SequencerEnabledFlag.Name)
+	if unsafeOnly && !isSequencer {
+		// The verifier node initially gains payloads from the sequencer via CLP2P.
+		// To sync to the chain tip, the verifier must close the gap between its current
+		// unsafe view and the sequencer's latest unsafe payloads.
+		// With derivation disabled, the node can only rely on RR Sync or EL Sync to close this gap.
+		if rrSyncEnabled {
+			// Allowing RR Sync technically works, but it is impractical for a verifier to
+			// rely solely on RR Syncing - bootstrapping would take too long.
+			// Since RR Sync is also being deprecated, fail early for clarity.
+			return nil, errors.New("derivation disabled (--l2.unsafe-only=true) and RR sync enabled (--syncmode.req-resp=true): " +
+				"reaching the unsafe tip would rely solely on RR sync, " +
+				"which is infeasible for bootstrap. Disable RR sync or enable derivation")
+		}
+		// If RR Sync is not used, EL Sync will fill in the unsafe gap.
+		// This path is much faster and more practical for closing the gap.
+	}
 	engineKind := engine.Kind(ctx.String(flags.L2EngineKind.Name))
 	cfg := &sync.Config{
 		SyncMode:                       mode,
 		SyncModeReqResp:                ctx.Bool(flags.SyncModeReqRespFlag.Name),
 		SkipSyncStartCheck:             ctx.Bool(flags.SkipSyncStartCheck.Name),
 		SupportsPostFinalizationELSync: engineKind.SupportsPostFinalizationELSync(),
+		UnsafeOnly:                     unsafeOnly,
+		L2FollowSourceEndpoint:         l2FollowSourceEndpoint,
 	}
 	if ctx.Bool(flags.L2EngineSyncEnabled.Name) {
 		cfg.SyncMode = sync.ELSync
 	}
-
 	return cfg, nil
 }

--- a/op-node/service_test.go
+++ b/op-node/service_test.go
@@ -1,0 +1,75 @@
+package opnode
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/flags"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func syncConfigCliApp() *cli.App {
+	syncConfigFlags := append([]cli.Flag{
+		flags.L2UnsafeOnly,
+		flags.SequencerEnabledFlag,
+		flags.L2EngineSyncEnabled,
+		flags.SyncModeFlag,
+		flags.SyncModeReqRespFlag,
+		flags.L2FollowSource,
+		flags.L2EngineKind,
+		flags.SkipSyncStartCheck,
+	}, flags.P2PFlags("")..., // For p2p.sync.req-resp
+	)
+	return &cli.App{
+		Flags: syncConfigFlags,
+		Action: func(c *cli.Context) error {
+			_, err := NewSyncConfig(c, log.New())
+			return err
+		},
+	}
+}
+
+func run(args []string) error {
+	return syncConfigCliApp().Run(append([]string{"test"}, args...))
+}
+
+func TestNewSyncConfigDefault(t *testing.T) {
+	require.NoError(t, run(nil))
+}
+
+func TestNewSyncConfig_DerivationDisabled_NoRRSync(t *testing.T) {
+	err := run([]string{
+		fmt.Sprintf("--%s=true", flags.L2UnsafeOnly.Name),
+		// No follow source with no derivation allowed
+		fmt.Sprintf("--%s=false", flags.SyncModeReqRespFlag.Name),
+	})
+	require.NoError(t, err)
+}
+
+func TestNewSyncConfig_FollowSourceWithDerivationDisabled(t *testing.T) {
+	err := run([]string{
+		fmt.Sprintf("--%s=true", flags.L2UnsafeOnly.Name),
+		fmt.Sprintf("--%s=http://example", flags.L2FollowSource.Name),
+		fmt.Sprintf("--%s=false", flags.SyncModeReqRespFlag.Name),
+	})
+	require.NoError(t, err)
+}
+
+func TestNewSyncConfig_FollowSourceWithDerivationEnabled(t *testing.T) {
+	err := run([]string{
+		// unsafe-only defaults in false
+		fmt.Sprintf("--%s=http://example", flags.L2FollowSource.Name),
+	})
+	require.ErrorContains(t, err, "cannot follow external safe/finalized with derivation enabled")
+}
+
+func TestNewSyncConfig_VerifierUnsafeOnlyWithRRSyncEnabled(t *testing.T) {
+	err := run([]string{
+		// verifier mode is default
+		fmt.Sprintf("--%s=true", flags.L2UnsafeOnly.Name),
+		fmt.Sprintf("--%s=true", flags.SyncModeReqRespFlag.Name),
+	})
+	require.ErrorContains(t, err, "reaching the unsafe tip would rely solely on RR sync")
+}

--- a/op-service/log/cli.go
+++ b/op-service/log/cli.go
@@ -53,7 +53,7 @@ func CLIFlagsWithCategory(envPrefix string, category string) []cli.Flag {
 		},
 		&cli.GenericFlag{
 			Name:     FormatFlagName,
-			Usage:    "Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty',",
+			Usage:    fmt.Sprintf("Format the log output. Supported formats: %s", SupportedFormatsString()),
 			Value:    NewFormatFlagValue(FormatText),
 			EnvVars:  opservice.PrefixEnvVar(envPrefix, "LOG_FORMAT"),
 			Category: category,
@@ -143,6 +143,25 @@ const (
 	FormatJSON     FormatType = "json"
 	FormatJSONMs   FormatType = "jsonms"
 )
+
+// All supported format types in a slice for iteration
+var formatTypes = []FormatType{
+	FormatText,
+	FormatTerminal,
+	FormatLogFmt,
+	FormatLogFmtMs,
+	FormatJSON,
+	FormatJSONMs,
+}
+
+// SupportedFormatsString returns a comma-delimited string of supported formats,
+func SupportedFormatsString() string {
+	names := make([]string, 0, len(formatTypes))
+	for _, f := range formatTypes {
+		names = append(names, f.String())
+	}
+	return strings.Join(names, ", ")
+}
 
 // FormatHandler returns the correct slog handler factory for the provided format.
 func FormatHandler(ft FormatType, color bool) func(io.Writer) slog.Handler {

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -102,6 +102,7 @@ FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/c
 FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.2.0 AS cannon-builder-v1-2-0
 FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.3.0 AS cannon-builder-v1-3-0
 FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.4.0 AS cannon-builder-v1-4-0
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.6.0 AS cannon-builder-v1-6-0
 
 FROM --platform=$BUILDPLATFORM builder AS cannon-builder
 ARG CANNON_VERSION=v0.0.0
@@ -113,6 +114,7 @@ COPY --from=cannon-builder-v1-2-0 /usr/local/bin/cannon-3 ./cannon/multicannon/e
 COPY --from=cannon-builder-v1-3-0 /usr/local/bin/cannon-4 ./cannon/multicannon/embeds/cannon-4
 COPY --from=cannon-builder-v1-4-0 /usr/local/bin/cannon-5 ./cannon/multicannon/embeds/cannon-5
 COPY --from=cannon-builder-v1-4-0 /usr/local/bin/cannon-6 ./cannon/multicannon/embeds/cannon-6
+COPY --from=cannon-builder-v1-6-0 /usr/local/bin/cannon-7 ./cannon/multicannon/embeds/cannon-7
 # Build current binaries
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build cd cannon && make cannon  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$CANNON_VERSION"

--- a/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
+++ b/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
@@ -86,6 +86,7 @@ interface ISystemConfig is IProxyAdminOwnedBase {
     function renounceOwnership() external;
     function resourceConfig() external view returns (IResourceMetering.ResourceConfig memory);
     function scalar() external view returns (uint256);
+    function setBatcherHash(address _batcher) external;
     function setBatcherHash(bytes32 _batcherHash) external;
     function setGasConfig(uint256 _overhead, uint256 _scalar) external;
     function setGasConfigEcotone(uint32 _basefeeScalar, uint32 _blobbasefeeScalar) external;

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
@@ -757,6 +757,19 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_batcher",
+        "type": "address"
+      }
+    ],
+    "name": "setBatcherHash",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "_batcherHash",
         "type": "bytes32"

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -48,8 +48,8 @@
     "sourceCodeHash": "0xbf344c4369b8cb00ec7a3108f72795747f3bc59ab5b37ac18cf21e72e2979dbf"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0x4a4d7e60fc65777a2faaf34c31d1fa310299b5e3384ac1c77ef42d9051a9b14d",
-    "sourceCodeHash": "0xba941a73e213fdfbdf4ac0f8717e8f60036ca0bb421f9b08adcc1447f25cb477"
+    "initCodeHash": "0x66a35556b51f537e8d0e11502a371fd58294719ae52fdee957dee26342307b60",
+    "sourceCodeHash": "0x291e0d88c99defc3f0cdffd844e908471b28a47812ab7040fd17f15db67ece90"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -48,8 +48,8 @@
     "sourceCodeHash": "0xbf344c4369b8cb00ec7a3108f72795747f3bc59ab5b37ac18cf21e72e2979dbf"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0x66a35556b51f537e8d0e11502a371fd58294719ae52fdee957dee26342307b60",
-    "sourceCodeHash": "0x291e0d88c99defc3f0cdffd844e908471b28a47812ab7040fd17f15db67ece90"
+    "initCodeHash": "0x5ff0f79914999b54daeb3e3f38a1e2275f286e005a9e52055d169282605fec81",
+    "sourceCodeHash": "0xc2b530bf529ac23d1ba1adf67eedcc5d95e25c2919e1d97f4f2bba4823303b17"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -170,9 +170,9 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     error SystemConfig_InvalidFeatureState();
 
     /// @notice Semantic version.
-    /// @custom:semver 3.12.0
+    /// @custom:semver 3.13.0
     function version() public pure virtual returns (string memory) {
-        return "3.12.0";
+        return "3.13.0";
     }
 
     /// @notice Constructs the SystemConfig contract.
@@ -338,6 +338,12 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
 
         bytes memory data = abi.encode(_unsafeBlockSigner);
         emit ConfigUpdate(VERSION, UpdateType.UNSAFE_BLOCK_SIGNER, data);
+    }
+
+    /// @notice Updates the batcher hash by formatting a provided batcher address.
+    /// @param _batcher New batcher address.
+    function setBatcherHash(address _batcher) external onlyOwner {
+        _setBatcherHash(bytes32(uint256(uint160(_batcher))));
     }
 
     /// @notice Updates the batcher hash. Can only be called by the owner.

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -327,6 +327,12 @@ contract SystemConfig_SetBatcherHash_Test is SystemConfig_TestInit {
         systemConfig.setBatcherHash(bytes32(hex""));
     }
 
+    /// @notice Tests that the address overload reverts if the caller is not the owner.
+    function test_setBatcherHashFromAddress_notOwner_reverts(address batcher) external {
+        vm.expectRevert("Ownable: caller is not the owner");
+        systemConfig.setBatcherHash(batcher);
+    }
+
     /// @notice Tests that `setBatcherHash` updates the batcher hash successfully.
     function testFuzz_setBatcherHash_succeeds(bytes32 newBatcherHash) external {
         vm.expectEmit(address(systemConfig));
@@ -335,6 +341,18 @@ contract SystemConfig_SetBatcherHash_Test is SystemConfig_TestInit {
         vm.prank(systemConfig.owner());
         systemConfig.setBatcherHash(newBatcherHash);
         assertEq(systemConfig.batcherHash(), newBatcherHash);
+    }
+
+    /// @notice Tests that the address overload formats the hash correctly.
+    function testFuzz_setBatcherHashFromAddress_succeeds(address newBatcher) external {
+        bytes32 formatted = bytes32(uint256(uint160(newBatcher)));
+
+        vm.expectEmit(address(systemConfig));
+        emit ConfigUpdate(0, ISystemConfig.UpdateType.BATCHER, abi.encode(formatted));
+
+        vm.prank(systemConfig.owner());
+        systemConfig.setBatcherHash(newBatcher);
+        assertEq(systemConfig.batcherHash(), formatted);
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds new op-node sync flags (`l2.unsafe-only`, `l2.follow.source`) with validation/logging and tests; bumps SystemConfig to 3.13.1 with `setBatcherHash(address)`; updates cannon embeds/execution and improves log format help.
> 
> - **op-node (sync/config & CLI)**:
>   - Add flags `l2.unsafe-only` and `l2.follow.source`; inject into `sync.Config` as `UnsafeOnly` and `L2FollowSourceEndpoint` with `L2FollowSourceEnabled()`.
>   - Enforce invalid combinations in `NewSyncConfig` (e.g., follow-source with derivation enabled; unsafe-only with RR sync for verifiers); add tests in `service_test.go`.
>   - Log safety levels during init in `node.go`.
> - **Contracts (SystemConfig)**:
>   - Bump version to `3.13.1`.
>   - Add overload `setBatcherHash(address)`; update `ISystemConfig`, ABI snapshot, tests, and semver-lock.
> - **Cannon**:
>   - Use `cli.Exit` for error/exit code propagation in `multicannon/exec.go`.
>   - Dockerfile: add cannon v1.6.0 stage and embed `cannon-7`; Makefile now embeds `cannon-8`.
> - **Logging**:
>   - Improve `log.format` help to list supported formats dynamically via `SupportedFormatsString()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bdceb6dfbfb4f4e666b8a198ce497312e23f3cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->