### PR TITLE
fix: remove branching in init.go & link TODO issue

### DIFF
--- a/op-deployer/pkg/deployer/devfeatures.go
+++ b/op-deployer/pkg/deployer/devfeatures.go
@@ -17,9 +17,6 @@ var (
 
 	// DeployV2DisputeGamesDevFlag enables deployment of V2 dispute game contracts.
 	DeployV2DisputeGamesDevFlag = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000100")
-
-	// OPCMDevFlag enables deployment of OPCM v2 contracts.
-	OPCMV2DevFlag = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000010000")
 )
 
 // IsDevFeatureEnabled checks if a specific development feature is enabled in a feature bitmap.

--- a/op-deployer/pkg/deployer/opcm/read_superchain_deployment.go
+++ b/op-deployer/pkg/deployer/opcm/read_superchain_deployment.go
@@ -6,12 +6,12 @@ import (
 )
 
 type ReadSuperchainDeploymentInput struct {
-	OPCMAddress           common.Address `abi:"opcmAddress"` // TODO: Remove OPCMAddress field when OPCMv1 gets deprecated
+	OPCMAddress           common.Address `abi:"opcmAddress"` // TODO(#18612): Remove OPCMAddress field when OPCMv1 gets deprecated
 	SuperchainConfigProxy common.Address `abi:"superchainConfigProxy"`
 }
 
 type ReadSuperchainDeploymentOutput struct {
-	// TODO: Remove ProtocolVersions fields when OPCMv1 gets deprecated
+	// TODO(#18612): Remove ProtocolVersions fields when OPCMv1 gets deprecated
 	ProtocolVersionsImpl       common.Address
 	ProtocolVersionsProxy      common.Address
 	ProtocolVersionsOwner      common.Address

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
@@ -167,15 +166,4 @@ func PopulateSuperchainState(host *script.Host, opcmAddr common.Address, superch
 		ProtocolVersionsOwner:     out.ProtocolVersionsOwner,
 	}
 	return deployment, roles, nil
-}
-
-// isDevFeatureEnabled checks if a specific development feature is enabled in a feature bitmap.
-// This mirrors the function in devfeatures.go to avoid import cycles.
-func isDevFeatureEnabled(bitmap, flag common.Hash) bool {
-	b := new(big.Int).SetBytes(bitmap[:])
-	f := new(big.Int).SetBytes(flag[:])
-
-	featuresIsNonZero := f.Cmp(big.NewInt(0)) != 0
-	bitmapContainsFeatures := new(big.Int).And(b, f).Cmp(f) == 0
-	return featuresIsNonZero && bitmapContainsFeatures
 }

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -28,62 +28,39 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 	}
 
 	hasPredeployedOPCM := intent.OPCMAddress != nil
+	hasSuperchainConfigProxy := intent.SuperchainConfigProxy != nil
 
-	var opcmV2Enabled bool
-	if devFeatureBitmap, ok := intent.GlobalDeployOverrides["devFeatureBitmap"].(common.Hash); ok {
-		opcmV2Flag := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000010000")
-		opcmV2Enabled = isDevFeatureEnabled(devFeatureBitmap, opcmV2Flag)
-	}
-
-	if hasPredeployedOPCM && !opcmV2Enabled {
-		if intent.SuperchainConfigProxy != nil {
-			return fmt.Errorf("cannot set superchain config proxy for predeployed OPCM")
-		}
-
+	if hasPredeployedOPCM || hasSuperchainConfigProxy {
 		if intent.SuperchainRoles != nil {
-			return fmt.Errorf("cannot set superchain roles for predeployed OPCM")
+			return fmt.Errorf("cannot set superchain roles when using predeployed OPCM or SuperchainConfig")
 		}
 
-		// Use OPCMv1 to populate superchain state.
-		// When using OPCMv1, we only provide the OPCM address (superchainConfigProxy is zero).
+		opcmAddr := common.Address{}
+		if hasPredeployedOPCM {
+			opcmAddr = *intent.OPCMAddress
+		}
+
+		superchainConfigAddr := common.Address{}
+		if hasSuperchainConfigProxy {
+			superchainConfigAddr = *intent.SuperchainConfigProxy
+		}
+
 		// The ReadSuperchainDeployment script (packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol)
-		// detects OPCM v1 mode when superchainConfigProxy is zero, then queries the OPCM contract to discover:
-		// - ProtocolVersions contract address via opcm.protocolVersions()
-		// - SuperchainConfig contract address via opcm.superchainConfig()
-		// - All related proxy admin addresses, implementations, and role addresses
-		superDeployment, superRoles, err := PopulateSuperchainState(env.L1ScriptHost, *intent.OPCMAddress, common.Address{})
+		// uses the OPCM's semver version (>= 6.0.0 indicates v2) to determine how to populate the superchain state:
+		// - OPCMv1 (< 6.0.0): Queries the OPCM contract to get SuperchainConfig and ProtocolVersions
+		// - OPCMv2 (>= 6.0.0): Uses the provided SuperchainConfigProxy address; ProtocolVersions is deprecated
+		superDeployment, superRoles, err := PopulateSuperchainState(env.L1ScriptHost, opcmAddr, superchainConfigAddr)
 		if err != nil {
 			return fmt.Errorf("error populating superchain state: %w", err)
 		}
 		st.SuperchainDeployment = superDeployment
 		st.SuperchainRoles = superRoles
-		if st.ImplementationsDeployment == nil {
+
+		if hasPredeployedOPCM && st.ImplementationsDeployment == nil {
 			st.ImplementationsDeployment = &addresses.ImplementationsContracts{
-				OpcmImpl: *intent.OPCMAddress,
+				OpcmImpl: opcmAddr,
 			}
 		}
-	}
-
-	hasSuperchainConfigProxy := intent.SuperchainConfigProxy != nil
-	if hasSuperchainConfigProxy && opcmV2Enabled {
-		if intent.SuperchainRoles != nil {
-			return fmt.Errorf("cannot set superchain roles for superchain config proxy")
-		}
-
-		// Use OPCMv2 to populate superchain state.
-		// When using OPCMv2, we provide the SuperchainConfigProxy address while the OPCM address is zero.
-		// The ReadSuperchainDeployment script (packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol)
-		// detects OPCM v2 mode when superchainConfigProxy is non-zero, then queries the SuperchainConfig contract
-		// to discover the implementation address, proxy admin, guardian, and proxy admin owner.
-		// In OPCMv2, ProtocolVersions is being removed. Therefore, the ProtocolVersions-related fields
-		// (protocolVersionsImpl, protocolVersionsProxy, protocolVersionsOwner, recommendedProtocolVersion,
-		// requiredProtocolVersion) are intentionally left uninitialized.
-		superDeployment, superRoles, err := PopulateSuperchainState(env.L1ScriptHost, common.Address{}, *intent.SuperchainConfigProxy)
-		if err != nil {
-			return fmt.Errorf("error populating superchain state: %w", err)
-		}
-		st.SuperchainDeployment = superDeployment
-		st.SuperchainRoles = superRoles
 	}
 
 	l1ChainID, err := env.L1Client.ChainID(ctx)

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -161,8 +161,8 @@ func immutableErr(field string, was, is any) error {
 	return fmt.Errorf("%s is immutable: was %v, is %v", field, was, is)
 }
 
-// TODO: Remove OPCMAddress field when OPCMv1 gets deprecated
-// TODO: Remove ProtocolVersions fields when OPCMv1 gets deprecated
+// TODO(#18612): Remove OPCMAddress field when OPCMv1 gets deprecated
+// TODO(#18612): Remove ProtocolVersions fields when OPCMv1 gets deprecated
 func PopulateSuperchainState(host *script.Host, opcmAddr common.Address, superchainConfigProxy common.Address) (*addresses.SuperchainContracts, *addresses.SuperchainRoles, error) {
 	readScript, err := opcm.NewReadSuperchainDeploymentScript(host)
 	if err != nil {

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -295,13 +295,13 @@ func TestPopulateSuperchainState_OPCMV2(t *testing.T) {
 		SuperchainProxyAdminImpl: common.HexToAddress("0x189aBAAaa82DfC015A588A7dbaD6F13b1D3485Bc"),
 		SuperchainConfigProxy:    superchain.SuperchainConfigAddr,
 		SuperchainConfigImpl:     common.HexToAddress("0x4da82a327773965b8d4D85Fa3dB8249b387458E7"),
-		// TODO: Remove ProtocolVersions fields when OPCMv1 gets deprecated
+		// TODO(#18612): Remove ProtocolVersions fields when OPCMv1 gets deprecated
 		ProtocolVersionsProxy: common.Address{},
 		ProtocolVersionsImpl:  common.Address{},
 	}, *dep)
 	require.Equal(t, addresses.SuperchainRoles{
 		SuperchainProxyAdminOwner: common.HexToAddress("0x1Eb2fFc903729a0F03966B917003800b145F56E2"),
-		// TODO: Remove ProtocolVersions fields when OPCMv1 gets deprecated
+		// TODO(#18612): Remove ProtocolVersions fields when OPCMv1 gets deprecated
 		ProtocolVersionsOwner: common.Address{},
 		SuperchainGuardian:    common.HexToAddress("0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E"),
 	}, *roles)

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -38,7 +38,7 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 		require.NoError(t, retryProxy.Stop())
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
 	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
@@ -515,7 +515,7 @@ func TestInitLiveStrategy_OPCMV2WithSuperchainConfigProxy(t *testing.T) {
 		require.NoError(t, retryProxy.Stop())
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
 	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
@@ -596,7 +596,7 @@ func TestInitLiveStrategy_OPCMV2WithSuperchainConfigProxyAndRoles_reverts(t *tes
 		require.NoError(t, retryProxy.Stop())
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
 	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
@@ -637,12 +637,12 @@ func TestInitLiveStrategy_OPCMV2WithSuperchainConfigProxyAndRoles_reverts(t *tes
 		st,
 	)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot set superchain roles for superchain config proxy")
+	require.Contains(t, err.Error(), "cannot set superchain roles when using predeployed OPCM or SuperchainConfig")
 }
 
-// Validates that providing both
-// OPCMAddress and SuperchainConfigProxy with opcmV2Enabled=false returns an error.
-func TestInitLiveStrategy_OPCMV1WithSuperchainConfigProxy_reverts(t *testing.T) {
+// Validates that providing both OPCMAddress and SuperchainConfigProxy works correctly
+// The script will use the OPCM's semver to determine the version
+func TestInitLiveStrategy_OPCMV1WithSuperchainConfigProxy(t *testing.T) {
 	t.Parallel()
 
 	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
@@ -655,7 +655,7 @@ func TestInitLiveStrategy_OPCMV1WithSuperchainConfigProxy_reverts(t *testing.T) 
 		require.NoError(t, retryProxy.Stop())
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
 	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
@@ -669,7 +669,19 @@ func TestInitLiveStrategy_OPCMV1WithSuperchainConfigProxy_reverts(t *testing.T) 
 	opcmAddr, err := standard.OPCMImplAddressFor(l1ChainID, standard.CurrentTag)
 	require.NoError(t, err)
 
-	// Don't set opcmV2Enabled flag (defaults to false)
+	_, afacts := testutil.LocalArtifacts(t)
+	host, err := env.DefaultForkedScriptHost(
+		ctx,
+		broadcaster.NoopBroadcaster(),
+		testlog.Logger(t, log.LevelInfo),
+		common.Address{'D'},
+		afacts,
+		rpcClient,
+	)
+	require.NoError(t, err)
+
+	// Provide both OPCM address and SuperchainConfigProxy
+	// The script will check the OPCM version and handle accordingly
 	intent := &state.Intent{
 		ConfigType:            state.IntentTypeStandard,
 		L1ChainID:             l1ChainID,
@@ -686,14 +698,20 @@ func TestInitLiveStrategy_OPCMV1WithSuperchainConfigProxy_reverts(t *testing.T) 
 	err = InitLiveStrategy(
 		ctx,
 		&Env{
-			L1Client: client,
-			Logger:   lgr,
+			L1Client:     client,
+			Logger:       lgr,
+			L1ScriptHost: host,
 		},
 		intent,
 		st,
 	)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot set superchain config proxy for predeployed OPCM")
+	// Should succeed - the script handles version detection
+	require.NoError(t, err)
+
+	// For OPCMv1, ProtocolVersions should be populated
+	require.NotNil(t, st.SuperchainDeployment)
+	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.ProtocolVersionsProxy)
+	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.ProtocolVersionsImpl)
 }
 
 // Validates that providing both
@@ -711,7 +729,7 @@ func TestInitLiveStrategy_OPCMV1WithSuperchainRoles_reverts(t *testing.T) {
 		require.NoError(t, retryProxy.Stop())
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
 	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
@@ -748,7 +766,7 @@ func TestInitLiveStrategy_OPCMV1WithSuperchainRoles_reverts(t *testing.T) {
 		st,
 	)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot set superchain roles for predeployed OPCM")
+	require.Contains(t, err.Error(), "cannot set superchain roles when using predeployed OPCM or SuperchainConfig")
 }
 
 // Validates that the correct flow is chosen when
@@ -766,7 +784,7 @@ func TestInitLiveStrategy_FlowSelection_OPCMV1(t *testing.T) {
 		require.NoError(t, retryProxy.Stop())
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
 	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
@@ -839,7 +857,7 @@ func TestInitLiveStrategy_FlowSelection_OPCMV2(t *testing.T) {
 		require.NoError(t, retryProxy.Stop())
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
 	rpcClient, err := rpc.Dial(retryProxy.Endpoint())

--- a/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
@@ -9,6 +9,8 @@ import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
+import { SemverComp } from "src/libraries/SemverComp.sol";
+import { console } from "forge-std/console.sol";
 
 contract ReadSuperchainDeployment is Script {
     struct Input {
@@ -32,14 +34,25 @@ contract ReadSuperchainDeployment is Script {
     }
 
     function run(Input memory _input) public returns (Output memory output_) {
-        // On OPCM v2, each chain deploys with its own SuperchainConfig; it's no longer stored in the OPCM contract.
-        // This script detects the OPCM version by checking if superchainConfigProxy is non-zero:
-        // - v1: opcmAddress is used
-        // - v2: superchainConfigProxy is used (opcmAddress is ignored)
-        // This allows callers to require one single address as input and the field used depends on the version.
-        bool isOPCMV2 = address(_input.superchainConfigProxy) != address(0);
+        // Determine OPCM version by checking the semver or if the OPCM address is set. OPCM v2 starts at version 6.0.0.
+        //
+        IOPContractsManager opcm = IOPContractsManager(_input.opcmAddress);
+        bool isOPCMV2;
+        if (address(opcm) == address(0)) {
+            console.log("OPCM address is 0");
+            isOPCMV2 = true;
+        } else {
+            console.log("OPCM code length: %s", address(opcm).code.length);
+            require(address(opcm).code.length > 0, "ReadSuperchainDeployment: OPCM address has no code");
+            isOPCMV2 = SemverComp.gte(opcm.version(), "6.0.0");
+        }
 
         if (isOPCMV2) {
+            require(
+                address(_input.superchainConfigProxy) != address(0),
+                "ReadSuperchainDeployment: superchainConfigProxy required for OPCM v2"
+            );
+
             // For OPCM v2, ProtocolVersions is being removed. Therefore, the ProtocolVersions-related fields
             // (protocolVersionsImpl, protocolVersionsProxy, protocolVersionsOwner, recommendedProtocolVersion,
             // requiredProtocolVersion) are intentionally left uninitialized.
@@ -49,7 +62,7 @@ contract ReadSuperchainDeployment is Script {
             IProxy superchainConfigProxy = IProxy(payable(address(output_.superchainConfigProxy)));
 
             vm.startPrank(address(0));
-            output_.superchainConfigImpl = ISuperchainConfig(address(superchainConfigProxy.implementation()));
+            output_.superchainConfigImpl = ISuperchainConfig(superchainConfigProxy.implementation());
             vm.stopPrank();
 
             output_.guardian = output_.superchainConfigProxy.guardian();
@@ -57,10 +70,6 @@ contract ReadSuperchainDeployment is Script {
         } else {
             // When running on OPCM v1, the OPCM address is used to read the ProtocolVersions contract and
             // SuperchainConfig.
-            require(address(_input.opcmAddress) != address(0), "ReadSuperchainDeployment: opcmAddress not set");
-
-            IOPContractsManager opcm = IOPContractsManager(_input.opcmAddress);
-
             output_.protocolVersionsProxy = IProtocolVersions(opcm.protocolVersions());
             output_.superchainConfigProxy = ISuperchainConfig(opcm.superchainConfig());
             output_.superchainProxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(output_.superchainConfigProxy)));
@@ -69,8 +78,6 @@ contract ReadSuperchainDeployment is Script {
             IProxy superchainConfigProxy = IProxy(payable(address(output_.superchainConfigProxy)));
 
             vm.startPrank(address(0));
-            output_.protocolVersionsImpl = IProtocolVersions(address(protocolVersionsProxy.implementation()));
-            output_.superchainConfigImpl = ISuperchainConfig(address(superchainConfigProxy.implementation()));
             output_.protocolVersionsImpl = IProtocolVersions(protocolVersionsProxy.implementation());
             output_.superchainConfigImpl = ISuperchainConfig(superchainConfigProxy.implementation());
             vm.stopPrank();

--- a/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
@@ -12,12 +12,12 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 contract ReadSuperchainDeployment is Script {
     struct Input {
-        IOPContractsManager opcmAddress; // TODO: Remove OPCMAddress field when OPCMv1 gets deprecated
+        IOPContractsManager opcmAddress; // TODO(#18612): Remove OPCMAddress field when OPCMv1 gets deprecated
         ISuperchainConfig superchainConfigProxy;
     }
 
     struct Output {
-        // TODO: Remove ProtocolVersions fields when OPCMv1 gets deprecated
+        // TODO(#18612): Remove ProtocolVersions fields when OPCMv1 gets deprecated
         IProtocolVersions protocolVersionsImpl;
         IProtocolVersions protocolVersionsProxy;
         address protocolVersionsOwner;

--- a/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
@@ -10,7 +10,6 @@ import { IProxy } from "interfaces/universal/IProxy.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { SemverComp } from "src/libraries/SemverComp.sol";
-import { console } from "forge-std/console.sol";
 
 contract ReadSuperchainDeployment is Script {
     struct Input {
@@ -35,14 +34,11 @@ contract ReadSuperchainDeployment is Script {
 
     function run(Input memory _input) public returns (Output memory output_) {
         // Determine OPCM version by checking the semver or if the OPCM address is set. OPCM v2 starts at version 6.0.0.
-        //
         IOPContractsManager opcm = IOPContractsManager(_input.opcmAddress);
         bool isOPCMV2;
         if (address(opcm) == address(0)) {
-            console.log("OPCM address is 0");
             isOPCMV2 = true;
         } else {
-            console.log("OPCM code length: %s", address(opcm).code.length);
             require(address(opcm).code.length > 0, "ReadSuperchainDeployment: OPCM address has no code");
             isOPCMV2 = SemverComp.gte(opcm.version(), "6.0.0");
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces opcmV2 feature-flag branching with semver-based OPCM detection and simplifies InitLiveStrategy, updates the ReadSuperchainDeployment script accordingly, and refreshes tests/timeouts and TODO annotations.
> 
> - **Pipeline**:
>   - **Init flow**: Remove `devFeatureBitmap`/OPCM v2 branching; accept `OPCMAddress` and/or `SuperchainConfigProxy` and populate via `PopulateSuperchainState` which auto-detects OPCM version. Unify error: cannot set `SuperchainRoles` when using predeployed OPCM or SuperchainConfig. Populate `ImplementationsDeployment.OpcmImpl` when OPCM is provided.
> - **Contracts Script (`ReadSuperchainDeployment.s.sol`)**:
>   - Detect OPCM v2 by semver (>= `6.0.0`) or zero OPCM address; require non-zero `superchainConfigProxy` for v2. For v2, leave `ProtocolVersions*` unset; for v1, read via OPCM and fill all fields. Add code-existence check and minor call simplifications.
> - **Devfeatures**:
>   - Remove `OPCMV2DevFlag`; keep existing dev flags.
> - **Tests**:
>   - Increase timeouts to 180s. Add/adjust tests for v1/v2 flows, mixed inputs, invalid addresses, and output mapping; update expected errors; use forked script host with pinned Sepolia block.
> - **Docs/Comments**:
>   - Link TODOs to `#18612` in relevant files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bca8e044300c6dbcaa4aa3e325f045a66fde10c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->