### PR TITLE
fix: cgt liquidity controller natspec

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -117,7 +117,7 @@
   },
   "src/L2/LiquidityController.sol:LiquidityController": {
     "initCodeHash": "0xe492fe75e3c0a8a80ede7b50271263c42a2c7616a101861e892dba76f9771e34",
-    "sourceCodeHash": "0x7118aa0a3da50fede0a376cb0664e9146147daa7eb1f75bcd45a5606fd6d3afa"
+    "sourceCodeHash": "0xef9cf289b4bf63808b6822fc2c588fe516abbbfb90479553e7d54d43de344e50"
   },
   "src/L2/NativeAssetLiquidity.sol:NativeAssetLiquidity": {
     "initCodeHash": "0x04b176e5d484e54173a5644c833117c5fd9f055dce8678be9ec4cf07c0f01f00",

--- a/packages/contracts-bedrock/src/L2/LiquidityController.sol
+++ b/packages/contracts-bedrock/src/L2/LiquidityController.sol
@@ -98,13 +98,13 @@ contract LiquidityController is ISemver, Initializable, OwnableUpgradeable {
         if (!minters[msg.sender]) revert LiquidityController_Unauthorized();
         INativeAssetLiquidity(Predeploys.NATIVE_ASSET_LIQUIDITY).withdraw(_amount);
 
-        // This is a forced ETH send to the recipient, the recipient should NOT expect to be called
+        // This is a forced native asset send to the recipient, the recipient should NOT expect to be called
         new SafeSend{ value: _amount }(payable(_to));
 
         emit LiquidityMinted(msg.sender, _to, _amount);
     }
 
-    /// @notice Burns native asset liquidity by sending ETH to the contract
+    /// @notice Burns native asset liquidity by sending that native asset to the NativeAssetLiquidity contract
     function burn() external payable {
         if (!minters[msg.sender]) revert LiquidityController_Unauthorized();
         INativeAssetLiquidity(Predeploys.NATIVE_ASSET_LIQUIDITY).deposit{ value: msg.value }();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies LiquidityController NatSpec for mint/burn to refer to the native asset and updates the snapshot hash.
> 
> - **Contracts**:
>   - `src/L2/LiquidityController.sol`: Clarify NatSpec in `mint` (forced native asset send) and `burn` (send native asset to `NativeAssetLiquidity`).
> - **Snapshots**:
>   - `snapshots/semver-lock.json`: Update `sourceCodeHash` for `LiquidityController`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0ffacadf86310a2e767656c8056212af7f4f7a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->