### PR TITLE
chore: improve comments accuracy

### DIFF
--- a/packages/contracts-bedrock/src/L2/L1Withdrawer.sol
+++ b/packages/contracts-bedrock/src/L2/L1Withdrawer.sol
@@ -58,7 +58,7 @@ contract L1Withdrawer is ISemver {
     /// @param _minWithdrawalAmount The minimum amount of ETH required to trigger a withdrawal.
     /// @param _recipient The L1 address that will receive withdrawals.
     /// @param _withdrawalGasLimit The gas limit for the L1 withdrawal transaction.
-    /// @dev If target on L1 is `FeesDepositor`, the gas limit should be above 800k gas.
+    /// @dev If target on L1 is `FeesDepositor`, the gas limit should be at or above 800k gas.
     constructor(uint256 _minWithdrawalAmount, address _recipient, uint32 _withdrawalGasLimit) {
         minWithdrawalAmount = _minWithdrawalAmount;
         recipient = _recipient;
@@ -105,7 +105,7 @@ contract L1Withdrawer is ISemver {
 
     /// @notice Updates the withdrawal gas limit. Only callable by the ProxyAdmin owner.
     /// @param _newWithdrawalGasLimit The new withdrawal gas limit.
-    /// @dev If target on L1 is `FeesDepositor`, the gas limit should be above 800k gas.
+    /// @dev If target on L1 is `FeesDepositor`, the gas limit should be at or above 800k gas.
     function setWithdrawalGasLimit(uint32 _newWithdrawalGasLimit) external {
         if (msg.sender != IProxyAdmin(Predeploys.PROXY_ADMIN).owner()) {
             revert L1Withdrawer_OnlyProxyAdminOwner();


### PR DESCRIPTION
Small PR improving the accuracy of the comments related to the gas required for the FeesDepositor. Here is a Gist with the traces of the gas costs when FeesDepositor receives ETH and triggers/doesn't trigger a portal deposit: https://gist.github.com/0xChin/f0e05c23599b9966f5601d27f71f5aae

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies `L1Withdrawer.sol` docs to state the L1 gas limit for `FeesDepositor` must be at or above 800k gas (constructor and setter comments).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 974b442da9635be23199dc5f1a7893b42ede1a4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->