### PR TITLE
feat: add opcmv2 flag to deployImplementations and apply opcmv2 deployment test 

### DIFF
--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -363,6 +363,61 @@ func TestEndToEndApply(t *testing.T) {
 	})
 
 	// TODO: Add tests for OPCMV2
+	t.Run("OPCMV2 deployment", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		lgr := testlog.Logger(t, slog.LevelDebug)
+		l1RPC, l1Client := devnet.DefaultAnvilRPC(t, lgr)
+		_, pk, dk := shared.DefaultPrivkey(t)
+		l1ChainID := new(big.Int).SetUint64(devnet.DefaultChainID)
+		l2ChainID := uint256.NewInt(1)
+		loc, _ := testutil.LocalArtifacts(t)
+		testCacheDir := testutils.IsolatedTestDirWithAutoCleanup(t)
+
+		intent, st := shared.NewIntent(t, l1ChainID, dk, l2ChainID, loc, loc, testCustomGasLimit)
+
+		// Enable OPCMV2 dev flag
+		intent.GlobalDeployOverrides = map[string]any{
+			"devFeatureBitmap": deployer.OPCMV2DevFlag,
+		}
+
+		require.NoError(t, deployer.ApplyPipeline(
+			ctx,
+			deployer.ApplyPipelineOpts{
+				DeploymentTarget:   deployer.DeploymentTargetLive,
+				L1RPCUrl:           l1RPC,
+				DeployerPrivateKey: pk,
+				Intent:             intent,
+				State:              st,
+				Logger:             lgr,
+				StateWriter:        pipeline.NoopStateWriter(),
+				CacheDir:           testCacheDir,
+			},
+		))
+
+		// Verify that OPCMV2 was deployed in implementations
+		require.NotEmpty(t, st.ImplementationsDeployment.OpcmV2Impl, "OPCMV2 implementation should be deployed")
+		require.NotEmpty(t, st.ImplementationsDeployment.OpcmContainerImpl, "OPCM container implementation should be deployed")
+		require.NotEmpty(t, st.ImplementationsDeployment.OpcmStandardValidatorImpl, "OPCM standard validator implementation should be deployed")
+
+		// Verify that implementations are deployed on L1
+		cg := ethClientCodeGetter(ctx, l1Client)
+
+		opcmV2Code := cg(t, st.ImplementationsDeployment.OpcmV2Impl)
+		require.NotEmpty(t, opcmV2Code, "OPCMV2 should have code deployed")
+
+		// Verify that the dev feature bitmap is set to OPCMV2
+		require.Equal(t, deployer.OPCMV2DevFlag, intent.GlobalDeployOverrides["devFeatureBitmap"])
+
+		// Assert that the OPCM V1 addresses are zero
+		require.Equal(t, common.Address{}, st.ImplementationsDeployment.OpcmImpl, "OPCM V1 implementation should be zero")
+		require.Equal(t, common.Address{}, st.ImplementationsDeployment.OpcmContractsContainerImpl, "OPCM container implementation should be zero")
+		require.Equal(t, common.Address{}, st.ImplementationsDeployment.OpcmGameTypeAdderImpl, "OPCM game type adder implementation should be zero")
+		require.Equal(t, common.Address{}, st.ImplementationsDeployment.OpcmDeployerImpl, "OPCM deployer implementation should be zero")
+		require.Equal(t, common.Address{}, st.ImplementationsDeployment.OpcmUpgraderImpl, "OPCM upgrader implementation should be zero")
+		require.Equal(t, common.Address{}, st.ImplementationsDeployment.OpcmInteropMigratorImpl, "OPCM interop migrator implementation should be zero")
+	})
 }
 
 func TestGlobalOverrides(t *testing.T) {

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -362,7 +362,6 @@ func TestEndToEndApply(t *testing.T) {
 		require.Equal(t, amount, account.Balance, "Native asset liquidity predeploy should have the configured balance")
 	})
 
-	// TODO: Add tests for OPCMV2
 	t.Run("OPCMV2 deployment", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
@@ -107,7 +108,7 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 	// Select which OPCM to use based on dev feature flag
 	opcmAddr := st.ImplementationsDeployment.OpcmImpl
 	if devFeatureBitmap, ok := intent.GlobalDeployOverrides["devFeatureBitmap"].(common.Hash); ok {
-		opcmV2Flag := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000010000")
+		opcmV2Flag := deployer.OPCMV2DevFlag
 		if isDevFeatureEnabled(devFeatureBitmap, opcmV2Flag) && st.ImplementationsDeployment.OpcmV2Impl != (common.Address{}) {
 			opcmAddr = st.ImplementationsDeployment.OpcmV2Impl
 		}

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
@@ -108,7 +107,7 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 	// Select which OPCM to use based on dev feature flag
 	opcmAddr := st.ImplementationsDeployment.OpcmImpl
 	if devFeatureBitmap, ok := intent.GlobalDeployOverrides["devFeatureBitmap"].(common.Hash); ok {
-		opcmV2Flag := deployer.OPCMV2DevFlag
+		opcmV2Flag := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000010000")
 		if isDevFeatureEnabled(devFeatureBitmap, opcmV2Flag) && st.ImplementationsDeployment.OpcmV2Impl != (common.Address{}) {
 			opcmAddr = st.ImplementationsDeployment.OpcmV2Impl
 		}

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -386,9 +386,10 @@ library ChainAssertions {
         require(address(_opcm) != address(0), "CHECK-OPCM-10");
 
         require(bytes(_opcm.version()).length > 0, "CHECK-OPCM-15");
-        require(address(_opcm.protocolVersions()) == _proxies.ProtocolVersions, "CHECK-OPCM-17");
-        require(address(_opcm.superchainConfig()) == _proxies.SuperchainConfig, "CHECK-OPCM-19");
-
+        if (!_opcm.isDevFeatureEnabled(DevFeatures.OPCM_V2)) {
+            require(address(_opcm.protocolVersions()) == _proxies.ProtocolVersions, "CHECK-OPCM-17");
+            require(address(_opcm.superchainConfig()) == _proxies.SuperchainConfig, "CHECK-OPCM-19");
+        }
         // Ensure that the OPCM impls are correctly saved
         IOPContractsManager.Implementations memory impls = _opcm.implementations();
         require(impls.l1ERC721BridgeImpl == _impls.L1ERC721Bridge, "CHECK-OPCM-50");

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -296,14 +296,14 @@ contract Deploy is Deployer {
         // Save the implementation addresses which are needed outside of this function or script.
         // When called in a fork test, this will overwrite the existing implementations.
         artifacts.save("MipsSingleton", address(dio.mipsSingleton));
-        if (DevFeatures.isDevFeatureEnabled(dio.opcm.devFeatureBitmap(), DevFeatures.OPCM_V2)) {
+        if (DevFeatures.isDevFeatureEnabled(cfg.devFeatureBitmap(), DevFeatures.OPCM_V2)) {
             artifacts.save("OPContractsManagerV2", address(dio.opcmV2));
         } else {
             artifacts.save("OPContractsManager", address(dio.opcm));
         }
         artifacts.save("DelayedWETHImpl", address(dio.delayedWETHImpl));
         artifacts.save("PreimageOracle", address(dio.preimageOracleSingleton));
-        if (DevFeatures.isDevFeatureEnabled(dio.opcm.devFeatureBitmap(), DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {
+        if (DevFeatures.isDevFeatureEnabled(cfg.devFeatureBitmap(), DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {
             artifacts.save("PermissionedDisputeGame", address(dio.permissionedDisputeGameV2Impl));
         }
 
@@ -333,10 +333,16 @@ contract Deploy is Deployer {
             _mips: IMIPS64(address(dio.mipsSingleton)),
             _oracle: IPreimageOracle(address(dio.preimageOracleSingleton))
         });
+        IOPContractsManager _opcm;
+        if (DevFeatures.isDevFeatureEnabled(cfg.devFeatureBitmap(), DevFeatures.OPCM_V2)) {
+            _opcm = IOPContractsManager(address(dio.opcmV2));
+        } else {
+            _opcm = IOPContractsManager(address(dio.opcm));
+        }
         ChainAssertions.checkOPContractsManager({
             _impls: impls,
             _proxies: _proxies(),
-            _opcm: IOPContractsManager(address(dio.opcm)),
+            _opcm: _opcm,
             _mips: IMIPS64(address(dio.mipsSingleton))
         });
         ChainAssertions.checkSystemConfigImpls(impls);
@@ -373,7 +379,7 @@ contract Deploy is Deployer {
         artifacts.save("AnchorStateRegistryProxy", address(deployOutput.anchorStateRegistryProxy));
         artifacts.save("OptimismPortalProxy", address(deployOutput.optimismPortalProxy));
         artifacts.save("OptimismPortal2Proxy", address(deployOutput.optimismPortalProxy));
-        if (!DevFeatures.isDevFeatureEnabled(opcm.devFeatureBitmap(), DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {
+        if (!DevFeatures.isDevFeatureEnabled(cfg.devFeatureBitmap(), DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {
             artifacts.save("PermissionedDisputeGame", address(deployOutput.permissionedDisputeGame));
         }
 

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -179,6 +179,60 @@ contract DeployImplementations is Script {
             superPermissionedDisputeGameImpl: address(_output.superPermissionedDisputeGameImpl)
         });
 
+        // Deploy OPCM V1 components
+        deployOPCMBPImplsContainer(_input, _output, _blueprints, implementations);
+        deployOPCMGameTypeAdder(_output);
+        deployOPCMDeployer(_input, _output);
+        deployOPCMUpgrader(_output);
+        deployOPCMInteropMigrator(_output);
+        deployOPCMStandardValidator(_input, _output, implementations);
+
+        // Semgrep rule will fail because the arguments are encoded inside of a separate function.
+        opcm_ = IOPContractsManager(
+            // nosemgrep: sol-safety-deployutils-args
+            DeployUtils.createDeterministic({
+                _name: "OPContractsManager",
+                _args: encodeOPCMConstructor(_input, _output),
+                _salt: _salt
+            })
+        );
+
+        vm.label(address(opcm_), "OPContractsManager");
+        _output.opcm = opcm_;
+
+        // Set OPCM V2 addresses to zero (not deployed)
+        _output.opcmV2 = IOPContractsManagerV2(address(0));
+        _output.opcmContainer = IOPContractsManagerContainer(address(0));
+    }
+
+    function createOPCMContractV2(
+        Input memory _input,
+        Output memory _output,
+        IOPContractsManager.Blueprints memory _blueprints
+    )
+        private
+    {
+        IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
+            superchainConfigImpl: address(_output.superchainConfigImpl),
+            protocolVersionsImpl: address(_output.protocolVersionsImpl),
+            l1ERC721BridgeImpl: address(_output.l1ERC721BridgeImpl),
+            optimismPortalImpl: address(_output.optimismPortalImpl),
+            optimismPortalInteropImpl: address(_output.optimismPortalInteropImpl),
+            ethLockboxImpl: address(_output.ethLockboxImpl),
+            systemConfigImpl: address(_output.systemConfigImpl),
+            optimismMintableERC20FactoryImpl: address(_output.optimismMintableERC20FactoryImpl),
+            l1CrossDomainMessengerImpl: address(_output.l1CrossDomainMessengerImpl),
+            l1StandardBridgeImpl: address(_output.l1StandardBridgeImpl),
+            disputeGameFactoryImpl: address(_output.disputeGameFactoryImpl),
+            anchorStateRegistryImpl: address(_output.anchorStateRegistryImpl),
+            delayedWETHImpl: address(_output.delayedWETHImpl),
+            mipsImpl: address(_output.mipsSingleton),
+            faultDisputeGameV2Impl: address(_output.faultDisputeGameV2Impl),
+            permissionedDisputeGameV2Impl: address(_output.permissionedDisputeGameV2Impl),
+            superFaultDisputeGameImpl: address(_output.superFaultDisputeGameImpl),
+            superPermissionedDisputeGameImpl: address(_output.superPermissionedDisputeGameImpl)
+        });
+
         IOPContractsManagerContainer.Implementations memory implementationsV2 = IOPContractsManagerContainer
             .Implementations({
             superchainConfigImpl: address(_output.superchainConfigImpl),
@@ -215,27 +269,18 @@ contract DeployImplementations is Script {
             permissionlessDisputeGame2: _blueprints.permissionlessDisputeGame2
         });
 
-        deployOPCMBPImplsContainer(_input, _output, _blueprints, implementations);
+        // Deploy OPCM V2 components
         deployOPCMContainer(_input, _output, blueprintsV2, implementationsV2);
-        deployOPCMGameTypeAdder(_output);
-        deployOPCMDeployer(_input, _output);
-        deployOPCMUpgrader(_output);
-        deployOPCMInteropMigrator(_output);
         deployOPCMStandardValidator(_input, _output, implementations);
         deployOPCMV2(_output);
 
-        // Semgrep rule will fail because the arguments are encoded inside of a separate function.
-        opcm_ = IOPContractsManager(
-            // nosemgrep: sol-safety-deployutils-args
-            DeployUtils.createDeterministic({
-                _name: "OPContractsManager",
-                _args: encodeOPCMConstructor(_input, _output),
-                _salt: _salt
-            })
-        );
-
-        vm.label(address(opcm_), "OPContractsManager");
-        _output.opcm = opcm_;
+        // Set OPCM V1 addresses to zero (not deployed)
+        _output.opcm = IOPContractsManager(address(0));
+        _output.opcmContractsContainer = IOPContractsManagerContractsContainer(address(0));
+        _output.opcmGameTypeAdder = IOPContractsManagerGameTypeAdder(address(0));
+        _output.opcmDeployer = IOPContractsManagerDeployer(address(0));
+        _output.opcmUpgrader = IOPContractsManagerUpgrader(address(0));
+        _output.opcmInteropMigrator = IOPContractsManagerInteropMigrator(address(0));
     }
 
     /// @notice Encodes the constructor of the OPContractsManager contract. Used to avoid stack too
@@ -292,10 +337,16 @@ contract DeployImplementations is Script {
         // forgefmt: disable-end
         vm.stopBroadcast();
 
-        IOPContractsManager opcm = createOPCMContract(_input, _output, blueprints);
+        // Check if OPCM V2 should be deployed
+        bool deployV2 = DevFeatures.isDevFeatureEnabled(_input.devFeatureBitmap, DevFeatures.OPCM_V2);
 
-        vm.label(address(opcm), "OPContractsManager");
-        _output.opcm = opcm;
+        if (deployV2) {
+            createOPCMContractV2(_input, _output, blueprints);
+        } else {
+            IOPContractsManager opcm = createOPCMContract(_input, _output, blueprints);
+            vm.label(address(opcm), "OPContractsManager");
+            _output.opcm = opcm;
+        }
     }
 
     // --- Core Contracts ---
@@ -847,8 +898,12 @@ contract DeployImplementations is Script {
     function assertValidOutput(Input memory _input, Output memory _output) private {
         // With 12 addresses, we'd get a stack too deep error if we tried to do this inline as a
         // single call to `Solarray.addresses`. So we split it into two calls.
+
+        // Check which OPCM version was deployed
+        bool deployedV2 = DevFeatures.isDevFeatureEnabled(_input.devFeatureBitmap, DevFeatures.OPCM_V2);
+
         address[] memory addrs1 = Solarray.addresses(
-            address(_output.opcm),
+            deployedV2 ? address(_output.opcmV2) : address(_output.opcm),
             address(_output.optimismPortalImpl),
             address(_output.delayedWETHImpl),
             address(_output.preimageOracleSingleton),
@@ -883,6 +938,27 @@ contract DeployImplementations is Script {
         }
 
         DeployUtils.assertValidContractAddresses(Solarray.extend(addrs1, addrs2));
+
+        // Validate OPCM V2 flag
+        if (DevFeatures.isDevFeatureEnabled(_input.devFeatureBitmap, DevFeatures.OPCM_V2)) {
+            require(
+                address(_output.opcmV2) != address(0),
+                "DeployImplementations: OPCM V2 flag enabled but OPCM V2 not deployed"
+            );
+            require(
+                address(_output.opcm) == address(0),
+                "DeployImplementations: OPCM V2 flag enabled but OPCM V1 was deployed"
+            );
+        } else {
+            require(
+                address(_output.opcm) != address(0),
+                "DeployImplementations: OPCM V2 flag disabled but OPCM V1 not deployed"
+            );
+            require(
+                address(_output.opcmV2) == address(0),
+                "DeployImplementations: OPCM V2 flag disabled but OPCM V2 was deployed"
+            );
+        }
 
         // Validate V2 contracts not deployed when flag is disabled
         if (!DevFeatures.isDevFeatureEnabled(_input.devFeatureBitmap, DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {
@@ -921,15 +997,18 @@ contract DeployImplementations is Script {
         ChainAssertions.checkL1StandardBridgeImpl(_output.l1StandardBridgeImpl);
         ChainAssertions.checkMIPS(_output.mipsSingleton, _output.preimageOracleSingleton);
 
-        Types.ContractSet memory proxies;
-        proxies.SuperchainConfig = address(_input.superchainConfigProxy);
-        proxies.ProtocolVersions = address(_input.protocolVersionsProxy);
-        ChainAssertions.checkOPContractsManager({
-            _impls: impls,
-            _proxies: proxies,
-            _opcm: IOPContractsManager(address(_output.opcm)),
-            _mips: IMIPS64(address(_output.mipsSingleton))
-        });
+        // Only check OPCM V1 if it was deployed
+        if (!DevFeatures.isDevFeatureEnabled(_input.devFeatureBitmap, DevFeatures.OPCM_V2)) {
+            Types.ContractSet memory proxies;
+            proxies.SuperchainConfig = address(_input.superchainConfigProxy);
+            proxies.ProtocolVersions = address(_input.protocolVersionsProxy);
+            ChainAssertions.checkOPContractsManager({
+                _impls: impls,
+                _proxies: proxies,
+                _opcm: IOPContractsManager(address(_output.opcm)),
+                _mips: IMIPS64(address(_output.mipsSingleton))
+            });
+        }
 
         ChainAssertions.checkOptimismMintableERC20FactoryImpl(_output.optimismMintableERC20FactoryImpl);
         ChainAssertions.checkOptimismPortal2({

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -213,28 +213,7 @@ contract DeployImplementations is Script {
         private
         returns (IOPContractsManagerV2 opcmV2_)
     {
-        IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
-            superchainConfigImpl: address(_output.superchainConfigImpl),
-            protocolVersionsImpl: address(_output.protocolVersionsImpl),
-            l1ERC721BridgeImpl: address(_output.l1ERC721BridgeImpl),
-            optimismPortalImpl: address(_output.optimismPortalImpl),
-            optimismPortalInteropImpl: address(_output.optimismPortalInteropImpl),
-            ethLockboxImpl: address(_output.ethLockboxImpl),
-            systemConfigImpl: address(_output.systemConfigImpl),
-            optimismMintableERC20FactoryImpl: address(_output.optimismMintableERC20FactoryImpl),
-            l1CrossDomainMessengerImpl: address(_output.l1CrossDomainMessengerImpl),
-            l1StandardBridgeImpl: address(_output.l1StandardBridgeImpl),
-            disputeGameFactoryImpl: address(_output.disputeGameFactoryImpl),
-            anchorStateRegistryImpl: address(_output.anchorStateRegistryImpl),
-            delayedWETHImpl: address(_output.delayedWETHImpl),
-            mipsImpl: address(_output.mipsSingleton),
-            faultDisputeGameV2Impl: address(_output.faultDisputeGameV2Impl),
-            permissionedDisputeGameV2Impl: address(_output.permissionedDisputeGameV2Impl),
-            superFaultDisputeGameImpl: address(_output.superFaultDisputeGameImpl),
-            superPermissionedDisputeGameImpl: address(_output.superPermissionedDisputeGameImpl)
-        });
-
-        IOPContractsManagerContainer.Implementations memory implementationsV2 = IOPContractsManagerContainer
+        IOPContractsManagerContainer.Implementations memory implementations = IOPContractsManagerContainer
             .Implementations({
             superchainConfigImpl: address(_output.superchainConfigImpl),
             protocolVersionsImpl: address(_output.protocolVersionsImpl),
@@ -258,7 +237,7 @@ contract DeployImplementations is Script {
         });
 
         // Convert blueprints to V2 blueprints
-        IOPContractsManagerContainer.Blueprints memory blueprintsV2 = IOPContractsManagerContainer.Blueprints({
+        IOPContractsManagerContainer.Blueprints memory blueprints = IOPContractsManagerContainer.Blueprints({
             addressManager: _blueprints.addressManager,
             proxy: _blueprints.proxy,
             proxyAdmin: _blueprints.proxyAdmin,
@@ -271,8 +250,8 @@ contract DeployImplementations is Script {
         });
 
         // Deploy OPCM V2 components
-        deployOPCMContainer(_input, _output, blueprintsV2, implementationsV2);
-        deployOPCMStandardValidator(_input, _output, implementations);
+        deployOPCMContainer(_input, _output, blueprints, implementations);
+        deployOPCMStandardValidatorV2(_input, _output, implementations);
         opcmV2_ = deployOPCMV2(_output);
 
         // Set OPCM V1 addresses to zero (not deployed)
@@ -778,6 +757,50 @@ contract DeployImplementations is Script {
         Input memory _input,
         Output memory _output,
         IOPContractsManager.Implementations memory _implementations
+    )
+        private
+    {
+        IOPContractsManagerStandardValidator.Implementations memory opcmImplementations;
+        opcmImplementations.l1ERC721BridgeImpl = _implementations.l1ERC721BridgeImpl;
+        opcmImplementations.optimismPortalImpl = _implementations.optimismPortalImpl;
+        opcmImplementations.optimismPortalInteropImpl = _implementations.optimismPortalInteropImpl;
+        opcmImplementations.ethLockboxImpl = _implementations.ethLockboxImpl;
+        opcmImplementations.systemConfigImpl = _implementations.systemConfigImpl;
+        opcmImplementations.optimismMintableERC20FactoryImpl = _implementations.optimismMintableERC20FactoryImpl;
+        opcmImplementations.l1CrossDomainMessengerImpl = _implementations.l1CrossDomainMessengerImpl;
+        opcmImplementations.l1StandardBridgeImpl = _implementations.l1StandardBridgeImpl;
+        opcmImplementations.disputeGameFactoryImpl = _implementations.disputeGameFactoryImpl;
+        opcmImplementations.anchorStateRegistryImpl = _implementations.anchorStateRegistryImpl;
+        opcmImplementations.delayedWETHImpl = _implementations.delayedWETHImpl;
+        opcmImplementations.mipsImpl = _implementations.mipsImpl;
+
+        IOPContractsManagerStandardValidator impl = IOPContractsManagerStandardValidator(
+            DeployUtils.createDeterministic({
+                _name: "OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        IOPContractsManagerStandardValidator.__constructor__,
+                        (
+                            opcmImplementations,
+                            _input.superchainConfigProxy,
+                            _input.l1ProxyAdminOwner,
+                            _input.challenger,
+                            _input.withdrawalDelaySeconds,
+                            _input.devFeatureBitmap
+                        )
+                    )
+                ),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "OPContractsManagerStandardValidatorImpl");
+        _output.opcmStandardValidator = impl;
+    }
+
+    function deployOPCMStandardValidatorV2(
+        Input memory _input,
+        Output memory _output,
+        IOPContractsManagerContainer.Implementations memory _implementations
     )
         private
     {

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -211,6 +211,7 @@ contract DeployImplementations is Script {
         IOPContractsManager.Blueprints memory _blueprints
     )
         private
+        returns (IOPContractsManagerV2 opcmV2_)
     {
         IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
             superchainConfigImpl: address(_output.superchainConfigImpl),
@@ -272,7 +273,7 @@ contract DeployImplementations is Script {
         // Deploy OPCM V2 components
         deployOPCMContainer(_input, _output, blueprintsV2, implementationsV2);
         deployOPCMStandardValidator(_input, _output, implementations);
-        deployOPCMV2(_output);
+        opcmV2_ = deployOPCMV2(_output);
 
         // Set OPCM V1 addresses to zero (not deployed)
         _output.opcm = IOPContractsManager(address(0));
@@ -281,6 +282,8 @@ contract DeployImplementations is Script {
         _output.opcmDeployer = IOPContractsManagerDeployer(address(0));
         _output.opcmUpgrader = IOPContractsManagerUpgrader(address(0));
         _output.opcmInteropMigrator = IOPContractsManagerInteropMigrator(address(0));
+
+        return opcmV2_;
     }
 
     /// @notice Encodes the constructor of the OPContractsManager contract. Used to avoid stack too
@@ -341,7 +344,9 @@ contract DeployImplementations is Script {
         bool deployV2 = DevFeatures.isDevFeatureEnabled(_input.devFeatureBitmap, DevFeatures.OPCM_V2);
 
         if (deployV2) {
-            createOPCMContractV2(_input, _output, blueprints);
+            IOPContractsManagerV2 opcmV2 = createOPCMContractV2(_input, _output, blueprints);
+            vm.label(address(opcmV2), "OPContractsManagerV2");
+            _output.opcmV2 = opcmV2;
         } else {
             IOPContractsManager opcm = createOPCMContract(_input, _output, blueprints);
             vm.label(address(opcm), "OPContractsManager");
@@ -813,8 +818,8 @@ contract DeployImplementations is Script {
         _output.opcmStandardValidator = impl;
     }
 
-    function deployOPCMV2(Output memory _output) private {
-        IOPContractsManagerV2 impl = IOPContractsManagerV2(
+    function deployOPCMV2(Output memory _output) private returns (IOPContractsManagerV2 opcmV2_) {
+        opcmV2_ = IOPContractsManagerV2(
             DeployUtils.createDeterministic({
                 _name: "OPContractsManagerV2.sol:OPContractsManagerV2",
                 _args: DeployUtils.encodeConstructor(
@@ -825,8 +830,7 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.label(address(impl), "OPContractsManagerV2Impl");
-        _output.opcmV2 = impl;
+        vm.label(address(opcmV2_), "OPContractsManagerV2Impl");
     }
 
     function deployStorageSetterImpl(Output memory _output) private {

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -844,7 +844,7 @@ contract DeployImplementations is Script {
     function deployOPCMV2(Output memory _output) private returns (IOPContractsManagerV2 opcmV2_) {
         opcmV2_ = IOPContractsManagerV2(
             DeployUtils.createDeterministic({
-                _name: "OPContractsManagerV2.sol:OPContractsManagerV2",
+                _name: "OPContractsManagerV2",
                 _args: DeployUtils.encodeConstructor(
                     abi.encodeCall(
                         IOPContractsManagerV2.__constructor__, (_output.opcmContainer, _output.opcmStandardValidator)
@@ -853,7 +853,7 @@ contract DeployImplementations is Script {
                 _salt: _salt
             })
         );
-        vm.label(address(opcmV2_), "OPContractsManagerV2Impl");
+        vm.label(address(opcmV2_), "OPContractsManagerV2");
     }
 
     function deployStorageSetterImpl(Output memory _output) private {

--- a/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
@@ -5,8 +5,11 @@ import { IProxy } from "interfaces/universal/IProxy.sol";
 import { Script } from "forge-std/Script.sol";
 import { IMIPS64 } from "interfaces/cannon/IMIPS64.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
+import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.sol";
+import { IOPContractsManagerContainer } from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { IStaticL1ChugSplashProxy } from "interfaces/legacy/IL1ChugSplashProxy.sol";
+import { DevFeatures } from "src/libraries/DevFeatures.sol";
 
 contract ReadImplementationAddresses is Script {
     struct Input {
@@ -59,25 +62,53 @@ contract ReadImplementationAddresses is Script {
         vm.prank(address(0));
         output_.l1StandardBridge = IStaticL1ChugSplashProxy(_input.l1StandardBridgeProxy).getImplementation();
 
-        // Get implementations from OPCM
-        // TODO: Adapt to OPCMV2 interface when feature enabled
-        IOPContractsManager opcm = IOPContractsManager(_input.opcm);
-        output_.opcmGameTypeAdder = address(opcm.opcmGameTypeAdder());
-        output_.opcmDeployer = address(opcm.opcmDeployer());
-        output_.opcmUpgrader = address(opcm.opcmUpgrader());
-        output_.opcmInteropMigrator = address(opcm.opcmInteropMigrator());
-        output_.opcmStandardValidator = address(opcm.opcmStandardValidator());
+        // Check if OPCM v2 is being used
+        bool useV2 = isDevFeatureOpcmV2Enabled(_input.opcm);
 
-        IOPContractsManager.Implementations memory impls = opcm.implementations();
-        output_.mipsSingleton = impls.mipsImpl;
-        output_.delayedWETH = impls.delayedWETHImpl;
-        output_.ethLockbox = impls.ethLockboxImpl;
-        output_.anchorStateRegistry = impls.anchorStateRegistryImpl;
-        output_.optimismPortalInterop = impls.optimismPortalInteropImpl;
-        output_.faultDisputeGameV2 = impls.faultDisputeGameV2Impl;
-        output_.permissionedDisputeGameV2 = impls.permissionedDisputeGameV2Impl;
-        output_.superFaultDisputeGame = impls.superFaultDisputeGameImpl;
-        output_.superPermissionedDisputeGame = impls.superPermissionedDisputeGameImpl;
+        if (useV2) {
+            // Get implementations from OPCM V2
+            IOPContractsManagerV2 opcmV2 = IOPContractsManagerV2(_input.opcm);
+
+            // OPCMV2 doesn't expose these addresses directly, so we set them to zero
+            // These are internal to the OPCM container and not meant to be accessed externally
+            output_.opcmGameTypeAdder = address(0);
+            output_.opcmDeployer = address(0);
+            output_.opcmUpgrader = address(0);
+            output_.opcmInteropMigrator = address(0);
+
+            // StandardValidator is accessible via the standardValidator() method
+            output_.opcmStandardValidator = address(opcmV2.standardValidator());
+
+            IOPContractsManagerContainer.Implementations memory impls = opcmV2.implementations();
+            output_.mipsSingleton = impls.mipsImpl;
+            output_.delayedWETH = impls.delayedWETHImpl;
+            output_.ethLockbox = impls.ethLockboxImpl;
+            output_.anchorStateRegistry = impls.anchorStateRegistryImpl;
+            output_.optimismPortalInterop = impls.optimismPortalInteropImpl;
+            output_.faultDisputeGameV2 = impls.faultDisputeGameV2Impl;
+            output_.permissionedDisputeGameV2 = impls.permissionedDisputeGameV2Impl;
+            output_.superFaultDisputeGame = impls.superFaultDisputeGameImpl;
+            output_.superPermissionedDisputeGame = impls.superPermissionedDisputeGameImpl;
+        } else {
+            // Get implementations from OPCM V1
+            IOPContractsManager opcm = IOPContractsManager(_input.opcm);
+            output_.opcmGameTypeAdder = address(opcm.opcmGameTypeAdder());
+            output_.opcmDeployer = address(opcm.opcmDeployer());
+            output_.opcmUpgrader = address(opcm.opcmUpgrader());
+            output_.opcmInteropMigrator = address(opcm.opcmInteropMigrator());
+            output_.opcmStandardValidator = address(opcm.opcmStandardValidator());
+
+            IOPContractsManager.Implementations memory impls = opcm.implementations();
+            output_.mipsSingleton = impls.mipsImpl;
+            output_.delayedWETH = impls.delayedWETHImpl;
+            output_.ethLockbox = impls.ethLockboxImpl;
+            output_.anchorStateRegistry = impls.anchorStateRegistryImpl;
+            output_.optimismPortalInterop = impls.optimismPortalInteropImpl;
+            output_.faultDisputeGameV2 = impls.faultDisputeGameV2Impl;
+            output_.permissionedDisputeGameV2 = impls.permissionedDisputeGameV2Impl;
+            output_.superFaultDisputeGame = impls.superFaultDisputeGameImpl;
+            output_.superPermissionedDisputeGame = impls.superPermissionedDisputeGameImpl;
+        }
 
         // Get L1CrossDomainMessenger from AddressManager
         IAddressManager am = IAddressManager(_input.addressManager);
@@ -85,6 +116,12 @@ contract ReadImplementationAddresses is Script {
 
         // Get PreimageOracle from MIPS singleton
         output_.preimageOracleSingleton = address(IMIPS64(output_.mipsSingleton).oracle());
+    }
+
+    /// @notice Checks if OPCM v2 dev feature flag is enabled from the contract's dev feature bitmap.
+    function isDevFeatureOpcmV2Enabled(address _opcmAddr) internal view returns (bool) {
+        // Both v1 and v2 share the same interface for this function.
+        return IOPContractsManager(_opcmAddr).isDevFeatureEnabled(DevFeatures.OPCM_V2);
     }
 
     function runWithBytes(bytes memory _input) public returns (bytes memory) {

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -94,26 +94,49 @@ contract DeployImplementations_Test is Test, FeatureFlags {
             );
 
             // Ensure legacy blueprints were not deployed
-            assertEq(
-                output.opcm.blueprints().permissionedDisputeGame1,
-                address(0),
-                "PermissionedDisputeGame1 blueprint should not be deployed"
-            );
-            assertEq(
-                output.opcm.blueprints().permissionedDisputeGame2,
-                address(0),
-                "PermissionedDisputeGame2 blueprint should not be deployed"
-            );
-            assertEq(
-                output.opcm.blueprints().permissionlessDisputeGame1,
-                address(0),
-                "PermissionlessDisputeGame1 blueprint should not be deployed"
-            );
-            assertEq(
-                output.opcm.blueprints().permissionlessDisputeGame2,
-                address(0),
-                "PermissionlessDisputeGame2 blueprint should not be deployed"
-            );
+            if (!isDevFeatureEnabled(DevFeatures.OPCM_V2)) {
+                assertEq(
+                    output.opcm.blueprints().permissionedDisputeGame1,
+                    address(0),
+                    "PermissionedDisputeGame1 blueprint should not be deployed"
+                );
+                assertEq(
+                    output.opcm.blueprints().permissionedDisputeGame2,
+                    address(0),
+                    "PermissionedDisputeGame2 blueprint should not be deployed"
+                );
+                assertEq(
+                    output.opcm.blueprints().permissionlessDisputeGame1,
+                    address(0),
+                    "PermissionlessDisputeGame1 blueprint should not be deployed"
+                );
+                assertEq(
+                    output.opcm.blueprints().permissionlessDisputeGame2,
+                    address(0),
+                    "PermissionlessDisputeGame2 blueprint should not be deployed"
+                );
+            } else {
+                assertEq(
+                    output.opcmV2.blueprints().permissionedDisputeGame1,
+                    address(0),
+                    "PermissionedDisputeGame1 blueprint should not be deployed"
+                );
+                assertEq(
+                    output.opcmV2.blueprints().permissionedDisputeGame2,
+                    address(0),
+                    "PermissionedDisputeGame2 blueprint should not be deployed"
+                );
+                assertEq(
+                    output.opcmV2.blueprints().permissionlessDisputeGame1,
+                    address(0),
+                    "PermissionlessDisputeGame1 blueprint should not be deployed"
+                );
+                assertEq(
+                    output.opcmV2.blueprints().permissionlessDisputeGame2,
+                    address(0),
+                    "PermissionlessDisputeGame2 blueprint should not be deployed"
+                );
+            }
         } else {
             assertEq(address(output.faultDisputeGameV2Impl), address(0), "FaultDisputeGameV2 should not be deployed");
             assertEq(
@@ -305,6 +328,9 @@ contract DeployImplementations_Test is Test, FeatureFlags {
 
         DeployImplementations.Output memory output = deployImplementations.run(input);
 
+        // Check which OPCM version is deployed
+        bool opcmV2Enabled = DevFeatures.isDevFeatureEnabled(_devFeatureBitmap, DevFeatures.OPCM_V2);
+
         // Basic assertions
         assertNotEq(address(output.anchorStateRegistryImpl), address(0), "100");
         assertNotEq(address(output.delayedWETHImpl), address(0), "200");
@@ -314,10 +340,26 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         assertNotEq(address(output.l1ERC721BridgeImpl), address(0), "500");
         assertNotEq(address(output.l1StandardBridgeImpl), address(0), "600");
         assertNotEq(address(output.mipsSingleton), address(0), "700");
-        assertNotEq(address(output.opcm), address(0), "800");
-        assertNotEq(address(output.opcmContractsContainer), address(0), "900");
-        assertNotEq(address(output.opcmDeployer), address(0), "1000");
-        assertNotEq(address(output.opcmGameTypeAdder), address(0), "1100");
+
+        // OPCM version-specific assertions
+        if (opcmV2Enabled) {
+            assertNotEq(address(output.opcmV2), address(0), "800");
+            assertNotEq(address(output.opcmContainer), address(0), "900");
+            assertNotEq(address(output.opcmStandardValidator), address(0), "1000");
+            // V1 contracts should be null when V2 is enabled
+            assertEq(address(output.opcm), address(0), "800-v1");
+            assertEq(address(output.opcmContractsContainer), address(0), "900-v1");
+            assertEq(address(output.opcmDeployer), address(0), "1000-v1");
+            assertEq(address(output.opcmGameTypeAdder), address(0), "1100-v1");
+        } else {
+            assertNotEq(address(output.opcm), address(0), "800");
+            assertNotEq(address(output.opcmContractsContainer), address(0), "900");
+            assertNotEq(address(output.opcmDeployer), address(0), "1000");
+            assertNotEq(address(output.opcmGameTypeAdder), address(0), "1100");
+            // V2 contracts should be null when V1 is enabled
+            assertEq(address(output.opcmV2), address(0), "800-v2");
+            assertEq(address(output.opcmContainer), address(0), "900-v2");
+        }
 
         // Check V2 contracts based on feature flag
         bool v2Enabled = DevFeatures.isDevFeatureEnabled(_devFeatureBitmap, DevFeatures.DEPLOY_V2_DISPUTE_GAMES);
@@ -419,10 +461,26 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         assertNotEq(address(output.l1ERC721BridgeImpl).code, empty, "1700");
         assertNotEq(address(output.l1StandardBridgeImpl).code, empty, "1800");
         assertNotEq(address(output.mipsSingleton).code, empty, "1900");
-        assertNotEq(address(output.opcm).code, empty, "2000");
-        assertNotEq(address(output.opcmContractsContainer).code, empty, "2100");
-        assertNotEq(address(output.opcmDeployer).code, empty, "2200");
-        assertNotEq(address(output.opcmGameTypeAdder).code, empty, "2300");
+
+        // OPCM version-specific code assertions
+        if (opcmV2Enabled) {
+            assertNotEq(address(output.opcmV2).code, empty, "2000");
+            assertNotEq(address(output.opcmContainer).code, empty, "2100");
+            assertNotEq(address(output.opcmStandardValidator).code, empty, "2200");
+            // V1 contracts should be empty when V2 is enabled
+            assertEq(address(output.opcm).code, empty, "2000-v1");
+            assertEq(address(output.opcmContractsContainer).code, empty, "2100-v1");
+            assertEq(address(output.opcmDeployer).code, empty, "2200-v1");
+            assertEq(address(output.opcmGameTypeAdder).code, empty, "2300-v1");
+        } else {
+            assertNotEq(address(output.opcm).code, empty, "2000");
+            assertNotEq(address(output.opcmContractsContainer).code, empty, "2100");
+            assertNotEq(address(output.opcmDeployer).code, empty, "2200");
+            assertNotEq(address(output.opcmGameTypeAdder).code, empty, "2300");
+            // V2 contracts should be empty when V1 is enabled
+            assertEq(address(output.opcmV2).code, empty, "2000-v2");
+            assertEq(address(output.opcmContainer).code, empty, "2100-v2");
+        }
 
         // V2 contracts code existence based on feature flag
         if (v2Enabled) {


### PR DESCRIPTION
Closes OPT-1340

- Adds OPCMV2 deployment e2e test.
- Separates `createOPCMContractV2` from `createOPCMContract`.
- Refactor ReadImplementationsAddresses to use ocpmv2 interface when flag enabled