### PR TITLE
fix: remove dev feature flag from opcm

### DIFF
--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -254,6 +254,7 @@ func DeployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployme
 		AllowCustomDisputeParameters: true,
 		OperatorFeeScalar:            cfg.GasPriceOracleOperatorFeeScalar,
 		OperatorFeeConstant:          cfg.GasPriceOracleOperatorFeeConstant,
+		UseCustomGasToken:            cfg.UseCustomGasToken,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy L2 OP chain: %w", err)

--- a/op-deployer/pkg/deployer/opcm/opchain.go
+++ b/op-deployer/pkg/deployer/opcm/opchain.go
@@ -43,6 +43,8 @@ type DeployOPChainInput struct {
 
 	OperatorFeeScalar   uint32
 	OperatorFeeConstant uint64
+
+	UseCustomGasToken   bool
 }
 
 type DeployOPChainOutput struct {

--- a/op-deployer/pkg/deployer/opcm/opchain.go
+++ b/op-deployer/pkg/deployer/opcm/opchain.go
@@ -44,7 +44,7 @@ type DeployOPChainInput struct {
 	OperatorFeeScalar   uint32
 	OperatorFeeConstant uint64
 
-	UseCustomGasToken   bool
+	UseCustomGasToken bool
 }
 
 type DeployOPChainOutput struct {

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -126,6 +126,7 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 		AllowCustomDisputeParameters: proofParams.DangerouslyAllowCustomDisputeParameters,
 		OperatorFeeScalar:            thisIntent.OperatorFeeScalar,
 		OperatorFeeConstant:          thisIntent.OperatorFeeConstant,
+		UseCustomGasToken:            thisIntent.IsCustomGasTokenEnabled(),
 	}, nil
 }
 

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -157,6 +157,8 @@ interface IOPContractsManager {
         uint256 disputeSplitDepth;
         Duration disputeClockExtension;
         Duration disputeMaxClockDuration;
+        // Whether to use the custom gas token.
+        bool useCustomGasToken;
     }
 
     /// @notice The full set of outputs from deploying a new OP Stack chain.
@@ -337,17 +339,17 @@ interface IOPContractsManager {
         bool _allowFailure,
         IOPContractsManagerStandardValidator.ValidationOverrides calldata _overrides
     )
-    external
-    view
-    returns (string memory);
+        external
+        view
+        returns (string memory);
 
     function validate(
         IOPContractsManagerStandardValidator.ValidationInputDev calldata _input,
         bool _allowFailure
     )
-    external
-    view
-    returns (string memory);
+        external
+        view
+        returns (string memory);
 
     function deploy(DeployInput calldata _input) external returns (DeployOutput memory);
 

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -441,7 +441,8 @@ contract Deploy is Deployer {
             disputeMaxGameDepth: cfg.faultGameMaxDepth(),
             disputeSplitDepth: cfg.faultGameSplitDepth(),
             disputeClockExtension: Duration.wrap(uint64(cfg.faultGameClockExtension())),
-            disputeMaxClockDuration: Duration.wrap(uint64(cfg.faultGameMaxClockDuration()))
+            disputeMaxClockDuration: Duration.wrap(uint64(cfg.faultGameMaxClockDuration())),
+            useCustomGasToken: cfg.useCustomGasToken()
         });
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -78,7 +78,8 @@ contract DeployOPChain is Script {
             disputeMaxGameDepth: _input.disputeMaxGameDepth,
             disputeSplitDepth: _input.disputeSplitDepth,
             disputeClockExtension: _input.disputeClockExtension,
-            disputeMaxClockDuration: _input.disputeMaxClockDuration
+            disputeMaxClockDuration: _input.disputeMaxClockDuration,
+            useCustomGasToken: _input.useCustomGasToken
         });
 
         vm.broadcast(msg.sender);

--- a/packages/contracts-bedrock/scripts/libraries/Types.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Types.sol
@@ -49,5 +49,7 @@ library Types {
         // Fee params
         uint32 operatorFeeScalar;
         uint64 operatorFeeConstant;
+        // Whether to use the custom gas token.
+        bool useCustomGasToken;
     }
 }

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
@@ -312,6 +312,11 @@
             "internalType": "Duration",
             "name": "disputeMaxClockDuration",
             "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "useCustomGasToken",
+            "type": "bool"
           }
         ],
         "internalType": "struct OPContractsManager.DeployInput",

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerDeployer.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerDeployer.json
@@ -215,6 +215,11 @@
             "internalType": "Duration",
             "name": "disputeMaxClockDuration",
             "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "useCustomGasToken",
+            "type": "bool"
           }
         ],
         "internalType": "struct OPContractsManager.DeployInput",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0xcf86b4c819efbd2a1ade90a4390269ff0137c8ea79887d55c9c457c2cef186c0",
-    "sourceCodeHash": "0x5498fda0ce02788807f2589656355bdbb6df06fe4cdc2b6e31b6387f812422a5"
+    "initCodeHash": "0x6fd82aaec43858b34bd093e29bbacb659a95817d506de948aebd3c84e6d2a00a",
+    "sourceCodeHash": "0x5f63555e12cb8e27ce5c1511e986550bf2f1b9769e314223a7324b8dcfa29523"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0x0c8b15453d0f0bc5d9af07f104505e0bbb2b358f0df418289822fb73a8652b30",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1463,7 +1463,7 @@ contract OPContractsManagerDeployer is OPContractsManagerBase {
 
         // If the custom gas token feature was requested, enable the custom gas token feature in the SystemConfig
         // contract.
-        if (isDevFeatureEnabled(DevFeatures.CUSTOM_GAS_TOKEN)) {
+        if (_input.useCustomGasToken) {
             output.systemConfigProxy.setFeature(Features.CUSTOM_GAS_TOKEN, true);
         }
 
@@ -2137,6 +2137,8 @@ contract OPContractsManager is ISemver {
         uint256 disputeSplitDepth;
         Duration disputeClockExtension;
         Duration disputeMaxClockDuration;
+        // Whether to use the custom gas token.
+        bool useCustomGasToken;
     }
 
     /// @notice The full set of outputs from deploying a new OP Stack chain.

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -514,7 +514,8 @@ abstract contract OPContractsManager_TestInit is CommonTest, DisputeGames {
                 disputeMaxGameDepth: 73,
                 disputeSplitDepth: 30,
                 disputeClockExtension: Duration.wrap(10800),
-                disputeMaxClockDuration: Duration.wrap(302400)
+                disputeMaxClockDuration: Duration.wrap(302400),
+                useCustomGasToken: false
             })
         );
     }
@@ -2359,7 +2360,8 @@ contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase, DisputeGames 
             disputeMaxGameDepth: _doi.disputeMaxGameDepth,
             disputeSplitDepth: _doi.disputeSplitDepth,
             disputeClockExtension: _doi.disputeClockExtension,
-            disputeMaxClockDuration: _doi.disputeMaxClockDuration
+            disputeMaxClockDuration: _doi.disputeMaxClockDuration,
+            useCustomGasToken: _doi.useCustomGasToken
         });
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `useCustomGasToken` to OP chain deploy inputs and enables `SystemConfig` CUSTOM_GAS_TOKEN feature when set.
> 
> - **Contracts (Solidity)**:
>   - Extend `IOPContractsManager.DeployInput` and script `Types.DeployOPChainInput` with `bool useCustomGasToken`.
>   - In `OPContractsManagerDeployer.deploy`, enable `SystemConfig` `Features.CUSTOM_GAS_TOKEN` based on `_input.useCustomGasToken` (replaces dev-flag gating).
>   - Update deploy scripts (`Deploy.s.sol`, `DeployOPChain.s.sol`) to pass through `useCustomGasToken`.
>   - Update tests to cover custom gas token enablement (incl. fuzz) and add `Features` import; minor signature spacing fixes.
> - **Go (op-deployer/op-chain-ops)**:
>   - Add `UseCustomGasToken` to `opcm.DeployOPChainInput`; plumb from config/intent through pipeline and interopgen deploy flow.
> - **ABI/Snapshots**:
>   - Refresh ABIs to include new field; update `semver-lock.json` for `OPContractsManager`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f104e332b2f83ee265974f4c546d629fa17dad9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->