### PR TITLE
fix: ci unused imports error

### DIFF
--- a/packages/contracts-bedrock/test/L2/RevenueSharingIntegration.t.sol
+++ b/packages/contracts-bedrock/test/L2/RevenueSharingIntegration.t.sol
@@ -4,9 +4,7 @@ pragma solidity 0.8.15;
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { ISharesCalculator } from "interfaces/L2/ISharesCalculator.sol";
 import { ISuperchainRevSharesCalculator } from "interfaces/L2/ISuperchainRevSharesCalculator.sol";
-import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
-import { Types } from "src/libraries/Types.sol";
 import { ICrossDomainMessenger } from "interfaces/universal/ICrossDomainMessenger.sol";
 
 /// @title RevenueSharingIntegration_Test


### PR DESCRIPTION
CI log:
```
go run ./scripts/checks/unused-imports
❌  test/L2/RevenueSharingIntegration.t.sol: IFeeVault
❌  test/L2/RevenueSharingIntegration.t.sol: Types
error: processing failed
exit status 1
error: Recipe `unused-imports-check-no-build` failed on line 295 with exit code 1

Exited with code exit status 1
```