### PR TITLE
feat: add custom gas token faucet contracts

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
@@ -12,25 +12,22 @@ import { FaucetDeployer } from "scripts/deploy/cgt-faucet/FaucetDeployer.sol";
 ///         The FaucetDeployer is used by multisigs (via delegatecall) to deploy
 ///         and manage NativeAssetFaucet contracts on L2.
 contract DeployFaucetDeployer is Script {
+    address deployer;
+
     /// @notice Deploys the FaucetDeployer contract on L1.
     /// @param _portal The OptimismPortal2 contract address.
     function run(address _portal) public returns (FaucetDeployer) {
+        deployer = msg.sender;
+
         console.log("=== DeployFaucetDeployer ===");
         console.log("Portal:", _portal);
+        console.log("Deployer:", deployer);
 
-        vm.startBroadcast();
-
+        vm.broadcast(deployer);
         FaucetDeployer faucetDeployer = new FaucetDeployer(IOptimismPortal2(payable(_portal)));
-
-        vm.stopBroadcast();
 
         console.log("\n=== Deployment Complete ===");
         console.log("FaucetDeployer deployed at:", address(faucetDeployer));
-        console.log("\nUsage:");
-        console.log("1. From LiquidityController owner (Safe), delegatecall:");
-        console.log("   faucetDeployer.deployAndAuthorize(faucetOwner, permissionlessAmount, gasLimit)");
-        console.log("2. From faucet owner (Safe), delegatecall:");
-        console.log("   faucetDeployer.mint(faucetAddress, recipient, amount, gasLimit)");
 
         return faucetDeployer;
     }

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
@@ -5,6 +5,7 @@ import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";
 
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { Preinstalls } from "src/libraries/Preinstalls.sol";
 import { FaucetDeployer } from "scripts/deploy/cgt-faucet/FaucetDeployer.sol";
 
 /// @title DeployFaucetDeployer
@@ -12,19 +13,17 @@ import { FaucetDeployer } from "scripts/deploy/cgt-faucet/FaucetDeployer.sol";
 ///         The FaucetDeployer is used by multisigs (via delegatecall) to deploy
 ///         and manage NativeAssetFaucet contracts on L2.
 contract DeployFaucetDeployer is Script {
-    /// @notice The CREATE2 Deployer predeploy address on L2
-    address constant CREATE2_DEPLOYER = 0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2;
 
     /// @notice Deploys the FaucetDeployer contract on L1.
     /// @param _portal The OptimismPortal2 contract address.
     function run(address _portal) public returns (FaucetDeployer) {
         console.log("=== DeployFaucetDeployer ===");
         console.log("Portal:", _portal);
-        console.log("CREATE2 Deployer:", CREATE2_DEPLOYER);
+        console.log("CREATE2 Deployer:", Preinstalls.Create2Deployer);
 
         vm.startBroadcast();
 
-        FaucetDeployer faucetDeployer = new FaucetDeployer(IOptimismPortal2(payable(_portal)), CREATE2_DEPLOYER);
+        FaucetDeployer faucetDeployer = new FaucetDeployer(IOptimismPortal2(payable(_portal)), Preinstalls.Create2Deployer);
 
         vm.stopBroadcast();
 

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
@@ -12,7 +12,6 @@ import { FaucetDeployer } from "scripts/deploy/cgt-faucet/FaucetDeployer.sol";
 ///         The FaucetDeployer is used by multisigs (via delegatecall) to deploy
 ///         and manage NativeAssetFaucet contracts on L2.
 contract DeployFaucetDeployer is Script {
-
     /// @notice Deploys the FaucetDeployer contract on L1.
     /// @param _portal The OptimismPortal2 contract address.
     function run(address _portal) public returns (FaucetDeployer) {

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { FaucetDeployer } from "src/L1/FaucetDeployer.sol";
+
+/// @title DeployFaucetDeployer
+/// @notice Script to deploy the FaucetDeployer contract on L1.
+///         The FaucetDeployer is used by multisigs (via delegatecall) to deploy
+///         and manage NativeAssetFaucet contracts on L2.
+contract DeployFaucetDeployer is Script {
+    /// @notice The CREATE2 Deployer predeploy address on L2
+    address constant CREATE2_DEPLOYER = 0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2;
+
+    function run() external {
+        // Get environment variables
+        address payable portal = payable(vm.envAddress("PORTAL"));
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        console.log("=== DeployFaucetDeployer ===");
+        console.log("Portal:", portal);
+        console.log("CREATE2 Deployer:", CREATE2_DEPLOYER);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        FaucetDeployer faucetDeployer = new FaucetDeployer(IOptimismPortal2(portal), CREATE2_DEPLOYER);
+
+        vm.stopBroadcast();
+
+        console.log("\n=== Deployment Complete ===");
+        console.log("FaucetDeployer deployed at:", address(faucetDeployer));
+        console.log("\nUsage:");
+        console.log("1. From LiquidityController owner (Safe), delegatecall:");
+        console.log("   faucetDeployer.deployAndAuthorize(faucetOwner, permissionlessAmount, gasLimit)");
+        console.log("2. From faucet owner (Safe), delegatecall:");
+        console.log("   faucetDeployer.mint(faucetAddress, recipient, amount, gasLimit)");
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
@@ -5,7 +5,7 @@ import { Script } from "forge-std/Script.sol";
 import { console } from "forge-std/console.sol";
 
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
-import { FaucetDeployer } from "src/L1/FaucetDeployer.sol";
+import { FaucetDeployer } from "scripts/deploy/cgt-faucet/FaucetDeployer.sol";
 
 /// @title DeployFaucetDeployer
 /// @notice Script to deploy the FaucetDeployer contract on L1.

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
@@ -5,7 +5,6 @@ import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";
 
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
-import { Preinstalls } from "src/libraries/Preinstalls.sol";
 import { FaucetDeployer } from "scripts/deploy/cgt-faucet/FaucetDeployer.sol";
 
 /// @title DeployFaucetDeployer
@@ -19,11 +18,10 @@ contract DeployFaucetDeployer is Script {
     function run(address _portal) public returns (FaucetDeployer) {
         console.log("=== DeployFaucetDeployer ===");
         console.log("Portal:", _portal);
-        console.log("CREATE2 Deployer:", Preinstalls.Create2Deployer);
 
         vm.startBroadcast();
 
-        FaucetDeployer faucetDeployer = new FaucetDeployer(IOptimismPortal2(payable(_portal)), Preinstalls.Create2Deployer);
+        FaucetDeployer faucetDeployer = new FaucetDeployer(IOptimismPortal2(payable(_portal)));
 
         vm.stopBroadcast();
 

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Script } from "forge-std/Script.sol";
-import { console } from "forge-std/console.sol";
+import { console2 as console } from "forge-std/console2.sol";
 
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { FaucetDeployer } from "scripts/deploy/cgt-faucet/FaucetDeployer.sol";
@@ -15,18 +15,16 @@ contract DeployFaucetDeployer is Script {
     /// @notice The CREATE2 Deployer predeploy address on L2
     address constant CREATE2_DEPLOYER = 0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2;
 
-    function run() external {
-        // Get environment variables
-        address payable portal = payable(vm.envAddress("PORTAL"));
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-
+    /// @notice Deploys the FaucetDeployer contract on L1.
+    /// @param _portal The OptimismPortal2 contract address.
+    function run(address _portal) public returns (FaucetDeployer) {
         console.log("=== DeployFaucetDeployer ===");
-        console.log("Portal:", portal);
+        console.log("Portal:", _portal);
         console.log("CREATE2 Deployer:", CREATE2_DEPLOYER);
 
-        vm.startBroadcast(deployerPrivateKey);
+        vm.startBroadcast();
 
-        FaucetDeployer faucetDeployer = new FaucetDeployer(IOptimismPortal2(portal), CREATE2_DEPLOYER);
+        FaucetDeployer faucetDeployer = new FaucetDeployer(IOptimismPortal2(payable(_portal)), CREATE2_DEPLOYER);
 
         vm.stopBroadcast();
 
@@ -37,5 +35,7 @@ contract DeployFaucetDeployer is Script {
         console.log("   faucetDeployer.deployAndAuthorize(faucetOwner, permissionlessAmount, gasLimit)");
         console.log("2. From faucet owner (Safe), delegatecall:");
         console.log("   faucetDeployer.mint(faucetAddress, recipient, amount, gasLimit)");
+
+        return faucetDeployer;
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { ILiquidityController } from "interfaces/L2/ILiquidityController.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { NativeAssetFaucet } from "src/L2/NativeAssetFaucet.sol";
+
+/// @title ICreate2Deployer
+/// @notice Interface for the CREATE2 Deployer predeploy
+interface ICreate2Deployer {
+    function deploy(uint256 _value, bytes32 _salt, bytes memory _code) external returns (address);
+}
+
+/// @title DeployNativeAssetFaucet
+/// @notice Script to deploy NativeAssetFaucet to L2 via deposit transactions
+contract DeployNativeAssetFaucet is Script {
+    /// @notice The CREATE2 Deployer predeploy address
+    address constant CREATE2_DEPLOYER = 0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2;
+
+    /// @notice Salt prefix for deterministic deployment
+    string constant SALT_SEED = "Faucet2";
+
+    /// @notice Gas limit for L2 transactions
+    uint64 constant GAS_LIMIT = 1000000;
+
+    function run() external {
+        // Get environment variables
+        address payable portal = payable(vm.envAddress("PORTAL"));
+        address owner = vm.envAddress("FAUCET_OWNER");
+        uint256 permissionlessAmount = vm.envOr("PERMISSIONLESS_AMOUNT", uint256(1 ether));
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        console.log("=== DeployNativeAssetFaucet ===");
+        console.log("Portal:", portal);
+        console.log("Owner:", owner);
+        console.log("Permissionless Amount:", permissionlessAmount);
+
+        // Calculate the faucet address
+        address faucetAddress = computeFaucetAddress(owner, permissionlessAmount);
+        console.log("Computed Faucet Address:", faucetAddress);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // Step 1: Deploy faucet via CREATE2
+        console.log("\n=== Step 1: Deploying NativeAssetFaucet via CREATE2 ===");
+        deployFaucet(IOptimismPortal2(portal), owner, permissionlessAmount);
+
+        // Step 2: Authorize faucet as minter in LiquidityController
+        console.log("\n=== Step 2: Authorizing faucet as minter ===");
+        authorizeFaucet(IOptimismPortal2(portal), faucetAddress);
+
+        vm.stopBroadcast();
+
+        console.log("\n=== Deployment Complete ===");
+        console.log("Faucet will be deployed at:", faucetAddress);
+        console.log("Wait for L2 to process the deposit transactions (~10-15 seconds)");
+    }
+
+    /// @notice Deploys NativeAssetFaucet via CREATE2 on L2
+    function deployFaucet(
+        IOptimismPortal2 _portal,
+        address _owner,
+        uint256 _permissionlessAmount
+    )
+        internal
+    {
+        bytes memory initCode =
+            bytes.concat(type(NativeAssetFaucet).creationCode, abi.encode(_owner, _permissionlessAmount));
+        bytes32 salt = keccak256(abi.encodePacked(SALT_SEED, ":", _owner));
+
+        _portal.depositTransaction({
+            _to: CREATE2_DEPLOYER,
+            _value: 0,
+            _gasLimit: GAS_LIMIT,
+            _isCreation: false,
+            _data: abi.encodeCall(ICreate2Deployer.deploy, (0, salt, initCode))
+        });
+
+        console.log("Deposit transaction sent for CREATE2 deployment");
+    }
+
+    /// @notice Authorizes the faucet as a minter in LiquidityController
+    function authorizeFaucet(IOptimismPortal2 _portal, address _faucet) internal {
+        _portal.depositTransaction({
+            _to: Predeploys.LIQUIDITY_CONTROLLER,
+            _value: 0,
+            _gasLimit: GAS_LIMIT,
+            _isCreation: false,
+            _data: abi.encodeCall(ILiquidityController.authorizeMinter, (_faucet))
+        });
+
+        console.log("Deposit transaction sent for authorizeMinter");
+    }
+
+    /// @notice Computes the CREATE2 address for the faucet
+    function computeFaucetAddress(address _owner, uint256 _permissionlessAmount) public pure returns (address) {
+        bytes memory initCode =
+            bytes.concat(type(NativeAssetFaucet).creationCode, abi.encode(_owner, _permissionlessAmount));
+        bytes32 salt = keccak256(abi.encodePacked(SALT_SEED, ":", _owner));
+        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), CREATE2_DEPLOYER, salt, keccak256(initCode)));
+        return address(uint160(uint256(hash)));
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol
@@ -19,6 +19,8 @@ interface ICreate2Deployer {
 /// @title DeployNativeAssetFaucet
 /// @notice Script to deploy NativeAssetFaucet to L2 via deposit transactions
 contract DeployNativeAssetFaucet is Script {
+    address deployer;
+
     /// @notice Deploys and authorizes the NativeAssetFaucet on L2.
     /// @param _portal The OptimismPortal2 contract address.
     /// @param _owner The owner of the faucet.
@@ -35,32 +37,28 @@ contract DeployNativeAssetFaucet is Script {
         public
         returns (address)
     {
+        deployer = msg.sender;
+
         console.log("=== DeployNativeAssetFaucet ===");
         console.log("Portal:", _portal);
         console.log("Owner:", _owner);
         console.log("Permissionless Amount:", _permissionlessAmount);
         console.log("Gas Limit:", _gasLimit);
         console.log("Salt Seed:", _saltSeed);
+        console.log("Deployer:", deployer);
 
         // Calculate the faucet address
         address faucetAddress = computeFaucetAddress(_owner, _permissionlessAmount, _saltSeed);
         console.log("Computed Faucet Address:", faucetAddress);
 
-        vm.startBroadcast();
-
         // Step 1: Deploy faucet via CREATE2
-        console.log("\n=== Step 1: Deploying NativeAssetFaucet via CREATE2 ===");
         deployFaucet(IOptimismPortal2(payable(_portal)), _owner, _permissionlessAmount, _gasLimit, _saltSeed);
 
         // Step 2: Authorize faucet as minter in LiquidityController
-        console.log("\n=== Step 2: Authorizing faucet as minter ===");
         authorizeFaucet(IOptimismPortal2(payable(_portal)), faucetAddress, _gasLimit);
-
-        vm.stopBroadcast();
 
         console.log("\n=== Deployment Complete ===");
         console.log("Faucet will be deployed at:", faucetAddress);
-        console.log("Wait for L2 to process the deposit transactions (~10-15 seconds)");
 
         return faucetAddress;
     }
@@ -79,6 +77,7 @@ contract DeployNativeAssetFaucet is Script {
             bytes.concat(type(NativeAssetFaucet).creationCode, abi.encode(_owner, _permissionlessAmount));
         bytes32 salt = keccak256(abi.encodePacked(_saltSeed, ":", _owner));
 
+        vm.broadcast(deployer);
         _portal.depositTransaction({
             _to: Preinstalls.Create2Deployer,
             _value: 0,
@@ -86,12 +85,11 @@ contract DeployNativeAssetFaucet is Script {
             _isCreation: false,
             _data: abi.encodeCall(ICreate2Deployer.deploy, (0, salt, initCode))
         });
-
-        console.log("Deposit transaction sent for CREATE2 deployment");
     }
 
     /// @notice Authorizes the faucet as a minter in LiquidityController
     function authorizeFaucet(IOptimismPortal2 _portal, address _faucet, uint64 _gasLimit) internal {
+        vm.broadcast(deployer);
         _portal.depositTransaction({
             _to: Predeploys.LIQUIDITY_CONTROLLER,
             _value: 0,
@@ -99,8 +97,6 @@ contract DeployNativeAssetFaucet is Script {
             _isCreation: false,
             _data: abi.encodeCall(ILiquidityController.authorizeMinter, (_faucet))
         });
-
-        console.log("Deposit transaction sent for authorizeMinter");
     }
 
     /// @notice Computes the CREATE2 address for the faucet

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol
@@ -2,12 +2,12 @@
 pragma solidity 0.8.15;
 
 import { Script } from "forge-std/Script.sol";
-import { console } from "forge-std/console.sol";
+import { console2 as console } from "forge-std/console2.sol";
 
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ILiquidityController } from "interfaces/L2/ILiquidityController.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
-import { NativeAssetFaucet } from "src/L2/NativeAssetFaucet.sol";
+import { NativeAssetFaucet } from "scripts/deploy/cgt-faucet/NativeAssetFaucet.sol";
 
 /// @title ICreate2Deployer
 /// @notice Interface for the CREATE2 Deployer predeploy
@@ -21,61 +21,70 @@ contract DeployNativeAssetFaucet is Script {
     /// @notice The CREATE2 Deployer predeploy address
     address constant CREATE2_DEPLOYER = 0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2;
 
-    /// @notice Salt prefix for deterministic deployment
-    string constant SALT_SEED = "Faucet2";
-
-    /// @notice Gas limit for L2 transactions
-    uint64 constant GAS_LIMIT = 1000000;
-
-    function run() external {
-        // Get environment variables
-        address payable portal = payable(vm.envAddress("PORTAL"));
-        address owner = vm.envAddress("FAUCET_OWNER");
-        uint256 permissionlessAmount = vm.envOr("PERMISSIONLESS_AMOUNT", uint256(1 ether));
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-
+    /// @notice Deploys and authorizes the NativeAssetFaucet on L2.
+    /// @param _portal The OptimismPortal2 contract address.
+    /// @param _owner The owner of the faucet.
+    /// @param _permissionlessAmount The amount claimable per call.
+    /// @param _gasLimit The gas limit for L2 deposit transactions.
+    /// @param _saltSeed The salt seed for deterministic deployment.
+    function run(
+        address _portal,
+        address _owner,
+        uint256 _permissionlessAmount,
+        uint64 _gasLimit,
+        string memory _saltSeed
+    )
+        public
+        returns (address)
+    {
         console.log("=== DeployNativeAssetFaucet ===");
-        console.log("Portal:", portal);
-        console.log("Owner:", owner);
-        console.log("Permissionless Amount:", permissionlessAmount);
+        console.log("Portal:", _portal);
+        console.log("Owner:", _owner);
+        console.log("Permissionless Amount:", _permissionlessAmount);
+        console.log("Gas Limit:", _gasLimit);
+        console.log("Salt Seed:", _saltSeed);
 
         // Calculate the faucet address
-        address faucetAddress = computeFaucetAddress(owner, permissionlessAmount);
+        address faucetAddress = computeFaucetAddress(_owner, _permissionlessAmount, _saltSeed);
         console.log("Computed Faucet Address:", faucetAddress);
 
-        vm.startBroadcast(deployerPrivateKey);
+        vm.startBroadcast();
 
         // Step 1: Deploy faucet via CREATE2
         console.log("\n=== Step 1: Deploying NativeAssetFaucet via CREATE2 ===");
-        deployFaucet(IOptimismPortal2(portal), owner, permissionlessAmount);
+        deployFaucet(IOptimismPortal2(payable(_portal)), _owner, _permissionlessAmount, _gasLimit, _saltSeed);
 
         // Step 2: Authorize faucet as minter in LiquidityController
         console.log("\n=== Step 2: Authorizing faucet as minter ===");
-        authorizeFaucet(IOptimismPortal2(portal), faucetAddress);
+        authorizeFaucet(IOptimismPortal2(payable(_portal)), faucetAddress, _gasLimit);
 
         vm.stopBroadcast();
 
         console.log("\n=== Deployment Complete ===");
         console.log("Faucet will be deployed at:", faucetAddress);
         console.log("Wait for L2 to process the deposit transactions (~10-15 seconds)");
+
+        return faucetAddress;
     }
 
     /// @notice Deploys NativeAssetFaucet via CREATE2 on L2
     function deployFaucet(
         IOptimismPortal2 _portal,
         address _owner,
-        uint256 _permissionlessAmount
+        uint256 _permissionlessAmount,
+        uint64 _gasLimit,
+        string memory _saltSeed
     )
         internal
     {
         bytes memory initCode =
             bytes.concat(type(NativeAssetFaucet).creationCode, abi.encode(_owner, _permissionlessAmount));
-        bytes32 salt = keccak256(abi.encodePacked(SALT_SEED, ":", _owner));
+        bytes32 salt = keccak256(abi.encodePacked(_saltSeed, ":", _owner));
 
         _portal.depositTransaction({
             _to: CREATE2_DEPLOYER,
             _value: 0,
-            _gasLimit: GAS_LIMIT,
+            _gasLimit: _gasLimit,
             _isCreation: false,
             _data: abi.encodeCall(ICreate2Deployer.deploy, (0, salt, initCode))
         });
@@ -84,11 +93,11 @@ contract DeployNativeAssetFaucet is Script {
     }
 
     /// @notice Authorizes the faucet as a minter in LiquidityController
-    function authorizeFaucet(IOptimismPortal2 _portal, address _faucet) internal {
+    function authorizeFaucet(IOptimismPortal2 _portal, address _faucet, uint64 _gasLimit) internal {
         _portal.depositTransaction({
             _to: Predeploys.LIQUIDITY_CONTROLLER,
             _value: 0,
-            _gasLimit: GAS_LIMIT,
+            _gasLimit: _gasLimit,
             _isCreation: false,
             _data: abi.encodeCall(ILiquidityController.authorizeMinter, (_faucet))
         });
@@ -97,10 +106,18 @@ contract DeployNativeAssetFaucet is Script {
     }
 
     /// @notice Computes the CREATE2 address for the faucet
-    function computeFaucetAddress(address _owner, uint256 _permissionlessAmount) public pure returns (address) {
+    function computeFaucetAddress(
+        address _owner,
+        uint256 _permissionlessAmount,
+        string memory _saltSeed
+    )
+        public
+        pure
+        returns (address)
+    {
         bytes memory initCode =
             bytes.concat(type(NativeAssetFaucet).creationCode, abi.encode(_owner, _permissionlessAmount));
-        bytes32 salt = keccak256(abi.encodePacked(SALT_SEED, ":", _owner));
+        bytes32 salt = keccak256(abi.encodePacked(_saltSeed, ":", _owner));
         bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), CREATE2_DEPLOYER, salt, keccak256(initCode)));
         return address(uint160(uint256(hash)));
     }

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol
@@ -7,6 +7,7 @@ import { console2 as console } from "forge-std/console2.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ILiquidityController } from "interfaces/L2/ILiquidityController.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Preinstalls } from "src/libraries/Preinstalls.sol";
 import { NativeAssetFaucet } from "scripts/deploy/cgt-faucet/NativeAssetFaucet.sol";
 
 /// @title ICreate2Deployer
@@ -18,8 +19,6 @@ interface ICreate2Deployer {
 /// @title DeployNativeAssetFaucet
 /// @notice Script to deploy NativeAssetFaucet to L2 via deposit transactions
 contract DeployNativeAssetFaucet is Script {
-    /// @notice The CREATE2 Deployer predeploy address
-    address constant CREATE2_DEPLOYER = 0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2;
 
     /// @notice Deploys and authorizes the NativeAssetFaucet on L2.
     /// @param _portal The OptimismPortal2 contract address.
@@ -82,7 +81,7 @@ contract DeployNativeAssetFaucet is Script {
         bytes32 salt = keccak256(abi.encodePacked(_saltSeed, ":", _owner));
 
         _portal.depositTransaction({
-            _to: CREATE2_DEPLOYER,
+            _to: Preinstalls.Create2Deployer,
             _value: 0,
             _gasLimit: _gasLimit,
             _isCreation: false,
@@ -118,7 +117,7 @@ contract DeployNativeAssetFaucet is Script {
         bytes memory initCode =
             bytes.concat(type(NativeAssetFaucet).creationCode, abi.encode(_owner, _permissionlessAmount));
         bytes32 salt = keccak256(abi.encodePacked(_saltSeed, ":", _owner));
-        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), CREATE2_DEPLOYER, salt, keccak256(initCode)));
+        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), Preinstalls.Create2Deployer, salt, keccak256(initCode)));
         return address(uint160(uint256(hash)));
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol
@@ -19,7 +19,6 @@ interface ICreate2Deployer {
 /// @title DeployNativeAssetFaucet
 /// @notice Script to deploy NativeAssetFaucet to L2 via deposit transactions
 contract DeployNativeAssetFaucet is Script {
-
     /// @notice Deploys and authorizes the NativeAssetFaucet on L2.
     /// @param _portal The OptimismPortal2 contract address.
     /// @param _owner The owner of the faucet.

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/FaucetDeployer.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/FaucetDeployer.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Interfaces
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { ILiquidityController } from "interfaces/L2/ILiquidityController.sol";
+
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+import { NativeAssetFaucet } from "src/L2/NativeAssetFaucet.sol";
+
+/// @title ICreate2Deployer
+/// @notice Interface for the CREATE2 Deployer predeploy
+interface ICreate2Deployer {
+    function deploy(uint256 _value, bytes32 _salt, bytes memory _code) external returns (address);
+}
+
+/// @title FaucetDeployer
+/// @notice L1 contract to deploy and manage NativeAssetFaucet on L2 via deposit transactions.
+///         This contract is designed to be called via delegatecall from a Safe or similar multisig.
+///         - deployAndAuthorize(): Called by LiquidityController owner to deploy faucet and authorize it as minter
+///         - mint(): Called by faucet owner to mint tokens to recipients
+contract FaucetDeployer {
+    /// @notice The address of the OptimismPortal2 on L1.
+    IOptimismPortal2 public immutable portal;
+
+    /// @notice The address of the CREATE2 Deployer predeploy on L2.
+    address public immutable create2Deployer;
+
+    /// @notice The salt prefix for the Faucet system.
+    string internal constant SALT_SEED = "Faucet";
+
+    /// @notice Constructor to set the OptimismPortal2 and CREATE2 Deployer addresses
+    /// @param _portal The address of the OptimismPortal2 on L1
+    /// @param _create2Deployer The address of the CREATE2 Deployer predeploy on L2
+    constructor(IOptimismPortal2 _portal, address _create2Deployer) {
+        portal = _portal;
+        create2Deployer = _create2Deployer;
+    }
+
+    /// @notice Deploys a NativeAssetFaucet via CREATE2 on L2 and authorizes it as a minter.
+    ///         Must be called by the LiquidityController owner (or via delegatecall from a Safe).
+    /// @param _faucetOwner Owner of the NativeAssetFaucet contract (can be different from LC owner)
+    /// @param _permissionlessAmount Amount users can claim per block in permissionless mode
+    /// @param _gasLimit Gas limit for each L2 deposit transaction
+    /// @return faucetAddress The computed address where the faucet will be deployed
+    function deployAndAuthorize(
+        address _faucetOwner,
+        uint256 _permissionlessAmount,
+        uint64 _gasLimit
+    )
+        external
+        returns (address faucetAddress)
+    {
+        bytes memory initCode =
+            bytes.concat(type(NativeAssetFaucet).creationCode, abi.encode(_faucetOwner, _permissionlessAmount));
+        bytes32 salt = keccak256(abi.encodePacked(SALT_SEED, ":", _faucetOwner));
+
+        // Calculate the CREATE2 address
+        faucetAddress = computeCreate2Address(salt, initCode);
+
+        // Deploy the faucet via CREATE2
+        portal.depositTransaction({
+            _to: create2Deployer,
+            _value: 0,
+            _gasLimit: _gasLimit,
+            _isCreation: false,
+            _data: abi.encodeCall(ICreate2Deployer.deploy, (0, salt, initCode))
+        });
+
+        // Authorize the faucet as a minter in the LiquidityController
+        portal.depositTransaction({
+            _to: Predeploys.LIQUIDITY_CONTROLLER,
+            _value: 0,
+            _gasLimit: _gasLimit,
+            _isCreation: false,
+            _data: abi.encodeCall(ILiquidityController.authorizeMinter, (faucetAddress))
+        });
+    }
+
+    /// @notice Mints tokens to a recipient via the NativeAssetFaucet.
+    ///         Must be called by the faucet owner (or via delegatecall from a Safe that owns the faucet).
+    /// @param _faucet Address of the NativeAssetFaucet contract on L2
+    /// @param _to Address to receive the minted tokens
+    /// @param _amount Amount of tokens to mint
+    /// @param _gasLimit Gas limit for the L2 deposit transaction
+    function mint(address _faucet, address _to, uint256 _amount, uint64 _gasLimit) external {
+        portal.depositTransaction({
+            _to: _faucet,
+            _value: 0,
+            _gasLimit: _gasLimit,
+            _isCreation: false,
+            _data: abi.encodeCall(NativeAssetFaucet.mint, (_to, _amount))
+        });
+    }
+
+    /// @notice Computes the CREATE2 address for a given salt and init code
+    /// @param _salt The salt used for CREATE2 deployment
+    /// @param _initCode The initialization code
+    /// @return The computed CREATE2 address
+    function computeCreate2Address(bytes32 _salt, bytes memory _initCode) public view returns (address) {
+        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), create2Deployer, _salt, keccak256(_initCode)));
+        return address(uint160(uint256(hash)));
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/FaucetDeployer.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/FaucetDeployer.sol
@@ -96,7 +96,8 @@ contract FaucetDeployer {
     /// @param _initCode The initialization code
     /// @return The computed CREATE2 address
     function computeCreate2Address(bytes32 _salt, bytes memory _initCode) public pure returns (address) {
-        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), Preinstalls.Create2Deployer, _salt, keccak256(_initCode)));
+        bytes32 hash =
+            keccak256(abi.encodePacked(bytes1(0xff), Preinstalls.Create2Deployer, _salt, keccak256(_initCode)));
         return address(uint160(uint256(hash)));
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/FaucetDeployer.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/FaucetDeployer.sol
@@ -7,6 +7,7 @@ import { ILiquidityController } from "interfaces/L2/ILiquidityController.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Preinstalls } from "src/libraries/Preinstalls.sol";
 
 import { NativeAssetFaucet } from "scripts/deploy/cgt-faucet/NativeAssetFaucet.sol";
 
@@ -25,18 +26,13 @@ contract FaucetDeployer {
     /// @notice The address of the OptimismPortal2 on L1.
     IOptimismPortal2 public immutable portal;
 
-    /// @notice The address of the CREATE2 Deployer predeploy on L2.
-    address public immutable create2Deployer;
-
     /// @notice The salt prefix for the Faucet system.
     string internal constant SALT_SEED = "Faucet";
 
-    /// @notice Constructor to set the OptimismPortal2 and CREATE2 Deployer addresses
+    /// @notice Constructor to set the OptimismPortal2 address
     /// @param _portal The address of the OptimismPortal2 on L1
-    /// @param _create2Deployer The address of the CREATE2 Deployer predeploy on L2
-    constructor(IOptimismPortal2 _portal, address _create2Deployer) {
+    constructor(IOptimismPortal2 _portal) {
         portal = _portal;
-        create2Deployer = _create2Deployer;
     }
 
     /// @notice Deploys a NativeAssetFaucet via CREATE2 on L2 and authorizes it as a minter.
@@ -62,7 +58,7 @@ contract FaucetDeployer {
 
         // Deploy the faucet via CREATE2
         portal.depositTransaction({
-            _to: create2Deployer,
+            _to: Preinstalls.Create2Deployer,
             _value: 0,
             _gasLimit: _gasLimit,
             _isCreation: false,
@@ -99,8 +95,8 @@ contract FaucetDeployer {
     /// @param _salt The salt used for CREATE2 deployment
     /// @param _initCode The initialization code
     /// @return The computed CREATE2 address
-    function computeCreate2Address(bytes32 _salt, bytes memory _initCode) public view returns (address) {
-        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), create2Deployer, _salt, keccak256(_initCode)));
+    function computeCreate2Address(bytes32 _salt, bytes memory _initCode) public pure returns (address) {
+        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), Preinstalls.Create2Deployer, _salt, keccak256(_initCode)));
         return address(uint160(uint256(hash)));
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/FaucetDeployer.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/FaucetDeployer.sol
@@ -8,7 +8,7 @@ import { ILiquidityController } from "interfaces/L2/ILiquidityController.sol";
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 
-import { NativeAssetFaucet } from "src/L2/NativeAssetFaucet.sol";
+import { NativeAssetFaucet } from "scripts/deploy/cgt-faucet/NativeAssetFaucet.sol";
 
 /// @title ICreate2Deployer
 /// @notice Interface for the CREATE2 Deployer predeploy

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/MintNativeAsset.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/MintNativeAsset.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+import { console2 as console } from "forge-std/console2.sol";
+
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { NativeAssetFaucet } from "scripts/deploy/cgt-faucet/NativeAssetFaucet.sol";
+
+/// @title MintNativeAsset
+/// @notice Script to mint native asset on L2 via deposit transaction from L1.
+///         Must be executed by the faucet owner.
+contract MintNativeAsset is Script {
+    address deployer;
+
+    /// @notice Mints native asset to a recipient on L2.
+    /// @param _portal The OptimismPortal2 contract address on L1.
+    /// @param _faucet The NativeAssetFaucet contract address on L2.
+    /// @param _to The recipient address on L2.
+    /// @param _amount The amount to mint (in wei).
+    /// @param _gasLimit The gas limit for the L2 deposit transaction.
+    function run(
+        address _portal,
+        address _faucet,
+        address _to,
+        uint256 _amount,
+        uint64 _gasLimit
+    )
+        public
+    {
+        deployer = msg.sender;
+
+        console.log("=== MintNativeAsset ===");
+        console.log("Portal:", _portal);
+        console.log("Faucet:", _faucet);
+        console.log("Recipient:", _to);
+        console.log("Amount:", _amount);
+        console.log("Gas Limit:", _gasLimit);
+        console.log("Deployer (must be faucet owner):", deployer);
+
+        vm.broadcast(deployer);
+        IOptimismPortal2(payable(_portal)).depositTransaction({
+            _to: _faucet,
+            _value: 0,
+            _gasLimit: _gasLimit,
+            _isCreation: false,
+            _data: abi.encodeCall(NativeAssetFaucet.mint, (_to, _amount))
+        });
+
+        console.log("\n=== Mint Complete ===");
+        console.log("Deposit transaction sent to mint", _amount, "wei to", _to);
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/NativeAssetFaucet.sol
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/NativeAssetFaucet.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
+
+// Interfaces
+import { ILiquidityController } from "interfaces/L2/ILiquidityController.sol";
+
+/// @title NativeAssetFaucet
+/// @notice Simple faucet contract for CGT devnets.
+///         This contract is immutable and can only be called by its owner or the aliased owner.
+///         Also supports permissionless minting with a per-block rate limit.
+contract NativeAssetFaucet {
+    /// @notice Error for when the caller is not authorized
+    error NativeAssetFaucet_Unauthorized();
+
+    /// @notice Error for when user has already claimed in this block
+    error NativeAssetFaucet_BlockLimitReached();
+
+    /// @notice The owner of this contract (can be an L1 address)
+    address public immutable owner;
+
+    /// @notice Amount users can claim per block in permissionless mode
+    uint256 public permissionlessAmount;
+
+    /// @notice Mapping of user address to last block number they claimed
+    mapping(address => uint256) public lastClaimBlock;
+
+    /// @notice Constructor to set the owner and initial permissionless amount
+    /// @param _owner The owner address (can be L1 address, will accept both normal and aliased calls)
+    /// @param _permissionlessAmount Initial amount users can claim per block
+    constructor(address _owner, uint256 _permissionlessAmount) {
+        owner = _owner;
+        permissionlessAmount = _permissionlessAmount;
+    }
+
+    /// @notice Modifier to restrict access to owner or aliased owner
+    modifier onlyOwner() {
+        if (msg.sender != owner && msg.sender != AddressAliasHelper.applyL1ToL2Alias(owner)) {
+            revert NativeAssetFaucet_Unauthorized();
+        }
+        _;
+    }
+
+    /// @notice Mints tokens to a recipient via the LiquidityController (owner only)
+    /// @param _to The address to receive the minted tokens
+    /// @param _amount The amount of tokens to mint
+    function mint(address _to, uint256 _amount) external onlyOwner {
+        ILiquidityController(Predeploys.LIQUIDITY_CONTROLLER).mint(_to, _amount);
+    }
+
+    /// @notice Sets the permissionless claim amount (owner only)
+    /// @param _amount The new amount users can claim per block
+    function setPermissionlessAmount(uint256 _amount) external onlyOwner {
+        permissionlessAmount = _amount;
+    }
+
+    /// @notice Permissionless claim function - anyone can claim per block
+    /// @param _to The address to receive the minted tokens
+    function claim(address _to) external {
+        if (lastClaimBlock[_to] == block.number) {
+            revert NativeAssetFaucet_BlockLimitReached();
+        }
+
+        lastClaimBlock[_to] = block.number;
+
+        ILiquidityController(Predeploys.LIQUIDITY_CONTROLLER).mint(_to, permissionlessAmount);
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/README.md
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/README.md
@@ -4,39 +4,24 @@ Deploy a NativeAssetFaucet on L2 via deposit transactions from L1. The faucet al
 
 ## Prerequisites
 
-- The LiquidityController owner on L2 can be an EOA or a multisig (Safe)
-- If EOA: the same address must have funds on L1 to execute the deployment script
-- If Safe: the Safe's **aliased address** must be the LiquidityController owner on L2
+The deployment script sends deposit transactions that deploy the faucet and authorize it as a minter. These transactions must originate from the LiquidityController owner on L2.
+
+- **If EOA**: The same EOA must be the LiquidityController owner on L2 and have funds on L1 to execute the script
+- **If Safe**: The Safe's **aliased address** must be the LiquidityController owner on L2 (see "Deployment with Multisig" section)
 
 ## Contracts
 
-| Contract | Description |
-|----------|-------------|
-| `NativeAssetFaucet.sol` | L2 contract that mints native asset to recipients |
-| `FaucetDeployer.sol` | L1 helper for deploying via Safe delegatecall (optional) |
-| `DeployNativeAssetFaucet.s.sol` | Forge script to deploy and authorize the faucet |
-| `DeployFaucetDeployer.s.sol` | Forge script to deploy the FaucetDeployer helper |
-| `MintNativeAsset.s.sol` | Forge script to mint native asset from L1 (for admins) |
+| Contract                        | Description                                              |
+| ------------------------------- | -------------------------------------------------------- |
+| `NativeAssetFaucet.sol`         | L2 contract that mints native asset to recipients        |
+| `FaucetDeployer.sol`            | L1 helper for deploying via Safe delegatecall (optional) |
+| `DeployNativeAssetFaucet.s.sol` | Forge script to deploy and authorize the faucet          |
+| `DeployFaucetDeployer.s.sol`    | Forge script to deploy the FaucetDeployer helper         |
+| `MintNativeAsset.s.sol`         | Forge script to mint native asset from L1 (for admins)   |
 
-## Deployment
+## Deployment with EOA
 
-### Step 1: Get the Portal address
-
-```bash
-L1_MESSENGER=$(cast call 0x4200000000000000000000000000000000000007 "otherMessenger()(address)" --rpc-url <L2_RPC_URL>)
-PORTAL=$(cast call $L1_MESSENGER "portal()(address)" --rpc-url <L1_RPC_URL>)
-echo "Portal: $PORTAL"
-```
-
-### Step 2: Verify LiquidityController owner
-
-```bash
-cast call 0x420000000000000000000000000000000000002a "owner()(address)" --rpc-url <L2_RPC_URL>
-```
-
-This address must match the account that will execute the deployment script.
-
-### Step 3: Deploy the faucet
+### Step 1: Deploy the faucet
 
 Run the script with the LiquidityController owner's private key:
 
@@ -54,29 +39,16 @@ forge script scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol \
 ```
 
 Parameters:
-- `PORTAL_ADDRESS`: OptimismPortal2 address on L1 (from Step 1)
+
+- `PORTAL_ADDRESS`: OptimismPortal2 address on L1
 - `FAUCET_OWNER`: Address that will own the faucet (can call `mint()` without limits)
 - `PERMISSIONLESS_AMOUNT`: Amount claimable per `claim()` call (in wei)
 - `GAS_LIMIT`: Gas limit for L2 deposit transactions (recommended: 500000)
 - `SALT_SEED`: Salt for deterministic CREATE2 deployment (e.g., "Faucet")
 
-Example:
-```bash
-forge script scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol \
-  --sig "run(address,address,uint256,uint64,string)" \
-  0x5cB3C128A2Ad79fb3d675038dAcFf885ad7aa9d1 \
-  0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 \
-  1000000000000000000 \
-  500000 \
-  "Faucet" \
-  --rpc-url http://127.0.0.1:8455 \
-  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
-  --broadcast
-```
+### Step 2: Verify deployment
 
-### Step 4: Verify deployment
-
-Wait ~10 seconds for the deposit transactions to be processed on L2, then verify:
+Wait for the deposit transactions to be processed on L2, then verify:
 
 ```bash
 FAUCET=<FAUCET_ADDRESS_FROM_SCRIPT_OUTPUT>
@@ -127,7 +99,7 @@ cast send $FAUCET "setPermissionlessAmount(uint256)" <NEW_AMOUNT> \
 
 ## Admin Minting from L1
 
-When the faucet owner doesn't have gas on L2, they can mint from L1 using the `MintNativeAsset` script:
+When the faucet owner is an EOA and doesn't have gas on L2, they can mint from L1 using the `MintNativeAsset` script:
 
 ```bash
 forge script scripts/deploy/cgt-faucet/MintNativeAsset.s.sol \
@@ -142,23 +114,68 @@ forge script scripts/deploy/cgt-faucet/MintNativeAsset.s.sol \
   --broadcast
 ```
 
-Example (mint 10 tokens to a recipient):
+This sends a deposit transaction from L1 that calls `mint()` on the faucet. The transaction must be signed by the faucet owner.
+
+## Deployment with Multisig (Safe)
+
+When the LiquidityController owner is a Safe's aliased address, use the `FaucetDeployer` helper contract.
+
+### Step 1: Deploy FaucetDeployer on L1
+
 ```bash
-forge script scripts/deploy/cgt-faucet/MintNativeAsset.s.sol \
-  --sig "run(address,address,address,uint256,uint64)" \
-  0x5cB3C128A2Ad79fb3d675038dAcFf885ad7aa9d1 \
-  0x0C3348692E1752D309F975F4423B21F44878A54C \
-  0x1111111111111111111111111111111111111111 \
-  10000000000000000000 \
-  100000 \
-  --rpc-url http://127.0.0.1:8455 \
-  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+forge script scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol \
+  --sig "run(address)" \
+  <PORTAL_ADDRESS> \
+  --rpc-url <L1_RPC_URL> \
+  --private-key <ANY_FUNDED_PRIVATE_KEY> \
   --broadcast
 ```
 
-This sends a deposit transaction from L1 that calls `mint()` on the faucet. The transaction must be signed by the faucet owner.
+Save the deployed `FAUCET_DEPLOYER` address from the output.
+
+### Step 2: Execute via Safe delegatecall
+
+From the Safe UI or CLI, execute a delegatecall to the FaucetDeployer:
+
+**Target:** `<FAUCET_DEPLOYER_ADDRESS>`
+**Operation:** `delegatecall`
+**Function:** `deployAndAuthorize(address,uint256,uint64)`
+**Parameters:**
+
+- `_faucetOwner`: Address that will own the faucet
+- `_permissionlessAmount`: Amount claimable per call (in wei)
+- `_gasLimit`: Gas limit for L2 transactions (recommended: 500000)
+
+Example calldata:
+
+```bash
+cast calldata "deployAndAuthorize(address,uint256,uint64)" \
+  <FAUCET_OWNER> \
+  1000000000000000000 \
+  500000
+```
+
+### Step 3: Verify deployment
+
+Same as EOA deployment - wait for L2 to process and verify the faucet is deployed and authorized.
+
+### Minting via Safe
+
+The faucet owner (if it's a Safe) can mint tokens using the FaucetDeployer:
+
+**Target:** `<FAUCET_DEPLOYER_ADDRESS>`
+**Operation:** `delegatecall`
+**Function:** `mint(address,address,uint256,uint64)`
+**Parameters:**
+
+- `_faucet`: NativeAssetFaucet address on L2
+- `_to`: Recipient address
+- `_amount`: Amount to mint
+- `_gasLimit`: Gas limit (recommended: 500000)
 
 ## Architecture
+
+### EOA Flow
 
 ```
 L1                                              L2
@@ -177,82 +194,34 @@ L1                                              L2
 ```
 
 The deployment script sends two deposit transactions from L1:
+
 1. Deploy NativeAssetFaucet via CREATE2
 2. Authorize the faucet as a minter in LiquidityController
 
 Both transactions must come from the LiquidityController owner for the authorization to succeed.
 
-## Deployment with Multisig (Safe)
-
-When the LiquidityController owner is a Safe's aliased address, use the `FaucetDeployer` helper contract.
-
-### Step 1: Calculate the aliased address
-
-The L2 owner must be the Safe's aliased address:
+### Safe Flow
 
 ```
-L2_owner = L1_Safe_address + 0x1111000000000000000000000000000000001111
+L1                                              L2
+┌──────────────────┐
+│      Safe        │
+│  (LC Owner L1)   │
+└────────┬─────────┘
+         │ delegatecall
+         ▼
+┌──────────────────┐                           ┌─────────────────────┐
+│                  │                           │                     │
+│  FaucetDeployer  │──depositTransaction──────►│  NativeAssetFaucet  │
+│                  │  (from: Safe)             │  (CREATE2 deployed) │
+└──────────────────┘                           └──────────┬──────────┘
+                                                          │
+                                    msg.sender = aliased  │ mint()
+                                                          ▼
+                                               ┌─────────────────────┐
+                                               │ LiquidityController │
+                                               │ owner = Safe aliased│
+                                               └─────────────────────┘
 ```
 
-```bash
-python3 -c "
-safe = int('<L1_SAFE_ADDRESS>', 16)
-offset = int('0x1111000000000000000000000000000000001111', 16)
-aliased = (safe + offset) % (2**160)
-print(f'Safe aliased (L2): {hex(aliased)}')"
-```
-
-Verify it matches the LiquidityController owner:
-```bash
-cast call 0x420000000000000000000000000000000000002a "owner()(address)" --rpc-url <L2_RPC_URL>
-```
-
-### Step 2: Deploy FaucetDeployer on L1
-
-```bash
-forge script scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol \
-  --sig "run(address)" \
-  <PORTAL_ADDRESS> \
-  --rpc-url <L1_RPC_URL> \
-  --private-key <ANY_FUNDED_PRIVATE_KEY> \
-  --broadcast
-```
-
-Save the deployed `FAUCET_DEPLOYER` address from the output.
-
-### Step 3: Execute via Safe delegatecall
-
-From the Safe UI or CLI, execute a delegatecall to the FaucetDeployer:
-
-**Target:** `<FAUCET_DEPLOYER_ADDRESS>`
-**Operation:** `delegatecall`
-**Function:** `deployAndAuthorize(address,uint256,uint64)`
-**Parameters:**
-- `_faucetOwner`: Address that will own the faucet
-- `_permissionlessAmount`: Amount claimable per call (in wei)
-- `_gasLimit`: Gas limit for L2 transactions (recommended: 500000)
-
-Example calldata:
-```bash
-cast calldata "deployAndAuthorize(address,uint256,uint64)" \
-  <FAUCET_OWNER> \
-  1000000000000000000 \
-  500000
-```
-
-### Step 4: Verify deployment
-
-Same as EOA deployment - wait for L2 to process and verify the faucet is deployed and authorized.
-
-### Minting via Safe
-
-The faucet owner (if it's a Safe) can mint tokens using the FaucetDeployer:
-
-**Target:** `<FAUCET_DEPLOYER_ADDRESS>`
-**Operation:** `delegatecall`
-**Function:** `mint(address,address,uint256,uint64)`
-**Parameters:**
-- `_faucet`: NativeAssetFaucet address on L2
-- `_to`: Recipient address
-- `_amount`: Amount to mint
-- `_gasLimit`: Gas limit (recommended: 100000)
+When using a Safe, the deposit transaction originates from the Safe contract. On L2, the `msg.sender` is the Safe's **aliased address** (`Safe + 0x1111...1111`). The LiquidityController owner must be set to this aliased address for authorization to succeed.

--- a/packages/contracts-bedrock/scripts/deploy/cgt-faucet/README.md
+++ b/packages/contracts-bedrock/scripts/deploy/cgt-faucet/README.md
@@ -1,0 +1,258 @@
+# Custom Gas Token Faucet
+
+Deploy a NativeAssetFaucet on L2 via deposit transactions from L1. The faucet allows minting of the native asset (custom gas token) to recipients.
+
+## Prerequisites
+
+- The LiquidityController owner on L2 can be an EOA or a multisig (Safe)
+- If EOA: the same address must have funds on L1 to execute the deployment script
+- If Safe: the Safe's **aliased address** must be the LiquidityController owner on L2
+
+## Contracts
+
+| Contract | Description |
+|----------|-------------|
+| `NativeAssetFaucet.sol` | L2 contract that mints native asset to recipients |
+| `FaucetDeployer.sol` | L1 helper for deploying via Safe delegatecall (optional) |
+| `DeployNativeAssetFaucet.s.sol` | Forge script to deploy and authorize the faucet |
+| `DeployFaucetDeployer.s.sol` | Forge script to deploy the FaucetDeployer helper |
+| `MintNativeAsset.s.sol` | Forge script to mint native asset from L1 (for admins) |
+
+## Deployment
+
+### Step 1: Get the Portal address
+
+```bash
+L1_MESSENGER=$(cast call 0x4200000000000000000000000000000000000007 "otherMessenger()(address)" --rpc-url <L2_RPC_URL>)
+PORTAL=$(cast call $L1_MESSENGER "portal()(address)" --rpc-url <L1_RPC_URL>)
+echo "Portal: $PORTAL"
+```
+
+### Step 2: Verify LiquidityController owner
+
+```bash
+cast call 0x420000000000000000000000000000000000002a "owner()(address)" --rpc-url <L2_RPC_URL>
+```
+
+This address must match the account that will execute the deployment script.
+
+### Step 3: Deploy the faucet
+
+Run the script with the LiquidityController owner's private key:
+
+```bash
+forge script scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol \
+  --sig "run(address,address,uint256,uint64,string)" \
+  <PORTAL_ADDRESS> \
+  <FAUCET_OWNER> \
+  <PERMISSIONLESS_AMOUNT> \
+  <GAS_LIMIT> \
+  <SALT_SEED> \
+  --rpc-url <L1_RPC_URL> \
+  --private-key <LC_OWNER_PRIVATE_KEY> \
+  --broadcast
+```
+
+Parameters:
+- `PORTAL_ADDRESS`: OptimismPortal2 address on L1 (from Step 1)
+- `FAUCET_OWNER`: Address that will own the faucet (can call `mint()` without limits)
+- `PERMISSIONLESS_AMOUNT`: Amount claimable per `claim()` call (in wei)
+- `GAS_LIMIT`: Gas limit for L2 deposit transactions (recommended: 500000)
+- `SALT_SEED`: Salt for deterministic CREATE2 deployment (e.g., "Faucet")
+
+Example:
+```bash
+forge script scripts/deploy/cgt-faucet/DeployNativeAssetFaucet.s.sol \
+  --sig "run(address,address,uint256,uint64,string)" \
+  0x5cB3C128A2Ad79fb3d675038dAcFf885ad7aa9d1 \
+  0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 \
+  1000000000000000000 \
+  500000 \
+  "Faucet" \
+  --rpc-url http://127.0.0.1:8455 \
+  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+  --broadcast
+```
+
+### Step 4: Verify deployment
+
+Wait ~10 seconds for the deposit transactions to be processed on L2, then verify:
+
+```bash
+FAUCET=<FAUCET_ADDRESS_FROM_SCRIPT_OUTPUT>
+
+# Check faucet has code
+cast code $FAUCET --rpc-url <L2_RPC_URL>
+
+# Check faucet owner
+cast call $FAUCET "owner()(address)" --rpc-url <L2_RPC_URL>
+
+# Check faucet is authorized as minter
+cast call 0x420000000000000000000000000000000000002a "minters(address)(bool)" $FAUCET --rpc-url <L2_RPC_URL>
+```
+
+## Usage
+
+### Permissionless claim
+
+Anyone can call `claim()` to receive the `permissionlessAmount`:
+
+```bash
+cast send $FAUCET "claim(address)" <RECIPIENT> \
+  --private-key <ANY_PRIVATE_KEY> \
+  --rpc-url <L2_RPC_URL>
+```
+
+Note: There is a rate limit of one claim per block per recipient.
+
+### Owner mint
+
+The faucet owner can mint any amount without limits:
+
+```bash
+cast send $FAUCET "mint(address,uint256)" <RECIPIENT> <AMOUNT> \
+  --private-key <FAUCET_OWNER_PRIVATE_KEY> \
+  --rpc-url <L2_RPC_URL>
+```
+
+### Update permissionless amount
+
+The faucet owner can update the permissionless claim amount:
+
+```bash
+cast send $FAUCET "setPermissionlessAmount(uint256)" <NEW_AMOUNT> \
+  --private-key <FAUCET_OWNER_PRIVATE_KEY> \
+  --rpc-url <L2_RPC_URL>
+```
+
+## Admin Minting from L1
+
+When the faucet owner doesn't have gas on L2, they can mint from L1 using the `MintNativeAsset` script:
+
+```bash
+forge script scripts/deploy/cgt-faucet/MintNativeAsset.s.sol \
+  --sig "run(address,address,address,uint256,uint64)" \
+  <PORTAL_ADDRESS> \
+  <FAUCET_ADDRESS> \
+  <RECIPIENT_ADDRESS> \
+  <AMOUNT_IN_WEI> \
+  <GAS_LIMIT> \
+  --rpc-url <L1_RPC_URL> \
+  --private-key <FAUCET_OWNER_PRIVATE_KEY> \
+  --broadcast
+```
+
+Example (mint 10 tokens to a recipient):
+```bash
+forge script scripts/deploy/cgt-faucet/MintNativeAsset.s.sol \
+  --sig "run(address,address,address,uint256,uint64)" \
+  0x5cB3C128A2Ad79fb3d675038dAcFf885ad7aa9d1 \
+  0x0C3348692E1752D309F975F4423B21F44878A54C \
+  0x1111111111111111111111111111111111111111 \
+  10000000000000000000 \
+  100000 \
+  --rpc-url http://127.0.0.1:8455 \
+  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+  --broadcast
+```
+
+This sends a deposit transaction from L1 that calls `mint()` on the faucet. The transaction must be signed by the faucet owner.
+
+## Architecture
+
+```
+L1                                              L2
+┌──────────────────┐                           ┌─────────────────────┐
+│                  │                           │                     │
+│  EOA (LC Owner)  │──depositTransaction──────►│  NativeAssetFaucet  │
+│                  │                           │  (CREATE2 deployed) │
+└──────────────────┘                           └──────────┬──────────┘
+                                                          │
+                                               authorized │ mint()
+                                                          ▼
+                                               ┌─────────────────────┐
+                                               │ LiquidityController │
+                                               │ (0x42...002a)       │
+                                               └─────────────────────┘
+```
+
+The deployment script sends two deposit transactions from L1:
+1. Deploy NativeAssetFaucet via CREATE2
+2. Authorize the faucet as a minter in LiquidityController
+
+Both transactions must come from the LiquidityController owner for the authorization to succeed.
+
+## Deployment with Multisig (Safe)
+
+When the LiquidityController owner is a Safe's aliased address, use the `FaucetDeployer` helper contract.
+
+### Step 1: Calculate the aliased address
+
+The L2 owner must be the Safe's aliased address:
+
+```
+L2_owner = L1_Safe_address + 0x1111000000000000000000000000000000001111
+```
+
+```bash
+python3 -c "
+safe = int('<L1_SAFE_ADDRESS>', 16)
+offset = int('0x1111000000000000000000000000000000001111', 16)
+aliased = (safe + offset) % (2**160)
+print(f'Safe aliased (L2): {hex(aliased)}')"
+```
+
+Verify it matches the LiquidityController owner:
+```bash
+cast call 0x420000000000000000000000000000000000002a "owner()(address)" --rpc-url <L2_RPC_URL>
+```
+
+### Step 2: Deploy FaucetDeployer on L1
+
+```bash
+forge script scripts/deploy/cgt-faucet/DeployFaucetDeployer.s.sol \
+  --sig "run(address)" \
+  <PORTAL_ADDRESS> \
+  --rpc-url <L1_RPC_URL> \
+  --private-key <ANY_FUNDED_PRIVATE_KEY> \
+  --broadcast
+```
+
+Save the deployed `FAUCET_DEPLOYER` address from the output.
+
+### Step 3: Execute via Safe delegatecall
+
+From the Safe UI or CLI, execute a delegatecall to the FaucetDeployer:
+
+**Target:** `<FAUCET_DEPLOYER_ADDRESS>`
+**Operation:** `delegatecall`
+**Function:** `deployAndAuthorize(address,uint256,uint64)`
+**Parameters:**
+- `_faucetOwner`: Address that will own the faucet
+- `_permissionlessAmount`: Amount claimable per call (in wei)
+- `_gasLimit`: Gas limit for L2 transactions (recommended: 500000)
+
+Example calldata:
+```bash
+cast calldata "deployAndAuthorize(address,uint256,uint64)" \
+  <FAUCET_OWNER> \
+  1000000000000000000 \
+  500000
+```
+
+### Step 4: Verify deployment
+
+Same as EOA deployment - wait for L2 to process and verify the faucet is deployed and authorized.
+
+### Minting via Safe
+
+The faucet owner (if it's a Safe) can mint tokens using the FaucetDeployer:
+
+**Target:** `<FAUCET_DEPLOYER_ADDRESS>`
+**Operation:** `delegatecall`
+**Function:** `mint(address,address,uint256,uint64)`
+**Parameters:**
+- `_faucet`: NativeAssetFaucet address on L2
+- `_to`: Recipient address
+- `_amount`: Amount to mint
+- `_gasLimit`: Gas limit (recommended: 100000)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces an L2 `NativeAssetFaucet` with owner-controlled minting and permissionless rate-limited claims, plus an L1 `FaucetDeployer` and Forge scripts to deploy/authorize/mint via `OptimismPortal2`, with docs.
> 
> - **Contracts**:
>   - `scripts/deploy/cgt-faucet/NativeAssetFaucet.sol`: L2 faucet with `owner`, `mint`, `setPermissionlessAmount`, and per-block `claim` via `ILiquidityController`.
>   - `scripts/deploy/cgt-faucet/FaucetDeployer.sol`: L1 helper using `OptimismPortal2` to CREATE2-deploy faucet on L2 and `authorizeMinter`, plus `mint` passthrough; includes `computeCreate2Address`.
> - **Scripts**:
>   - `DeployNativeAssetFaucet.s.sol`: Computes faucet address, deposits txs to CREATE2-deploy and authorize as minter.
>   - `DeployFaucetDeployer.s.sol`: Deploys `FaucetDeployer` on L1.
>   - `MintNativeAsset.s.sol`: Sends L1 deposit tx to call `mint` on L2 faucet.
> - **Docs**:
>   - `README.md`: Usage and deployment guides for EOA and Safe flows, parameters, verification steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f978541531ce5cd41960370be6157fa8653ae0cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->