### PR TITLE
test: use correct game type and pass correct extra instruction to UpgradeOPChain

### DIFF
--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -217,10 +217,15 @@ func TestEndToEndBootstrapApplyWithUpgrade(t *testing.T) {
 				CacheDir:                        testCacheDir,
 				Logger:                          lgr,
 				Challenger:                      common.Address{'C'},
+				FaultGameMaxGameDepth:           standard.DisputeMaxGameDepth,
+				FaultGameSplitDepth:             standard.DisputeSplitDepth,
+				FaultGameClockExtension:         standard.DisputeClockExtension,
+				FaultGameMaxClockDuration:       standard.DisputeMaxClockDuration,
 			}
 			if deployer.IsDevFeatureEnabled(tt.devFeature, deployer.OpcmV2DevFlag) {
 				cfg.DevFeatureBitmap = deployer.OpcmV2DevFlag
 			}
+
 			runEndToEndBootstrapAndApplyUpgradeTest(t, afactsFS, cfg)
 		})
 	}
@@ -880,13 +885,13 @@ func runEndToEndBootstrapAndApplyUpgradeTest(t *testing.T, afactsFS foundry.Stat
 						DisputeGameConfigs: []embedded.DisputeGameConfig{
 							{
 								Enabled:  true,
-								InitBond: big.NewInt(0),
+								InitBond: big.NewInt(1000000000000000000),
 								GameType: embedded.GameTypeCannon,
 								GameArgs: []byte{},
 							},
 							{
 								Enabled:  true,
-								InitBond: big.NewInt(0),
+								InitBond: big.NewInt(1000000000000000000),
 								GameType: embedded.GameTypePermissionedCannon,
 								GameArgs: []byte{},
 							},
@@ -902,9 +907,14 @@ func runEndToEndBootstrapAndApplyUpgradeTest(t *testing.T, afactsFS foundry.Stat
 								Key:  "PermittedProxyDeployment",
 								Data: []byte("DelayedWETH"),
 							},
+							{
+								Key:  "overrides.cfg.useCustomGasToken",
+								Data: make([]byte, 32),
+							},
 						},
 					},
 				}
+
 				upgradeConfigBytes, err := json.Marshal(upgradeConfig)
 				require.NoError(t, err, "UpgradeOPChainV2Input should marshal to JSON")
 				err = embedded.DefaultUpgrader.Upgrade(host, upgradeConfigBytes)

--- a/op-deployer/pkg/deployer/upgrade/embedded/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/embedded/upgrade.go
@@ -56,7 +56,7 @@ type GameType uint32
 const (
 	GameTypeCannon             GameType = 0
 	GameTypePermissionedCannon GameType = 1
-	GameTypeCannonKona         GameType = 2
+	GameTypeCannonKona         GameType = 8
 )
 
 // OPChainConfig represents the configuration for an OP Chain upgrade on OPCM v1.


### PR DESCRIPTION
- Changes the game type literal being used in Go for `Cannon Kona` type to match `Types.sol`
- Passes the correct `ExtraInstructions` for upgrading using OPCM v2 on Go tests
- Adds missing `ImplementationsConfig` values in tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `GameTypeCannonKona` to `8` and update integration tests to configure fault game params, nonzero init bonds, and add CGT override for OPCM v2 upgrades.
> 
> - **Tests (integration)**:
>   - Configure fault game parameters in `bootstrap.Implementations` via `ImplementationsConfig` (`FaultGameMaxGameDepth`, `FaultGameSplitDepth`, `FaultGameClockExtension`, `FaultGameMaxClockDuration`).
>   - OPCM v2 chain upgrade:
>     - Set `InitBond` to `1e18` for `GameTypeCannon` and `GameTypePermissionedCannon`.
>     - Add `ExtraInstructions` entry `"overrides.cfg.useCustomGasToken"` (32-byte zero data) alongside `"PermittedProxyDeployment"`.
> - **Upgrade encoder**:
>   - Update `GameTypeCannonKona` value from `2` to `8` in `embedded/upgrade.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04fe18094db93b4aa0a8da5c736c15a8c28a026b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->