### PR TITLE
refactor: opcm2 extra instruction keymatch

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
@@ -46,6 +46,14 @@ interface IOPContractsManagerUtils {
         pure
         returns (bytes32);
 
+    function isMatchingInstructionByKey(
+        ExtraInstruction memory _instruction,
+        string memory _key
+    )
+        external
+        pure
+        returns (bool);
+
     function isMatchingInstruction(
         ExtraInstruction memory _instruction,
         string memory _key,

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerUtils.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerUtils.json
@@ -374,6 +374,42 @@
   {
     "inputs": [
       {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct OPContractsManagerUtils.ExtraInstruction",
+        "name": "_instruction",
+        "type": "tuple"
+      },
+      {
+        "internalType": "string",
+        "name": "_key",
+        "type": "string"
+      }
+    ],
+    "name": "isMatchingInstructionByKey",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "_source",
         "type": "address"

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xb3184aa5d95a82109e7134d1f61941b30e25f655b9849a0e303d04bbce0cde0b"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x8526ea4f5b326fe0da182db6259f4b50634459f6956e5e2b276dfc6a7ab425d0",
-    "sourceCodeHash": "0xe17f10be500ca896195070b835f4120a6c36ef8e96b2cda8fa15390582479a75"
+    "initCodeHash": "0xf853fa9b9320cd355d1dc729bda114f19335dac7ba384b96ba3d88a8d5f3b0c1",
+    "sourceCodeHash": "0xb7c3f165960b402541cc3267c856c958d697c01a94419627bd30b25b0c449641"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xb3184aa5d95a82109e7134d1f61941b30e25f655b9849a0e303d04bbce0cde0b"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x0fd527b2417a16a65a4f2d48f99747fac1f2b9cd2e8aeb76e263bb14b0ab6909",
-    "sourceCodeHash": "0x6f4aae59008976b44cbf0026818a60e149ce2eafeab6549b774480369eb8f7dd"
+    "initCodeHash": "0x8526ea4f5b326fe0da182db6259f4b50634459f6956e5e2b276dfc6a7ab425d0",
+    "sourceCodeHash": "0xe17f10be500ca896195070b835f4120a6c36ef8e96b2cda8fa15390582479a75"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -89,6 +89,21 @@ contract OPContractsManagerUtils {
         return keccak256(abi.encode(_l2ChainId, _saltMixer, _contractName));
     }
 
+    /// @notice Helper function to check if an instruction matches a given key.
+    /// @param _instruction The instruction to check.
+    /// @param _key The key of the instruction to check for.
+    /// @return True if the instruction matches, false otherwise.
+    function isMatchingInstructionByKey(
+        ExtraInstruction memory _instruction,
+        string memory _key
+    )
+        public
+        pure
+        returns (bool)
+    {
+        return LibString.eq(_instruction.key, _key);
+    }
+
     /// @notice Helper function to check if an instruction matches a given key and data.
     /// @param _instruction The instruction to check.
     /// @param _key The key of the instruction to check for.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
@@ -55,6 +55,24 @@ abstract contract OPContractsManagerUtilsCaller {
         );
     }
 
+    /// @notice Helper function to check if an instruction matches a given key.
+    /// @param _instruction The instruction to check.
+    /// @param _key The key of the instruction to check for.
+    /// @return True if the instruction matches, false otherwise.
+    function _isMatchingInstructionByKey(
+        IOPContractsManagerUtils.ExtraInstruction memory _instruction,
+        string memory _key
+    )
+        internal
+        view
+        returns (bool)
+    {
+        return abi.decode(
+            _staticcall(abi.encodeCall(IOPContractsManagerUtils.isMatchingInstructionByKey, (_instruction, _key))),
+            (bool)
+        );
+    }
+
     /// @notice Helper function to check if an instruction matches a given key and data.
     /// @param _instruction The instruction to check.
     /// @param _key The key of the instruction to check for.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -307,10 +307,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             }
             // Custom Gas Token is being enabled for the first time.
             // TODO:(#18502): Remove this allowance after U18 ships.
-            if (
-                _isMatchingInstruction(_instruction, "overrides.cfg.useCustomGasToken", abi.encode(true))
-                    || _isMatchingInstruction(_instruction, "overrides.cfg.useCustomGasToken", abi.encode(false))
-            ) {
+            if (_isMatchingInstructionByKey(_instruction, "overrides.cfg.useCustomGasToken")) {
                 return true;
             }
         }

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -167,7 +167,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
     /// @custom:semver 6.0.4
-    string public constant version = "6.0.4";
+    string public constant version = "6.0.5";
 
     /// @param _contractsContainer The container of blueprint and implementation contract addresses.
     /// @param _standardValidator The standard validator for this OPCM release.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
@@ -609,6 +609,44 @@ contract OPContractsManagerUtils_ContractsContainer_Test is OPContractsManagerUt
     }
 }
 
+/// @title OPContractsManagerUtils_IsMatchingInstruction_Test
+/// @notice Tests the isMatchingInstruction function.
+contract OPContractsManagerUtils_IsMatchingInstruction_Test is OPContractsManagerUtils_TestInit {
+    /// @notice Tests that isMatchingInstruction returns true when the instruction matches the key and data.
+    function testFuzz_isMatchingInstruction_succeeds(OPContractsManagerUtils.ExtraInstruction memory _instruction)
+        public
+        view
+    {
+        assertTrue(utils.isMatchingInstruction(_instruction, _instruction.key, _instruction.data));
+    }
+
+    /// @notice Tests that isMatchingInstruction returns false when the instruction does not match the key.
+    function testFuzz_isMatchingInstruction_notMatchingKey_fails(
+        OPContractsManagerUtils.ExtraInstruction memory _instruction
+    )
+        public
+        view
+    {
+        // Create a key that is not the same as the instruction key.
+        string memory _key = string.concat("not:", _instruction.key);
+
+        assertFalse(utils.isMatchingInstruction(_instruction, _key, _instruction.data));
+    }
+
+    /// @notice Tests that isMatchingInstruction returns false when the instruction does not match the data.
+    function testFuzz_isMatchingInstruction_notMatchingData_fails(
+        OPContractsManagerUtils.ExtraInstruction memory _instruction
+    )
+        public
+        view
+    {
+        // Create a data that is not the same as the instruction data.
+        bytes memory _data = bytes.concat("not:", _instruction.data);
+
+        assertFalse(utils.isMatchingInstruction(_instruction, _instruction.key, _data));
+    }
+}
+
 /// @title OPContractsManagerUtils_IsMatchingInstructionByKey_Test
 /// @notice Tests the isMatchingInstructionByKey function.
 contract OPContractsManagerUtils_IsMatchingInstructionByKey_Test is OPContractsManagerUtils_TestInit {

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
@@ -617,16 +617,18 @@ contract OPContractsManagerUtils_IsMatchingInstructionByKey_Test is OPContractsM
         public
         view
     {
-        assertEq(utils.isMatchingInstructionByKey(_instruction, _instruction.key), true);
+        assertTrue(utils.isMatchingInstructionByKey(_instruction, _instruction.key));
     }
 
     /// @notice Tests that isMatchingInstructionKey returns false when the instruction does not match the key.
-    function test_isMatchingInstructionByKey_notMatchingKey_fails() public view {
-        assertEq(
-            utils.isMatchingInstructionByKey(
-                OPContractsManagerUtils.ExtraInstruction({ key: "testKey", data: bytes("testData") }), "wrongKey"
-            ),
-            false
-        );
+    function testFuzz_isMatchingInstructionByKey_notMatchingKey_fails(
+        OPContractsManagerUtils.ExtraInstruction memory _instruction
+    )
+        public
+        view
+    {
+        // Create a key that is not the same as the instruction key.
+        string memory _key = string.concat("not:", _instruction.key);
+        assertFalse(utils.isMatchingInstructionByKey(_instruction, _key));
     }
 }

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
@@ -621,7 +621,7 @@ contract OPContractsManagerUtils_IsMatchingInstructionByKey_Test is OPContractsM
     }
 
     /// @notice Tests that isMatchingInstructionKey returns false when the instruction does not match the key.
-    function test_isMatchingInstructionByKey_fails() public view {
+    function test_isMatchingInstructionByKey_notMatchingKey_fails() public view {
         assertEq(
             utils.isMatchingInstructionByKey(
                 OPContractsManagerUtils.ExtraInstruction({ key: "testKey", data: bytes("testData") }), "wrongKey"

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
@@ -608,3 +608,25 @@ contract OPContractsManagerUtils_ContractsContainer_Test is OPContractsManagerUt
         assertEq(address(utils.contractsContainer()), address(container));
     }
 }
+
+/// @title OPContractsManagerUtils_IsMatchingInstructionByKey_Test
+/// @notice Tests the isMatchingInstructionByKey function.
+contract OPContractsManagerUtils_IsMatchingInstructionByKey_Test is OPContractsManagerUtils_TestInit {
+    /// @notice Tests that isMatchingInstructionByKey returns true when the instruction matches the key.
+    function testFuzz_isMatchingInstructionByKey_succeeds(OPContractsManagerUtils.ExtraInstruction memory _instruction)
+        public
+        view
+    {
+        assertEq(utils.isMatchingInstructionByKey(_instruction, _instruction.key), true);
+    }
+
+    /// @notice Tests that isMatchingInstructionKey returns false when the instruction does not match the key.
+    function test_isMatchingInstructionByKey_fails() public view {
+        assertEq(
+            utils.isMatchingInstructionByKey(
+                OPContractsManagerUtils.ExtraInstruction({ key: "testKey", data: bytes("testData") }), "wrongKey"
+            ),
+            false
+        );
+    }
+}


### PR DESCRIPTION
Adds a helper function for `OPContractsManagerUtils.sol` to match an `ExtraInstruction` by its key only.