### PR TITLE
chore: sync sc-feat/opcm2-upgrade-op-chain with develop

### DIFF
--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -388,3 +388,13 @@ rules:
         # LegacyMintableERC20 and the corresponding interface use legacy naming conventions.
         - packages/contracts-bedrock/src/legacy/LegacyMintableERC20.sol
         - packages/contracts-bedrock/interfaces/legacy/ILegacyMintableERC20Full.sol
+
+  - id: sol-safety-opcmv2-use-internal-version
+    languages: [generic]
+    severity: ERROR
+    message: Use _version() instead of version() in OPContractsManagerV2. Direct calls to version() are not properly mockable/testable due to DELEGATECALL context.
+    patterns:
+      - pattern-regex: (?<!\.)(?<!function\s)(?<!_)version\(\)
+    paths:
+      include:
+        - packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol

--- a/.semgrep/tests/sol-rules.sol-safety-opcmv2-use-internal-version.t.sol
+++ b/.semgrep/tests/sol-rules.sol-safety-opcmv2-use-internal-version.t.sol
@@ -1,0 +1,26 @@
+contract SemgrepTest__sol_safety_opcmv2_use_internal_version {
+    function badUsage() public view returns (string memory) {
+        // ruleid: sol-safety-opcmv2-use-internal-version
+        return version();
+    }
+
+    // ok: sol-safety-opcmv2-use-internal-version
+    function version() public pure returns (string memory) {
+        return "1.0.0";
+    }
+
+    function _version() internal view returns (string memory) {
+        // ok: sol-safety-opcmv2-use-internal-version
+        return thisOPCM.version();
+    }
+
+    function goodUsage() public view returns (string memory) {
+        // ok: sol-safety-opcmv2-use-internal-version
+        return _version();
+    }
+
+    function externalCall() public view returns (string memory) {
+        // ok: sol-safety-opcmv2-use-internal-version
+        return someContract.version();
+    }
+}

--- a/packages/contracts-bedrock/checks.yaml
+++ b/packages/contracts-bedrock/checks.yaml
@@ -34,7 +34,7 @@ phases:
         command: forge fmt --check
       - name: semgrep
         description: Run semgrep security linter
-        command: cd ../../ && semgrep scan --config .semgrep/rules/ ./packages/contracts-bedrock
+        command: cd ../../ && semgrep scan --error --config .semgrep/rules/ ./packages/contracts-bedrock
       - name: semgrep-test-validity
         description: Check semgrep tests are valid
         command: forge fmt ../../.semgrep/tests/sol-rules.t.sol --check

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
@@ -106,6 +106,7 @@ interface IOPContractsManagerV2 {
     error OPContractsManagerV2_UnsupportedGameType();
     error OPContractsManagerV2_InvalidUpgradeInstruction(string _key);
     error OPContractsManagerV2_CannotUpgradeToCustomGasToken();
+    error OPContractsManagerV2_InvalidUpgradeSequence(string _lastVersion, string _thisVersion);
     error IdentityPrecompileCallFailed();
     error ReservedBitsSet();
     error BytesArrayTooLong();
@@ -148,4 +149,7 @@ interface IOPContractsManagerV2 {
 
     /// @notice Returns whether a development feature is enabled.
     function isDevFeatureEnabled(bytes32 _feature) external view returns (bool);
+
+    /// @notice Checks if the upgrade sequence from the last used OPCM to this OPCM is permitted.
+    function isPermittedUpgradeSequence(ISystemConfig _systemConfig) external view returns (bool);
 }

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerV2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerV2.json
@@ -427,6 +427,25 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "contract ISystemConfig",
+        "name": "_systemConfig",
+        "type": "address"
+      }
+    ],
+    "name": "isPermittedUpgradeSequence",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "standardValidator",
     "outputs": [
@@ -657,7 +676,7 @@
         "type": "string"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -709,6 +728,22 @@
       }
     ],
     "name": "OPContractsManagerV2_InvalidUpgradeInstruction",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_lastVersion",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_thisVersion",
+        "type": "string"
+      }
+    ],
+    "name": "OPContractsManagerV2_InvalidUpgradeSequence",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xb3184aa5d95a82109e7134d1f61941b30e25f655b9849a0e303d04bbce0cde0b"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0xa2e3af90e9ff372b737f7eba83d20e44ceb22ed990d290d98b32d2ecb1316101",
-    "sourceCodeHash": "0x3333dd6ca2d7a0575ca9a7c10b79b0a38de8ea0aa550f98b99c11ba1f6b93c84"
+    "initCodeHash": "0x7648333338c6ca7e7e39421259b7c78174771263d84d03f9e363a8e0f9ba74f9",
+    "sourceCodeHash": "0x4c4f6079034ed5dfd0bf242a57a353583ed9ff948b6f9018d91b091a555574db"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xb3184aa5d95a82109e7134d1f61941b30e25f655b9849a0e303d04bbce0cde0b"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x08ce57f50f66685b62b09597a30b5080a140bb3c3cb4f282524200f96c321996",
-    "sourceCodeHash": "0x0a49fca3800abd9da52ca7fccb018af451c7f988328c826f9a0acb80395bff15"
+    "initCodeHash": "0xa2e3af90e9ff372b737f7eba83d20e44ceb22ed990d290d98b32d2ecb1316101",
+    "sourceCodeHash": "0x3333dd6ca2d7a0575ca9a7c10b79b0a38de8ea0aa550f98b99c11ba1f6b93c84"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -151,6 +151,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     /// @notice Thrown when a chain attempts to upgrade to custom gas token after initial deployment.
     error OPContractsManagerV2_CannotUpgradeToCustomGasToken();
 
+    /// @notice Thrown when an invalid upgrade sequence is provided.
+    error OPContractsManagerV2_InvalidUpgradeSequence(string _lastVersion, string _thisVersion);
+
     /// @notice Container of blueprint and implementation contract addresses.
     IOPContractsManagerContainer public immutable contractsContainer;
 
@@ -166,8 +169,10 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 6.0.6
-    string public constant version = "6.0.6";
+    /// @custom:semver 6.0.7
+    function version() public pure returns (string memory) {
+        return "6.0.7";
+    }
 
     /// @param _contractsContainer The container of blueprint and implementation contract addresses.
     /// @param _standardValidator The standard validator for this OPCM release.
@@ -299,7 +304,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         // developers start working on the next release this will automatically become false so
         // even if the code is somehow forgotten it will not actually apply to the deployment. Make
         // sure to REMOVE the allowance once the upgrade is complete.
-        if (SemverComp.lt(version, "7.0.0")) {
+        if (SemverComp.lt(_version(), "7.0.0")) {
             // Unified DelayedWETH is being deployed for the first time.
             // TODO:(#18382): Remove this allowance after unified DelayedWETH is deployed.
             if (_isMatchingInstruction(_instruction, Constants.PERMITTED_PROXY_DEPLOYMENT_KEY, "DelayedWETH")) {
@@ -698,6 +703,15 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             revert OPContractsManagerV2_SuperchainConfigNeedsUpgrade();
         }
 
+        // Chains prior to OPCMv2 don't yet have a functional lastUsedOPCMVersion function on the
+        // SystemConfig contract. The first deployment of OPCMv2 will make this function available
+        // and subsequent deployments will then use this function to verify the system is
+        // progressing from one OPCM to the next. We only care about this for upgrades, you can
+        // perform an initial deployment from any OPCM.
+        if (!_isInitialDeployment && !isPermittedUpgradeSequence(_cts.systemConfig)) {
+            revert OPContractsManagerV2_InvalidUpgradeSequence(_cts.systemConfig.lastUsedOPCMVersion(), _version());
+        }
+
         // Update the SystemConfig.
         // SystemConfig initializer is the only one large enough to require a separate function to
         // avoid stack-too-deep errors.
@@ -978,6 +992,42 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     //                        PUBLIC UTILITY FUNCTIONS                       //
     ///////////////////////////////////////////////////////////////////////////
 
+    /// @notice Checks if the upgrade sequence from the last used OPCM to this OPCM is permitted.
+    ///         This function is public to allow tests to verify upgrade sequence logic directly
+    ///         by mocking the OPCM version and calling this function, rather than running the full
+    ///         upgrade flow. This avoids the need for special testing flags that bypass validation.
+    /// @param _systemConfig The SystemConfig contract to check the upgrade sequence for.
+    /// @return True if the upgrade sequence is permitted, false otherwise.
+    function isPermittedUpgradeSequence(ISystemConfig _systemConfig) public view returns (bool) {
+        // If the SystemConfig is not initialized, this is an initial deployment, which is always
+        // permitted. Initial deployments can use any OPCM version.
+        if (address(_systemConfig) == address(0)) {
+            return true;
+        }
+
+        // Chains prior to OPCMv2 (version 7.0.0) don't have a functional lastUsedOPCM function on
+        // the SystemConfig contract. The first deployment of OPCMv2 makes this function available,
+        // so we skip this check for versions below 7.0.0.
+        if (SemverComp.lt(_version(), "7.0.0")) {
+            return true;
+        }
+
+        ISemver lastUsedOPCM = ISemver(address(_systemConfig.lastUsedOPCM()));
+        SemverComp.Semver memory lastUsedSemver = SemverComp.parse(lastUsedOPCM.version());
+        SemverComp.Semver memory thisSemver = SemverComp.parse(_version());
+
+        // We have three permitted cases:
+        // 1. Address of the last used OPCM is identical to the address of this OPCM (re-running).
+        // 2. This OPCM version is the same major version but a greater minor version (patch).
+        // 3. This OPCM version is the next major version (sequential upgrade).
+        bool isSameOPCM = address(lastUsedOPCM) == address(thisOPCM);
+        bool isNextMajor = thisSemver.major == lastUsedSemver.major + 1;
+        bool isSameMajorHigherMinor =
+            thisSemver.major == lastUsedSemver.major && thisSemver.minor > lastUsedSemver.minor;
+
+        return isSameOPCM || isSameMajorHigherMinor || isNextMajor;
+    }
+
     /// @notice Returns the blueprint contract addresses.
     function blueprints() public view returns (IOPContractsManagerContainer.Blueprints memory) {
         return contractsContainer.blueprints();
@@ -993,5 +1043,17 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     /// @return True if the feature is enabled, false otherwise.
     function isDevFeatureEnabled(bytes32 _feature) public view returns (bool) {
         return contractsContainer.isDevFeatureEnabled(_feature);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    //                       INTERNAL UTILITY FUNCTIONS                      //
+    ///////////////////////////////////////////////////////////////////////////
+
+    /// @notice Helper for retrieving the version of the OPCM contract.
+    /// @dev We use thisOPCM.version() because it allows us to properly mock the version function
+    ///      in tests without running into issues because this contract is being DELEGATECALLed.
+    /// @return The version of the OPCM contract.
+    function _version() internal view returns (string memory) {
+        return thisOPCM.version();
     }
 }

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -169,9 +169,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 6.0.7
+    /// @custom:semver 7.0.0
     function version() public pure returns (string memory) {
-        return "6.0.7";
+        return "7.0.0";
     }
 
     /// @param _contractsContainer The container of blueprint and implementation contract addresses.
@@ -304,7 +304,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         // developers start working on the next release this will automatically become false so
         // even if the code is somehow forgotten it will not actually apply to the deployment. Make
         // sure to REMOVE the allowance once the upgrade is complete.
-        if (SemverComp.lt(_version(), "7.0.0")) {
+        if (SemverComp.lt(_version(), "8.0.0")) {
             // Unified DelayedWETH is being deployed for the first time.
             // TODO:(#18382): Remove this allowance after unified DelayedWETH is deployed.
             if (_isMatchingInstruction(_instruction, Constants.PERMITTED_PROXY_DEPLOYMENT_KEY, "DelayedWETH")) {
@@ -1006,9 +1006,11 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         }
 
         // Chains prior to OPCMv2 (version 7.0.0) don't have a functional lastUsedOPCM function on
-        // the SystemConfig contract. The first deployment of OPCMv2 makes this function available,
-        // so we skip this check for versions below 7.0.0.
-        if (SemverComp.lt(_version(), "7.0.0")) {
+        // the SystemConfig contract. The first deployment of OPCMv2 which makes this available is
+        // version 7.0.0. We need to skip the check for 7.x.x OPCM versions because they can't
+        // guarantee that the lastUsedOPCM function will be available on the incoming SystemConfig.
+        // 8.0.0 and later will always have this function available.
+        if (SemverComp.lt(_version(), "8.0.0")) {
             return true;
         }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -756,8 +756,8 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
 contract OPContractsManagerV2_IsPermittedUpgradeSequence_Test is OPContractsManagerV2_TestInit {
     /// @notice Tests that the upgrade sequence is permitted when using the same OPCM (re-running upgrade).
     function test_isPermittedUpgradeSequence_sameOPCM_succeeds() public {
-        // Mock the OPCM version to be >= 7.0.0 so the check activates.
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.0.0"));
+        // Mock the OPCM version to be >= 8.0.0 so the check activates.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.0.0"));
 
         // Mock lastUsedOPCM to return the same OPCM address.
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(address(opcmV2)));
@@ -771,75 +771,21 @@ contract OPContractsManagerV2_IsPermittedUpgradeSequence_Test is OPContractsMana
         // Create a mock address for the "old" OPCM.
         address oldOPCM = makeAddr("oldOPCM");
 
-        // Mock the current OPCM version to be 7.1.0.
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.1.0"));
+        // Mock the current OPCM version to be 8.1.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.1.0"));
 
         // Mock lastUsedOPCM to return the old OPCM address.
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
 
-        // Mock the old OPCM version to be 7.0.0.
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.0.0"));
+        // Mock the old OPCM version to be 8.0.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.0.0"));
 
-        // Should return true because 7.1.0 > 7.0.0 (same major, higher minor).
+        // Should return true because 8.1.0 > 8.0.0 (same major, higher minor).
         assertTrue(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major higher minor should be permitted");
     }
 
     /// @notice Tests that the upgrade sequence is permitted when upgrading to the next major version.
     function test_isPermittedUpgradeSequence_nextMajorVersion_succeeds() public {
-        // Create a mock address for the "old" OPCM.
-        address oldOPCM = makeAddr("oldOPCM");
-
-        // Mock the current OPCM version to be 8.0.0.
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.0.0"));
-
-        // Mock lastUsedOPCM to return the old OPCM address.
-        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
-
-        // Mock the old OPCM version to be 7.2.0.
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.2.0"));
-
-        // Should return true because 8.0.0 is the next major after 7.x.x.
-        assertTrue(opcmV2.isPermittedUpgradeSequence(systemConfig), "next major version should be permitted");
-    }
-
-    /// @notice Tests that the upgrade sequence is not permitted when downgrading (same major, lower minor).
-    function test_isPermittedUpgradeSequence_sameMajorLowerMinor_fails() public {
-        // Create a mock address for the "old" OPCM.
-        address oldOPCM = makeAddr("oldOPCM");
-
-        // Mock the current OPCM version to be 7.0.0.
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.0.0"));
-
-        // Mock lastUsedOPCM to return the old OPCM address.
-        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
-
-        // Mock the old OPCM version to be 7.1.0.
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.1.0"));
-
-        // Should return false because 7.0.0 < 7.1.0 (downgrade).
-        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major lower minor should not be permitted");
-    }
-
-    /// @notice Tests that the upgrade sequence is not permitted when using same minor with different OPCM.
-    function test_isPermittedUpgradeSequence_sameMajorSameMinor_fails() public {
-        // Create a mock address for the "old" OPCM.
-        address oldOPCM = makeAddr("oldOPCM");
-
-        // Mock the current OPCM version to be 7.1.0.
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.1.0"));
-
-        // Mock lastUsedOPCM to return the old OPCM address.
-        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
-
-        // Mock the old OPCM version to be 7.1.0.
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.1.0"));
-
-        // Should return false because 7.1.0 == 7.1.0 (not higher).
-        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major same minor should not be permitted");
-    }
-
-    /// @notice Tests that the upgrade sequence is not permitted when skipping major versions.
-    function test_isPermittedUpgradeSequence_skipMajorVersion_fails() public {
         // Create a mock address for the "old" OPCM.
         address oldOPCM = makeAddr("oldOPCM");
 
@@ -849,10 +795,64 @@ contract OPContractsManagerV2_IsPermittedUpgradeSequence_Test is OPContractsMana
         // Mock lastUsedOPCM to return the old OPCM address.
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
 
-        // Mock the old OPCM version to be 7.0.0.
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.0.0"));
+        // Mock the old OPCM version to be 8.2.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.2.0"));
 
-        // Should return false because 9.0.0 skips major version 8.
+        // Should return true because 9.0.0 is the next major after 8.x.x.
+        assertTrue(opcmV2.isPermittedUpgradeSequence(systemConfig), "next major version should be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence is not permitted when downgrading (same major, lower minor).
+    function test_isPermittedUpgradeSequence_sameMajorLowerMinor_fails() public {
+        // Create a mock address for the "old" OPCM.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 8.0.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.0.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 8.1.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.1.0"));
+
+        // Should return false because 8.0.0 < 8.1.0 (downgrade).
+        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major lower minor should not be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence is not permitted when using same minor with different OPCM.
+    function test_isPermittedUpgradeSequence_sameMajorSameMinor_fails() public {
+        // Create a mock address for the "old" OPCM.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 8.1.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.1.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 8.1.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.1.0"));
+
+        // Should return false because 8.1.0 == 8.1.0 (not higher).
+        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major same minor should not be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence is not permitted when skipping major versions.
+    function test_isPermittedUpgradeSequence_skipMajorVersion_fails() public {
+        // Create a mock address for the "old" OPCM.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 10.0.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("10.0.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 8.0.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.0.0"));
+
+        // Should return false because 10.0.0 skips major version 9.
         assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "skipping major version should not be permitted");
     }
 
@@ -861,34 +861,34 @@ contract OPContractsManagerV2_IsPermittedUpgradeSequence_Test is OPContractsMana
         // Create a mock address for the "old" OPCM.
         address oldOPCM = makeAddr("oldOPCM");
 
-        // Mock the current OPCM version to be 7.0.0.
+        // Mock the current OPCM version to be 8.0.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.0.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 9.0.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("9.0.0"));
+
+        // Should return false because 8.0.0 < 9.0.0 (major downgrade).
+        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "major downgrade should not be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence check returns true for OPCM versions < 8.0.0.
+    function test_isPermittedUpgradeSequence_versionBelowThreshold_succeeds() public {
+        // Create a mock address for the "old" OPCM that would fail the check if it ran.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 7.0.0 (below threshold).
         vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.0.0"));
 
         // Mock lastUsedOPCM to return the old OPCM address.
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
 
-        // Mock the old OPCM version to be 8.0.0.
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.0.0"));
+        // Mock the old OPCM version to be 10.0.0 (would fail if check ran).
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("10.0.0"));
 
-        // Should return false because 7.0.0 < 8.0.0 (major downgrade).
-        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "major downgrade should not be permitted");
-    }
-
-    /// @notice Tests that the upgrade sequence check returns true for OPCM versions < 7.0.0.
-    function test_isPermittedUpgradeSequence_versionBelowThreshold_succeeds() public {
-        // Create a mock address for the "old" OPCM that would fail the check if it ran.
-        address oldOPCM = makeAddr("oldOPCM");
-
-        // Mock the current OPCM version to be 6.0.0 (below threshold).
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("6.0.0"));
-
-        // Mock lastUsedOPCM to return the old OPCM address.
-        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
-
-        // Mock the old OPCM version to be 9.0.0 (would fail if check ran).
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("9.0.0"));
-
-        // Should return true because the check is skipped for versions < 7.0.0.
+        // Should return true because the check is skipped for versions < 8.0.0.
         assertTrue(opcmV2.isPermittedUpgradeSequence(systemConfig), "version below threshold should be permitted");
     }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -18,6 +18,7 @@ import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IOPContractsManagerStandardValidator } from "interfaces/L1/IOPContractsManagerStandardValidator.sol";
 import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.sol";
 import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
@@ -445,6 +446,19 @@ contract OPContractsManagerV2_Upgrade_TestInit is OPContractsManagerV2_TestInit 
     {
         _runOpcmV2UpgradeAndChecks(opcmV2, _delegateCaller, _revertBytes, _expectedValidatorErrors);
     }
+
+    /// @notice Extracts the absolute prestate embedded in a dispute game config.
+    /// @param _gameType Game type to inspect.
+    /// @return prestate_ The absolute prestate stored in the factory's game args.
+    function _gameArgsAbsolutePrestate(GameType _gameType) internal view returns (bytes32 prestate_) {
+        bytes memory args = disputeGameFactory.gameArgs(_gameType);
+        if (args.length == 0) {
+            return bytes32(0);
+        }
+        assembly {
+            prestate_ := mload(add(args, 0x20))
+        }
+    }
 }
 
 /// @title OPContractsManagerV2_Upgrade_Test
@@ -735,18 +749,155 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
             "permissioned prestate not updated"
         );
     }
+}
 
-    /// @notice Extracts the absolute prestate embedded in a dispute game config.
-    /// @param _gameType Game type to inspect.
-    /// @return prestate_ The absolute prestate stored in the factory's game args.
-    function _gameArgsAbsolutePrestate(GameType _gameType) internal view returns (bytes32 prestate_) {
-        bytes memory args = disputeGameFactory.gameArgs(_gameType);
-        if (args.length == 0) {
-            return bytes32(0);
-        }
-        assembly {
-            prestate_ := mload(add(args, 0x20))
-        }
+/// @title OPContractsManagerV2_IsPermittedUpgradeSequence_Test
+/// @notice Tests OPContractsManagerV2.isPermittedUpgradeSequence
+contract OPContractsManagerV2_IsPermittedUpgradeSequence_Test is OPContractsManagerV2_TestInit {
+    /// @notice Tests that the upgrade sequence is permitted when using the same OPCM (re-running upgrade).
+    function test_isPermittedUpgradeSequence_sameOPCM_succeeds() public {
+        // Mock the OPCM version to be >= 7.0.0 so the check activates.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.0.0"));
+
+        // Mock lastUsedOPCM to return the same OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(address(opcmV2)));
+
+        // Should return true because it's the same OPCM.
+        assertTrue(opcmV2.isPermittedUpgradeSequence(systemConfig), "same OPCM should be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence is permitted when upgrading to same major but higher minor.
+    function test_isPermittedUpgradeSequence_sameMajorHigherMinor_succeeds() public {
+        // Create a mock address for the "old" OPCM.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 7.1.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.1.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 7.0.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.0.0"));
+
+        // Should return true because 7.1.0 > 7.0.0 (same major, higher minor).
+        assertTrue(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major higher minor should be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence is permitted when upgrading to the next major version.
+    function test_isPermittedUpgradeSequence_nextMajorVersion_succeeds() public {
+        // Create a mock address for the "old" OPCM.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 8.0.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.0.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 7.2.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.2.0"));
+
+        // Should return true because 8.0.0 is the next major after 7.x.x.
+        assertTrue(opcmV2.isPermittedUpgradeSequence(systemConfig), "next major version should be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence is not permitted when downgrading (same major, lower minor).
+    function test_isPermittedUpgradeSequence_sameMajorLowerMinor_fails() public {
+        // Create a mock address for the "old" OPCM.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 7.0.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.0.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 7.1.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.1.0"));
+
+        // Should return false because 7.0.0 < 7.1.0 (downgrade).
+        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major lower minor should not be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence is not permitted when using same minor with different OPCM.
+    function test_isPermittedUpgradeSequence_sameMajorSameMinor_fails() public {
+        // Create a mock address for the "old" OPCM.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 7.1.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.1.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 7.1.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.1.0"));
+
+        // Should return false because 7.1.0 == 7.1.0 (not higher).
+        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major same minor should not be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence is not permitted when skipping major versions.
+    function test_isPermittedUpgradeSequence_skipMajorVersion_fails() public {
+        // Create a mock address for the "old" OPCM.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 9.0.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("9.0.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 7.0.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.0.0"));
+
+        // Should return false because 9.0.0 skips major version 8.
+        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "skipping major version should not be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence is not permitted when downgrading major versions.
+    function test_isPermittedUpgradeSequence_downgradeMajorVersion_fails() public {
+        // Create a mock address for the "old" OPCM.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 7.0.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.0.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 8.0.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.0.0"));
+
+        // Should return false because 7.0.0 < 8.0.0 (major downgrade).
+        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "major downgrade should not be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence check returns true for OPCM versions < 7.0.0.
+    function test_isPermittedUpgradeSequence_versionBelowThreshold_succeeds() public {
+        // Create a mock address for the "old" OPCM that would fail the check if it ran.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 6.0.0 (below threshold).
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("6.0.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 9.0.0 (would fail if check ran).
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("9.0.0"));
+
+        // Should return true because the check is skipped for versions < 7.0.0.
+        assertTrue(opcmV2.isPermittedUpgradeSequence(systemConfig), "version below threshold should be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence check returns true for initial deployments.
+    function test_isPermittedUpgradeSequence_initialDeployment_succeeds() public view {
+        // Should return true for initial deployments (address(0) SystemConfig).
+        assertTrue(
+            opcmV2.isPermittedUpgradeSequence(ISystemConfig(address(0))), "initial deployment should be permitted"
+        );
     }
 }
 

--- a/packages/contracts-bedrock/test/opcm/UpgradeSuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/opcm/UpgradeSuperchainConfig.t.sol
@@ -6,7 +6,6 @@ import { Test } from "forge-std/Test.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 import { UpgradeSuperchainConfig } from "scripts/deploy/UpgradeSuperchainConfig.s.sol";
-import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.sol";
 import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds upgrade sequence validation to OPContractsManagerV2, replaces constant version with a pure function and internal accessor, and introduces a semgrep rule to enforce using the internal version accessor.
> 
> - **Contracts (OPContractsManagerV2)**
>   - Convert `version` from constant to `function version() pure` returning `"7.0.0"`; add `_version()` internal accessor and replace internal comparisons.
>   - Add `isPermittedUpgradeSequence(ISystemConfig)` with semver-based checks; enforce in `_apply` for non-initial upgrades.
>   - Add error `OPContractsManagerV2_InvalidUpgradeSequence(string _lastVersion, string _thisVersion)`.
>   - Update interface `IOPContractsManagerV2` and ABI; refresh `semver-lock` hashes.
> - **Tooling / Linting**
>   - Add semgrep rule `sol-safety-opcmv2-use-internal-version` to require `_version()` instead of direct `version()`; add corresponding test case.
>   - Make semgrep CI step fail on findings (`--error`).
> - **Tests**
>   - Add comprehensive tests for upgrade sequencing logic and adapt tests to new `_version()`/`version()` behavior.
>   - Minor test refactors (shared helpers) and cleanup (remove unused v1 import).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a087eb77fe6bea6ca54ff44eac09f9888a7ef9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->