### PR TITLE
fix: opcm2 upgrade cgt

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xc2b530bf529ac23d1ba1adf67eedcc5d95e25c2919e1d97f4f2bba4823303b17"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x261d0a21753bf8e1aa1cdac947c8b7213c1a18c7cd4c1232d5fb64563abb9658",
-    "sourceCodeHash": "0x032e7cf4529746dd08a59786af150962ef78b7252633c08020df27bbe23336d2"
+    "initCodeHash": "0x61f277f17bf912af82aa29ad6dab2eba80f7feaa657b8d2080698f967466f1a9",
+    "sourceCodeHash": "0xbedaf8efda625486fe6c2427c2bf3efe69b5fe1bbdd5d5835f9e2adb9755a441"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -159,8 +159,8 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     IOPContractsManagerStandardValidator public immutable standardValidator;
 
     /// @notice The version of the OPCM contract.
-    /// @custom:semver 6.2.0
-    string public constant version = "6.2.0";
+    /// @custom:semver 6.3.0
+    string public constant version = "6.3.0";
 
     /// @param _contractsContainer The container of blueprint and implementation contract addresses.
     /// @param _standardValidator The standard validator for this OPCM release.
@@ -805,10 +805,12 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         }
 
         // If the custom gas token feature was requested, enable it in the SystemConfig.
-        if (_cfg.useCustomGasToken) {
+        // If the cgt is enabled, we skip this step.
+        if (_cfg.useCustomGasToken && !_cts.systemConfig.isCustomGasToken()) {
             // NOTE: Enabling the custom gas token feature is only allowed during initial deployment to prevent
             // chains from enabling it during upgrades. Passing in true for this flag during an upgrade is considered an
             // error and will revert.
+            // Revert only if trying to upgrade from CGT disabled to CGT enabled.
             if (!_isInitialDeployment) {
                 revert OPContractsManagerV2_CannotUpgradeToCustomGasToken();
             }


### PR DESCRIPTION
tests are covered by:
- https://github.com/defi-wonderland/optimism/blob/493b1f63a2a2512113fca8a3bdb64cbab9dc9b87/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol#L666