### PR TITLE
test: opcm2 add read sup chain tests

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -44,7 +44,13 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 			return fmt.Errorf("cannot set superchain roles for predeployed OPCM")
 		}
 
-		// Use OPCMv1 to populate superchain state
+		// Use OPCMv1 to populate superchain state.
+		// When using OPCMv1, we only provide the OPCM address (superchainConfigProxy is zero).
+		// The ReadSuperchainDeployment script (packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol)
+		// detects OPCM v1 mode when superchainConfigProxy is zero, then queries the OPCM contract to discover:
+		// - ProtocolVersions contract address via opcm.protocolVersions()
+		// - SuperchainConfig contract address via opcm.superchainConfig()
+		// - All related proxy admin addresses, implementations, and role addresses
 		superDeployment, superRoles, err := PopulateSuperchainState(env.L1ScriptHost, *intent.OPCMAddress, common.Address{})
 		if err != nil {
 			return fmt.Errorf("error populating superchain state: %w", err)
@@ -57,13 +63,21 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 			}
 		}
 	}
+
 	hasSuperchainConfigProxy := intent.SuperchainConfigProxy != nil
 	if hasSuperchainConfigProxy && opcmV2Enabled {
 		if intent.SuperchainRoles != nil {
 			return fmt.Errorf("cannot set superchain roles for superchain config proxy")
 		}
 
-		// Use SuperchainConfigProxy to populate superchain state
+		// Use OPCMv2 to populate superchain state.
+		// When using OPCMv2, we provide the SuperchainConfigProxy address while the OPCM address is zero.
+		// The ReadSuperchainDeployment script (packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol)
+		// detects OPCM v2 mode when superchainConfigProxy is non-zero, then queries the SuperchainConfig contract
+		// to discover the implementation address, proxy admin, guardian, and proxy admin owner.
+		// In OPCMv2, ProtocolVersions is being removed. Therefore, the ProtocolVersions-related fields
+		// (protocolVersionsImpl, protocolVersionsProxy, protocolVersionsOwner, recommendedProtocolVersion,
+		// requiredProtocolVersion) are intentionally left uninitialized.
 		superDeployment, superRoles, err := PopulateSuperchainState(env.L1ScriptHost, common.Address{}, *intent.SuperchainConfigProxy)
 		if err != nil {
 			return fmt.Errorf("error populating superchain state: %w", err)

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -306,3 +306,597 @@ func TestPopulateSuperchainState_OPCMV2(t *testing.T) {
 		SuperchainGuardian:    common.HexToAddress("0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E"),
 	}, *roles)
 }
+
+// Tests error handling when an invalid OPCM address is provided.
+func TestPopulateSuperchainState_InvalidOpcmAddress(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
+	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
+
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
+	require.NoError(t, retryProxy.Start())
+	t.Cleanup(func() {
+		require.NoError(t, retryProxy.Stop())
+	})
+
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
+	require.NoError(t, err)
+
+	_, afacts := testutil.LocalArtifacts(t)
+	host, err := env.ForkedScriptHost(
+		broadcaster.NoopBroadcaster(),
+		testlog.Logger(t, log.LevelInfo),
+		common.Address{'D'},
+		afacts,
+		rpcClient,
+		big.NewInt(8227159),
+	)
+	require.NoError(t, err)
+
+	// Use an invalid address (non-existent contract)
+	invalidOpcmAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	dep, roles, err := PopulateSuperchainState(host, invalidOpcmAddr, common.Address{})
+	require.Error(t, err)
+	require.Nil(t, dep)
+	require.Nil(t, roles)
+	require.Contains(t, err.Error(), "error reading superchain deployment")
+}
+
+// Tests error handling when an invalid SuperchainConfigProxy is provided.
+func TestPopulateSuperchainState_InvalidSuperchainConfigProxy(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
+	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
+
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
+	require.NoError(t, retryProxy.Start())
+	t.Cleanup(func() {
+		require.NoError(t, retryProxy.Stop())
+	})
+
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
+	require.NoError(t, err)
+
+	_, afacts := testutil.LocalArtifacts(t)
+	host, err := env.ForkedScriptHost(
+		broadcaster.NoopBroadcaster(),
+		testlog.Logger(t, log.LevelInfo),
+		common.Address{'D'},
+		afacts,
+		rpcClient,
+		big.NewInt(8227159),
+	)
+	require.NoError(t, err)
+
+	// Use an invalid address (non-existent contract)
+	invalidSuperchainConfigProxy := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	dep, roles, err := PopulateSuperchainState(host, common.Address{}, invalidSuperchainConfigProxy)
+	require.Error(t, err)
+	require.Nil(t, dep)
+	require.Nil(t, roles)
+	require.Contains(t, err.Error(), "error reading superchain deployment")
+}
+
+// Validates that all fields from the script output are correctly
+// mapped to SuperchainContracts and SuperchainRoles for OPCM v1.
+func TestPopulateSuperchainState_OutputMappingV1(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
+	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
+
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
+	require.NoError(t, retryProxy.Start())
+	t.Cleanup(func() {
+		require.NoError(t, retryProxy.Stop())
+	})
+
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
+	require.NoError(t, err)
+
+	_, afacts := testutil.LocalArtifacts(t)
+	host, err := env.ForkedScriptHost(
+		broadcaster.NoopBroadcaster(),
+		testlog.Logger(t, log.LevelInfo),
+		common.Address{'D'},
+		afacts,
+		rpcClient,
+		big.NewInt(8227159),
+	)
+	require.NoError(t, err)
+
+	l1Versions, err := standard.L1VersionsFor(11155111)
+	require.NoError(t, err)
+	superchain, err := standard.SuperchainFor(11155111)
+	require.NoError(t, err)
+	opcmAddr := l1Versions["op-contracts/v2.0.0-rc.1"].OPContractsManager.Address
+
+	dep, roles, err := PopulateSuperchainState(host, common.Address(*opcmAddr), common.Address{})
+	require.NoError(t, err)
+	require.NotNil(t, dep)
+	require.NotNil(t, roles)
+
+	// Verify all SuperchainContracts fields are populated correctly
+	require.NotEqual(t, common.Address{}, dep.SuperchainProxyAdminImpl, "SuperchainProxyAdminImpl should be populated")
+	require.NotEqual(t, common.Address{}, dep.SuperchainConfigProxy, "SuperchainConfigProxy should be populated")
+	require.NotEqual(t, common.Address{}, dep.SuperchainConfigImpl, "SuperchainConfigImpl should be populated")
+	require.NotEqual(t, common.Address{}, dep.ProtocolVersionsProxy, "ProtocolVersionsProxy should be populated for v1")
+	require.NotEqual(t, common.Address{}, dep.ProtocolVersionsImpl, "ProtocolVersionsImpl should be populated for v1")
+
+	// Verify implementations are different from proxies
+	require.NotEqual(t, dep.SuperchainConfigImpl, dep.SuperchainConfigProxy, "SuperchainConfigImpl should differ from proxy")
+	require.NotEqual(t, dep.ProtocolVersionsImpl, dep.ProtocolVersionsProxy, "ProtocolVersionsImpl should differ from proxy")
+
+	// Verify all SuperchainRoles fields are populated correctly
+	require.NotEqual(t, common.Address{}, roles.SuperchainProxyAdminOwner, "SuperchainProxyAdminOwner should be populated")
+	require.NotEqual(t, common.Address{}, roles.ProtocolVersionsOwner, "ProtocolVersionsOwner should be populated for v1")
+	require.NotEqual(t, common.Address{}, roles.SuperchainGuardian, "SuperchainGuardian should be populated")
+
+	// Verify expected values match
+	require.Equal(t, superchain.SuperchainConfigAddr, dep.SuperchainConfigProxy)
+	require.Equal(t, superchain.ProtocolVersionsAddr, dep.ProtocolVersionsProxy)
+}
+
+// Validates that all fields from the script output are correctly
+// mapped to SuperchainContracts and SuperchainRoles for OPCM v2, and that ProtocolVersions fields are zeroed.
+func TestPopulateSuperchainState_OutputMappingV2(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
+	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
+
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
+	require.NoError(t, retryProxy.Start())
+	t.Cleanup(func() {
+		require.NoError(t, retryProxy.Stop())
+	})
+
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
+	require.NoError(t, err)
+
+	_, afacts := testutil.LocalArtifacts(t)
+	host, err := env.ForkedScriptHost(
+		broadcaster.NoopBroadcaster(),
+		testlog.Logger(t, log.LevelInfo),
+		common.Address{'D'},
+		afacts,
+		rpcClient,
+		big.NewInt(8227159),
+	)
+	require.NoError(t, err)
+
+	superchain, err := standard.SuperchainFor(11155111)
+	require.NoError(t, err)
+
+	dep, roles, err := PopulateSuperchainState(host, common.Address{}, superchain.SuperchainConfigAddr)
+	require.NoError(t, err)
+	require.NotNil(t, dep)
+	require.NotNil(t, roles)
+
+	// Verify SuperchainConfig fields are populated
+	require.NotEqual(t, common.Address{}, dep.SuperchainProxyAdminImpl, "SuperchainProxyAdminImpl should be populated")
+	require.NotEqual(t, common.Address{}, dep.SuperchainConfigProxy, "SuperchainConfigProxy should be populated")
+	require.NotEqual(t, common.Address{}, dep.SuperchainConfigImpl, "SuperchainConfigImpl should be populated")
+	require.NotEqual(t, dep.SuperchainConfigImpl, dep.SuperchainConfigProxy, "SuperchainConfigImpl should differ from proxy")
+
+	// Verify ProtocolVersions fields are zeroed for v2
+	require.Equal(t, common.Address{}, dep.ProtocolVersionsProxy, "ProtocolVersionsProxy should be zero for v2")
+	require.Equal(t, common.Address{}, dep.ProtocolVersionsImpl, "ProtocolVersionsImpl should be zero for v2")
+
+	// Verify SuperchainRoles fields are populated correctly
+	require.NotEqual(t, common.Address{}, roles.SuperchainProxyAdminOwner, "SuperchainProxyAdminOwner should be populated")
+	require.NotEqual(t, common.Address{}, roles.SuperchainGuardian, "SuperchainGuardian should be populated")
+
+	// Verify ProtocolVersionsOwner is zeroed for v2
+	require.Equal(t, common.Address{}, roles.ProtocolVersionsOwner, "ProtocolVersionsOwner should be zero for v2")
+
+	// Verify expected values match
+	require.Equal(t, superchain.SuperchainConfigAddr, dep.SuperchainConfigProxy)
+}
+
+// Validates the OPCM v2 flow in InitLiveStrategy
+// when SuperchainConfigProxy is provided and opcmV2Enabled is true.
+func TestInitLiveStrategy_OPCMV2WithSuperchainConfigProxy(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
+	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
+
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
+	require.NoError(t, retryProxy.Start())
+	t.Cleanup(func() {
+		require.NoError(t, retryProxy.Stop())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
+	require.NoError(t, err)
+	client := ethclient.NewClient(rpcClient)
+
+	l1ChainID := uint64(11155111)
+	superchain, err := standard.SuperchainFor(l1ChainID)
+	require.NoError(t, err)
+
+	_, afacts := testutil.LocalArtifacts(t)
+	host, err := env.DefaultForkedScriptHost(
+		ctx,
+		broadcaster.NoopBroadcaster(),
+		testlog.Logger(t, log.LevelInfo),
+		common.Address{'D'},
+		afacts,
+		rpcClient,
+	)
+	require.NoError(t, err)
+
+	// Set opcmV2Enabled flag via devFeatureBitmap
+	opcmV2Flag := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000010000")
+	intent := &state.Intent{
+		ConfigType:            state.IntentTypeStandard,
+		L1ChainID:             l1ChainID,
+		L1ContractsLocator:    artifacts.EmbeddedLocator,
+		L2ContractsLocator:    artifacts.EmbeddedLocator,
+		SuperchainConfigProxy: &superchain.SuperchainConfigAddr,
+		GlobalDeployOverrides: map[string]any{
+			"devFeatureBitmap": opcmV2Flag,
+		},
+	}
+
+	st := &state.State{
+		Version: 1,
+	}
+
+	err = InitLiveStrategy(
+		ctx,
+		&Env{
+			L1Client:     client,
+			Logger:       lgr,
+			L1ScriptHost: host,
+		},
+		intent,
+		st,
+	)
+	require.NoError(t, err)
+
+	// Verify state was populated
+	require.NotNil(t, st.SuperchainDeployment, "SuperchainDeployment should be populated")
+	require.NotNil(t, st.SuperchainRoles, "SuperchainRoles should be populated")
+
+	// Verify ProtocolVersions fields are zeroed for v2
+	require.Equal(t, common.Address{}, st.SuperchainDeployment.ProtocolVersionsProxy, "ProtocolVersionsProxy should be zero for v2")
+	require.Equal(t, common.Address{}, st.SuperchainDeployment.ProtocolVersionsImpl, "ProtocolVersionsImpl should be zero for v2")
+	require.Equal(t, common.Address{}, st.SuperchainRoles.ProtocolVersionsOwner, "ProtocolVersionsOwner should be zero for v2")
+
+	// Verify SuperchainConfig fields are populated
+	require.Equal(t, superchain.SuperchainConfigAddr, st.SuperchainDeployment.SuperchainConfigProxy)
+	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.SuperchainConfigImpl)
+	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.SuperchainProxyAdminImpl)
+}
+
+// Validates that providing both
+// SuperchainConfigProxy and SuperchainRoles with opcmV2Enabled returns an error.
+func TestInitLiveStrategy_OPCMV2WithSuperchainConfigProxyAndRoles_reverts(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
+	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
+
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
+	require.NoError(t, retryProxy.Start())
+	t.Cleanup(func() {
+		require.NoError(t, retryProxy.Stop())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
+	require.NoError(t, err)
+	client := ethclient.NewClient(rpcClient)
+
+	l1ChainID := uint64(11155111)
+	superchain, err := standard.SuperchainFor(l1ChainID)
+	require.NoError(t, err)
+
+	// Set opcmV2Enabled flag via devFeatureBitmap
+	opcmV2Flag := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000010000")
+	intent := &state.Intent{
+		ConfigType:            state.IntentTypeStandard,
+		L1ChainID:             l1ChainID,
+		L1ContractsLocator:    artifacts.EmbeddedLocator,
+		L2ContractsLocator:    artifacts.EmbeddedLocator,
+		SuperchainConfigProxy: &superchain.SuperchainConfigAddr,
+		SuperchainRoles: &addresses.SuperchainRoles{
+			SuperchainGuardian: common.Address{0: 99},
+		},
+		GlobalDeployOverrides: map[string]any{
+			"devFeatureBitmap": opcmV2Flag,
+		},
+	}
+
+	st := &state.State{
+		Version: 1,
+	}
+
+	err = InitLiveStrategy(
+		ctx,
+		&Env{
+			L1Client: client,
+			Logger:   lgr,
+		},
+		intent,
+		st,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot set superchain roles for superchain config proxy")
+}
+
+// Validates that providing both
+// OPCMAddress and SuperchainConfigProxy with opcmV2Enabled=false returns an error.
+func TestInitLiveStrategy_OPCMV1WithSuperchainConfigProxy_reverts(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
+	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
+
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
+	require.NoError(t, retryProxy.Start())
+	t.Cleanup(func() {
+		require.NoError(t, retryProxy.Stop())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
+	require.NoError(t, err)
+	client := ethclient.NewClient(rpcClient)
+
+	l1ChainID := uint64(11155111)
+	superchain, err := standard.SuperchainFor(l1ChainID)
+	require.NoError(t, err)
+
+	opcmAddr, err := standard.OPCMImplAddressFor(l1ChainID, standard.CurrentTag)
+	require.NoError(t, err)
+
+	// Don't set opcmV2Enabled flag (defaults to false)
+	intent := &state.Intent{
+		ConfigType:            state.IntentTypeStandard,
+		L1ChainID:             l1ChainID,
+		L1ContractsLocator:    artifacts.EmbeddedLocator,
+		L2ContractsLocator:    artifacts.EmbeddedLocator,
+		OPCMAddress:           &opcmAddr,
+		SuperchainConfigProxy: &superchain.SuperchainConfigAddr,
+	}
+
+	st := &state.State{
+		Version: 1,
+	}
+
+	err = InitLiveStrategy(
+		ctx,
+		&Env{
+			L1Client: client,
+			Logger:   lgr,
+		},
+		intent,
+		st,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot set superchain config proxy for predeployed OPCM")
+}
+
+// Validates that providing both
+// OPCMAddress and SuperchainRoles with opcmV2Enabled=false returns an error.
+func TestInitLiveStrategy_OPCMV1WithSuperchainRoles_reverts(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
+	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
+
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
+	require.NoError(t, retryProxy.Start())
+	t.Cleanup(func() {
+		require.NoError(t, retryProxy.Stop())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
+	require.NoError(t, err)
+	client := ethclient.NewClient(rpcClient)
+
+	l1ChainID := uint64(11155111)
+	opcmAddr, err := standard.OPCMImplAddressFor(l1ChainID, standard.CurrentTag)
+	require.NoError(t, err)
+
+	// Don't set opcmV2Enabled flag (defaults to false)
+	intent := &state.Intent{
+		ConfigType:         state.IntentTypeStandard,
+		L1ChainID:          l1ChainID,
+		L1ContractsLocator: artifacts.EmbeddedLocator,
+		L2ContractsLocator: artifacts.EmbeddedLocator,
+		OPCMAddress:        &opcmAddr,
+		SuperchainRoles: &addresses.SuperchainRoles{
+			SuperchainGuardian: common.Address{0: 99},
+		},
+	}
+
+	st := &state.State{
+		Version: 1,
+	}
+
+	err = InitLiveStrategy(
+		ctx,
+		&Env{
+			L1Client: client,
+			Logger:   lgr,
+		},
+		intent,
+		st,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot set superchain roles for predeployed OPCM")
+}
+
+// Validates that the correct flow is chosen when
+// hasPredeployedOPCM && !opcmV2Enabled, and that PopulateSuperchainState is called with correct parameters.
+func TestInitLiveStrategy_FlowSelection_OPCMV1(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
+	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
+
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
+	require.NoError(t, retryProxy.Start())
+	t.Cleanup(func() {
+		require.NoError(t, retryProxy.Stop())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
+	require.NoError(t, err)
+	client := ethclient.NewClient(rpcClient)
+
+	l1ChainID := uint64(11155111)
+	opcmAddr, err := standard.OPCMImplAddressFor(l1ChainID, standard.CurrentTag)
+	require.NoError(t, err)
+
+	_, afacts := testutil.LocalArtifacts(t)
+	host, err := env.DefaultForkedScriptHost(
+		ctx,
+		broadcaster.NoopBroadcaster(),
+		testlog.Logger(t, log.LevelInfo),
+		common.Address{'D'},
+		afacts,
+		rpcClient,
+	)
+	require.NoError(t, err)
+
+	// Don't set opcmV2Enabled flag (defaults to false)
+	intent := &state.Intent{
+		ConfigType:         state.IntentTypeStandard,
+		L1ChainID:          l1ChainID,
+		L1ContractsLocator: artifacts.EmbeddedLocator,
+		L2ContractsLocator: artifacts.EmbeddedLocator,
+		OPCMAddress:        &opcmAddr,
+	}
+
+	st := &state.State{
+		Version: 1,
+	}
+
+	err = InitLiveStrategy(
+		ctx,
+		&Env{
+			L1Client:     client,
+			Logger:       lgr,
+			L1ScriptHost: host,
+		},
+		intent,
+		st,
+	)
+	require.NoError(t, err)
+
+	// Verify OPCM v1 flow was used - ProtocolVersions should be populated
+	require.NotNil(t, st.SuperchainDeployment)
+	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.ProtocolVersionsProxy, "ProtocolVersionsProxy should be populated for v1")
+	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.ProtocolVersionsImpl, "ProtocolVersionsImpl should be populated for v1")
+	require.NotEqual(t, common.Address{}, st.SuperchainRoles.ProtocolVersionsOwner, "ProtocolVersionsOwner should be populated for v1")
+
+	// Verify ImplementationsDeployment was set
+	require.NotNil(t, st.ImplementationsDeployment)
+	require.Equal(t, opcmAddr, st.ImplementationsDeployment.OpcmImpl)
+}
+
+// Validates that the correct flow is chosen when
+// hasSuperchainConfigProxy && opcmV2Enabled, and that PopulateSuperchainState is called with correct parameters.
+func TestInitLiveStrategy_FlowSelection_OPCMV2(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
+	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
+
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
+	require.NoError(t, retryProxy.Start())
+	t.Cleanup(func() {
+		require.NoError(t, retryProxy.Stop())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
+	require.NoError(t, err)
+	client := ethclient.NewClient(rpcClient)
+
+	l1ChainID := uint64(11155111)
+	superchain, err := standard.SuperchainFor(l1ChainID)
+	require.NoError(t, err)
+
+	_, afacts := testutil.LocalArtifacts(t)
+	host, err := env.DefaultForkedScriptHost(
+		ctx,
+		broadcaster.NoopBroadcaster(),
+		testlog.Logger(t, log.LevelInfo),
+		common.Address{'D'},
+		afacts,
+		rpcClient,
+	)
+	require.NoError(t, err)
+
+	// Set opcmV2Enabled flag via devFeatureBitmap
+	opcmV2Flag := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000010000")
+	intent := &state.Intent{
+		ConfigType:            state.IntentTypeStandard,
+		L1ChainID:             l1ChainID,
+		L1ContractsLocator:    artifacts.EmbeddedLocator,
+		L2ContractsLocator:    artifacts.EmbeddedLocator,
+		SuperchainConfigProxy: &superchain.SuperchainConfigAddr,
+		GlobalDeployOverrides: map[string]any{
+			"devFeatureBitmap": opcmV2Flag,
+		},
+	}
+
+	st := &state.State{
+		Version: 1,
+	}
+
+	err = InitLiveStrategy(
+		ctx,
+		&Env{
+			L1Client:     client,
+			Logger:       lgr,
+			L1ScriptHost: host,
+		},
+		intent,
+		st,
+	)
+	require.NoError(t, err)
+
+	// Verify OPCM v2 flow was used - ProtocolVersions should be zeroed
+	require.NotNil(t, st.SuperchainDeployment)
+	require.Equal(t, common.Address{}, st.SuperchainDeployment.ProtocolVersionsProxy, "ProtocolVersionsProxy should be zero for v2")
+	require.Equal(t, common.Address{}, st.SuperchainDeployment.ProtocolVersionsImpl, "ProtocolVersionsImpl should be zero for v2")
+	require.Equal(t, common.Address{}, st.SuperchainRoles.ProtocolVersionsOwner, "ProtocolVersionsOwner should be zero for v2")
+
+	// Verify SuperchainConfig is populated
+	require.Equal(t, superchain.SuperchainConfigAddr, st.SuperchainDeployment.SuperchainConfigProxy)
+	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.SuperchainConfigImpl)
+}

--- a/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
@@ -32,11 +32,17 @@ contract ReadSuperchainDeployment is Script {
     }
 
     function run(Input memory _input) public returns (Output memory output_) {
-        // OPCM v2 is active when superchainConfigProxy is provided (non-zero)
+        // On OPCM v2, each chain deploys with its own SuperchainConfig; it's no longer stored in the OPCM contract.
+        // This script detects the OPCM version by checking if superchainConfigProxy is non-zero:
+        // - v1: opcmAddress is used
+        // - v2: superchainConfigProxy is used (opcmAddress is ignored)
+        // This allows callers to require one single address as input and the field used depends on the version.
         bool isOPCMV2 = address(_input.superchainConfigProxy) != address(0);
 
         if (isOPCMV2) {
-            // OPCM v2: Use provided SuperchainConfigProxy, leave protocol versions unfilled
+            // For OPCM v2, ProtocolVersions is being removed. Therefore, the ProtocolVersions-related fields
+            // (protocolVersionsImpl, protocolVersionsProxy, protocolVersionsOwner, recommendedProtocolVersion,
+            // requiredProtocolVersion) are intentionally left uninitialized.
             output_.superchainConfigProxy = _input.superchainConfigProxy;
             output_.superchainProxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(output_.superchainConfigProxy)));
 
@@ -48,10 +54,9 @@ contract ReadSuperchainDeployment is Script {
 
             output_.guardian = output_.superchainConfigProxy.guardian();
             output_.superchainProxyAdminOwner = output_.superchainProxyAdmin.owner();
-
-            // Protocol versions fields remain zero/unfilled in OPCM v2
         } else {
-            // OPCM v1: Original logic using OPCM address
+            // When running on OPCM v1, the OPCM address is used to read the ProtocolVersions contract and
+            // SuperchainConfig.
             require(address(_input.opcmAddress) != address(0), "ReadSuperchainDeployment: opcmAddress not set");
 
             IOPContractsManager opcm = IOPContractsManager(_input.opcmAddress);


### PR DESCRIPTION
- Adds clarifying comments on init.go and `ReadSuperchainDeployment.s.sol`
- Adds additional test cases for the different configurations for `InitLiveStrategy` and `PopulateSuperchainState`.