### PR TITLE
fix: opcm2 revert upgrade cgt

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
@@ -109,6 +109,7 @@ interface IOPContractsManagerV2 {
     error OPContractsManagerV2_DowngradeNotAllowed(address _contract);
     error OPContractsManagerV2_InvalidUpgradeInstruction();
     error OPContractsManagerV2_ConfigLoadFailed(string _name);
+    error OPContractsManagerV2_CannotUpgradeToCustomGasToken();
     error IdentityPrecompileCallFailed();
     error ReservedBitsSet();
     error BytesArrayTooLong();

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -175,6 +175,9 @@ contract OPContractsManagerV2 is ISemver {
     /// @notice Thrown when a config load fails.
     error OPContractsManagerV2_ConfigLoadFailed(string _name);
 
+    /// @notice Thrown when a chain attempts to upgrade to custom gas token after initial deployment.
+    error OPContractsManagerV2_CannotUpgradeToCustomGasToken();
+
     /// @notice Container of blueprint and implementation contract addresses.
     IOPContractsManagerContainer public immutable contractsContainer;
 
@@ -826,6 +829,9 @@ contract OPContractsManagerV2 is ISemver {
 
         // If the custom gas token feature was requested, enable it in the SystemConfig.
         if (_cfg.useCustomGasToken && !_cts.systemConfig.isFeatureEnabled(Features.CUSTOM_GAS_TOKEN)) {
+            if (!_isInitialDeployment) {
+                revert OPContractsManagerV2_CannotUpgradeToCustomGasToken();
+            }
             _cts.systemConfig.setFeature(Features.CUSTOM_GAS_TOKEN, true);
         }
 

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -829,6 +829,9 @@ contract OPContractsManagerV2 is ISemver {
 
         // If the custom gas token feature was requested, enable it in the SystemConfig.
         if (_cfg.useCustomGasToken && !_cts.systemConfig.isFeatureEnabled(Features.CUSTOM_GAS_TOKEN)) {
+            // NOTE: Enabling the custom gas token feature is only allowed during initial deployment to prevent
+            // chains from enabling it during upgrades. Passing in true for this flag during an upgrade is considered an
+            // error and will revert.
             if (!_isInitialDeployment) {
                 revert OPContractsManagerV2_CannotUpgradeToCustomGasToken();
             }

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -113,11 +113,9 @@ contract OPContractsManagerV2_Upgrade_TestInit is CommonTest, DisputeGames {
             IOPContractsManagerV2.ExtraInstruction({ key: "PermittedProxyDeployment", data: bytes("DelayedWETH") })
         );
 
+        // TODO(#18502): Remove the extra instruction for custom gas token after U18 ships.
         v2UpgradeInput.extraInstructions.push(
-            IOPContractsManagerV2.ExtraInstruction({
-                key: "overrides.cfg.useCustomGasToken",
-                data: abi.encode(Config.sysFeatureCustomGasToken())
-            })
+            IOPContractsManagerV2.ExtraInstruction({ key: "overrides.cfg.useCustomGasToken", data: abi.encode(false) })
         );
     }
 
@@ -477,6 +475,20 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
             abi.encodeWithSelector(
                 IOPContractsManagerV2.OPContractsManagerV2_ProxyMustLoad.selector, "L1CrossDomainMessenger"
             )
+        );
+    }
+
+    /// @notice Tests that the V2 upgrade function reverts when the user attempts to upgrade enabling custom gas token
+    ///         after initial deployment.
+    function test_upgrade_enableCustomGasTokenAfterInitialDeployment_reverts() public {
+        // Override the extra instruction for custom gas token to attempt to enable it.
+        v2UpgradeInput.extraInstructions[1] =
+            IOPContractsManagerV2.ExtraInstruction({ key: "overrides.cfg.useCustomGasToken", data: abi.encode(true) });
+
+        // nosemgrep: sol-style-use-abi-encodecall
+        runCurrentUpgradeV2(
+            chainPAO,
+            abi.encodeWithSelector(IOPContractsManagerV2.OPContractsManagerV2_CannotUpgradeToCustomGasToken.selector)
         );
     }
 

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -308,14 +308,13 @@ contract ForkLive is Deployer, StdAssertions, DisputeGames {
         });
 
         // Add extra instructions to allow the DelayedWETH proxy to be deployed.
+        // TODO(#18502): Remove the extra instruction for custom gas token after U18 ships.
         IOPContractsManagerV2.ExtraInstruction[] memory extraInstructions =
             new IOPContractsManagerV2.ExtraInstruction[](2);
         extraInstructions[0] =
             IOPContractsManagerV2.ExtraInstruction({ key: "PermittedProxyDeployment", data: bytes("DelayedWETH") });
-        extraInstructions[1] = IOPContractsManagerV2.ExtraInstruction({
-            key: "overrides.cfg.useCustomGasToken",
-            data: abi.encode(Config.sysFeatureCustomGasToken())
-        });
+        extraInstructions[1] =
+            IOPContractsManagerV2.ExtraInstruction({ key: "overrides.cfg.useCustomGasToken", data: abi.encode(false) });
 
         vm.prank(_delegateCaller, true);
         (bool upgradeSuccess,) = address(_opcm).delegatecall(


### PR DESCRIPTION
fix: prevent enabling CGT during upgrades and disable by default in tests

- Adds validation to block chain operators from enabling CGT during upgrades.
- Also disables CGT by default in configuration overrides for forked tests.