### PR TITLE
fix: remove cgt & fix tests

### DIFF
--- a/op-deployer/pkg/deployer/devfeatures.go
+++ b/op-deployer/pkg/deployer/devfeatures.go
@@ -18,9 +18,6 @@ var (
 	// DeployV2DisputeGamesDevFlag enables deployment of V2 dispute game contracts.
 	DeployV2DisputeGamesDevFlag = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000100")
 
-	// CustomGasTokenDevFlag enables the custom gas token.
-	CustomGasTokenDevFlag = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000001000")
-
 	// OPCMV2DevFlag enables the OPContractsManagerV2 contract.
 	OPCMV2DevFlag = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000010000")
 )

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
@@ -81,7 +81,6 @@ interface IOPContractsManagerV2 {
         uint256 l2ChainId;
         IResourceMetering.ResourceConfig resourceConfig;
         DisputeGameConfig[] disputeGameConfigs;
-        bool useCustomGasToken;
     }
 
     struct UpgradeInput {

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -36,6 +36,8 @@ import { IMIPS64 } from "interfaces/cannon/IMIPS64.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.sol";
+import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
 
 library ChainAssertions {
     Vm internal constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
@@ -110,10 +112,19 @@ library ChainAssertions {
         require(config.scalar() >> 248 == 1, "CHECK-SCFG-70");
         // Depends on start block being set to 0 in `initialize`
         require(config.startBlock() == block.number, "CHECK-SCFG-140");
-        require(
-            config.batchInbox() == IOPContractsManager(_doi.opcm).chainIdToBatchInboxAddress(_doi.l2ChainId),
-            "CHECK-SCFG-150"
-        );
+        if (IOPContractsManager(_doi.opcm).isDevFeatureEnabled(DevFeatures.OPCM_V2)) {
+            require(
+                config.batchInbox()
+                    == IOPContractsManagerUtils(IOPContractsManagerV2(address(_doi.opcm)).utils())
+                        .chainIdToBatchInboxAddress(_doi.l2ChainId),
+                "CHECK-SCFG-150"
+            );
+        } else {
+            require(
+                config.batchInbox() == IOPContractsManager(_doi.opcm).chainIdToBatchInboxAddress(_doi.l2ChainId),
+                "CHECK-SCFG-150"
+            );
+        }
         // Check _addresses
         require(config.l1CrossDomainMessenger() == _contracts.L1CrossDomainMessenger, "CHECK-SCFG-160");
         require(config.l1ERC721Bridge() == _contracts.L1ERC721Bridge, "CHECK-SCFG-170");

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -553,8 +553,7 @@ contract Deploy is Deployer {
             gasLimit: uint64(cfg.l2GenesisBlockGasLimit()),
             l2ChainId: cfg.l2ChainID(),
             resourceConfig: Constants.DEFAULT_RESOURCE_CONFIG(),
-            disputeGameConfigs: disputeGameConfigs,
-            useCustomGasToken: cfg.useCustomGasToken()
+            disputeGameConfigs: disputeGameConfigs
         });
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -22,14 +22,12 @@ import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
 import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
-import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
 import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
-import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
-import { GameType, GameTypes, Proposal } from "src/dispute/lib/Types.sol";
+import { GameTypes } from "src/dispute/lib/Types.sol";
 
 contract DeployOPChain is Script {
     struct Output {
@@ -213,8 +211,7 @@ contract DeployOPChain is Script {
             gasLimit: _input.gasLimit,
             l2ChainId: _input.l2ChainId,
             resourceConfig: Constants.DEFAULT_RESOURCE_CONFIG(),
-            disputeGameConfigs: disputeGameConfigs,
-            useCustomGasToken: _input.useCustomGasToken
+            disputeGameConfigs: disputeGameConfigs
         });
     }
 

--- a/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
@@ -63,7 +63,7 @@ contract ReadImplementationAddresses is Script {
         output_.l1StandardBridge = IStaticL1ChugSplashProxy(_input.l1StandardBridgeProxy).getImplementation();
 
         // Check if OPCM v2 is being used
-        bool useV2 = isDevFeatureOpcmV2Enabled(_input.opcm);
+        bool useV2 = IOPContractsManager(_input.opcm).isDevFeatureEnabled(DevFeatures.OPCM_V2);
 
         if (useV2) {
             // Get implementations from OPCM V2
@@ -116,12 +116,6 @@ contract ReadImplementationAddresses is Script {
 
         // Get PreimageOracle from MIPS singleton
         output_.preimageOracleSingleton = address(IMIPS64(output_.mipsSingleton).oracle());
-    }
-
-    /// @notice Checks if OPCM v2 dev feature flag is enabled from the contract's dev feature bitmap.
-    function isDevFeatureOpcmV2Enabled(address _opcmAddr) internal view returns (bool) {
-        // Both v1 and v2 share the same interface for this function.
-        return IOPContractsManager(_opcmAddr).isDevFeatureEnabled(DevFeatures.OPCM_V2);
     }
 
     function runWithBytes(bytes memory _input) public returns (bytes memory) {

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
@@ -1126,6 +1126,11 @@
   },
   {
     "inputs": [],
+    "name": "OPContractsManager_V1Disabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OnlyDelegatecall",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x6fd82aaec43858b34bd093e29bbacb659a95817d506de948aebd3c84e6d2a00a",
-    "sourceCodeHash": "0x5f63555e12cb8e27ce5c1511e986550bf2f1b9769e314223a7324b8dcfa29523"
+    "initCodeHash": "0xc00442723530a0a9288bcc8bc7ecabee248af5ea330fea9e5dcbd7456dfc5da3",
+    "sourceCodeHash": "0xa18df291aa5a9da72617726f5b436e34066d78c4b5dae7401b1d708bc62bb4cb"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0x0c8b15453d0f0bc5d9af07f104505e0bbb2b358f0df418289822fb73a8652b30",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0xc00442723530a0a9288bcc8bc7ecabee248af5ea330fea9e5dcbd7456dfc5da3",
-    "sourceCodeHash": "0xa18df291aa5a9da72617726f5b436e34066d78c4b5dae7401b1d708bc62bb4cb"
+    "initCodeHash": "0xf8a73b2ed02a9c4c920bca1583491e51167eec6cf68e2e0226cff9c31063bfc6",
+    "sourceCodeHash": "0xb95bf3765881adab6804cf29b2aef5f40eec0ce755b2d97bd1b9ff1da767e2c9"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0x0c8b15453d0f0bc5d9af07f104505e0bbb2b358f0df418289822fb73a8652b30",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -2236,9 +2236,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 5.7.1
+    /// @custom:semver 5.8.0
     function version() public pure virtual returns (string memory) {
-        return "5.7.1";
+        return "5.8.0";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -117,8 +117,6 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         IResourceMetering.ResourceConfig resourceConfig;
         // Dispute game configuration.
         DisputeGameConfig[] disputeGameConfigs;
-        // Feature flags.
-        bool useCustomGasToken;
     }
 
     /// @notice Partial input required for an upgrade.
@@ -585,16 +583,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
                 ),
                 (GameType)
             ),
-            disputeGameConfigs: _upgradeInput.disputeGameConfigs,
-            useCustomGasToken: abi.decode(
-                _loadBytes(
-                    address(_chainContracts.systemConfig),
-                    _chainContracts.systemConfig.isCustomGasToken.selector,
-                    "overrides.cfg.useCustomGasToken",
-                    _upgradeInput.extraInstructions
-                ),
-                (bool)
-            )
+            disputeGameConfigs: _upgradeInput.disputeGameConfigs
         });
     }
 
@@ -796,11 +785,6 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             _cts.disputeGameFactory.setInitBond(
                 _cfg.disputeGameConfigs[i].gameType, _cfg.disputeGameConfigs[i].initBond
             );
-        }
-
-        // If the custom gas token feature was requested, enable it in the SystemConfig.
-        if (_cfg.useCustomGasToken) {
-            _cts.systemConfig.setFeature(Features.CUSTOM_GAS_TOKEN, true);
         }
 
         // If critical transfer is allowed, tranfer ownership of the DisputeGameFactory and

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -2318,6 +2318,11 @@ contract OPContractsManager_Migrate_Test is OPContractsManager_TestInit {
 contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase, DisputeGames {
     using stdStorage for StdStorage;
 
+    function setUp() public override {
+        super.setUp();
+        skipIfDevFeatureEnabled(DevFeatures.OPCM_V2);
+    }
+
     // This helper function is used to convert the input struct type defined in DeployOPChain.s.sol
     // to the input struct type defined in OPContractsManager.sol.
     function toOPCMDeployInput(Types.DeployOPChainInput memory _doi)

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -219,7 +219,10 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         deployOPChainInput.basefeeScalar = uint32(uint256(hash(_seed, 6)));
         deployOPChainInput.blobBaseFeeScalar = uint32(uint256(hash(_seed, 7)));
         deployOPChainInput.l2ChainId = uint256(hash(_seed, 8));
-        deployOPChainInput.useCustomGasToken = uint256(hash(_seed, 9)) % 2 == 1;
+        // TODO: Remove this when cgt support is added to OPCM v2
+        if (!isDevFeatureEnabled(DevFeatures.OPCM_V2)) {
+            deployOPChainInput.useCustomGasToken = uint256(hash(_seed, 9)) % 2 == 1;
+        }
 
         DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
 
@@ -269,6 +272,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
     }
 
     function test_customGasToken_enabled_succeeds() public {
+        skipIfDevFeatureEnabled(DevFeatures.OPCM_V2);
         deployOPChainInput.useCustomGasToken = true;
         DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
 

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -219,7 +219,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         deployOPChainInput.basefeeScalar = uint32(uint256(hash(_seed, 6)));
         deployOPChainInput.blobBaseFeeScalar = uint32(uint256(hash(_seed, 7)));
         deployOPChainInput.l2ChainId = uint256(hash(_seed, 8));
-        // TODO: Remove this when cgt support is added to OPCM v2
+        // TODO(#18536): Remove this when cgt support is added to OPCM v2
         if (!isDevFeatureEnabled(DevFeatures.OPCM_V2)) {
             deployOPChainInput.useCustomGasToken = uint256(hash(_seed, 9)) % 2 == 1;
         }
@@ -272,6 +272,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
     }
 
     function test_customGasToken_enabled_succeeds() public {
+        // TODO(#18536): Remove this when cgt support is added to OPCM v2
         skipIfDevFeatureEnabled(DevFeatures.OPCM_V2);
         deployOPChainInput.useCustomGasToken = true;
         DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Drops custom gas token support from OPCM v2 configs and flows, updates scripts/tests accordingly, adds v2-aware batchInbox assertion, and bumps OPCM v1 to 5.8.0 with ABI/semver updates.
> 
> - **Contracts/Interfaces**:
>   - Remove `useCustomGasToken` from `IOPContractsManagerV2.FullConfig` and OPCM v2 deploy/upgrade code; delete CGT feature toggling logic.
>   - Add v2-aware `batchInbox` check using `IOPContractsManagerV2.utils()` in `ChainAssertions`.
>   - Bump `OPContractsManager` version to `5.8.0`; add `OPContractsManager_V1Disabled` error to ABI; update semver/ABI snapshots.
> - **Scripts**:
>   - Update `Deploy.s.sol`/`DeployOPChain.s.sol` to omit CGT for OPCM v2 paths; keep v1 behavior.
>   - `ReadImplementationAddresses.s.sol`: inline `isDevFeatureEnabled` check; remove helper.
> - **Tests**:
>   - Gate/skip CGT-related assertions under `DevFeatures.OPCM_V2`; adjust fuzz tests.
> - **Tooling**:
>   - Remove `CustomGasTokenDevFlag` from `op-deployer` dev flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f53cda09c69d138b11b61f1d8f1a23e12905ec17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->