### PR TITLE
chore: opcm2 addgametypev2 comments

### DIFF
--- a/op-deployer/pkg/deployer/abi_types.go
+++ b/op-deployer/pkg/deployer/abi_types.go
@@ -1,11 +1,13 @@
 package deployer
 
-import "github.com/ethereum/go-ethereum/accounts/abi"
+import (
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+)
 
 // Primitive ABI types primarily used with `abi.Arguments` to pack/unpack values when calling contract methods.
 var (
-	Uint256Type, _ = abi.NewType("uint256", "", nil)
-	BytesType, _   = abi.NewType("bytes", "", nil)
-	AddressType, _ = abi.NewType("address", "", nil)
-	Bytes32Type, _ = abi.NewType("bytes32", "", nil)
+	Uint256Type = opcm.MustType("uint256")
+	BytesType   = opcm.MustType("bytes")
+	AddressType = opcm.MustType("address")
+	Bytes32Type = opcm.MustType("bytes32")
 )

--- a/op-deployer/pkg/deployer/abi_types.go
+++ b/op-deployer/pkg/deployer/abi_types.go
@@ -1,0 +1,11 @@
+package deployer
+
+import "github.com/ethereum/go-ethereum/accounts/abi"
+
+// Primitive ABI types primarily used with `abi.Arguments` to pack/unpack values when calling contract methods.
+var (
+	Uint256Type, _ = abi.NewType("uint256", "", nil)
+	BytesType, _   = abi.NewType("bytes", "", nil)
+	AddressType, _ = abi.NewType("address", "", nil)
+	Bytes32Type, _ = abi.NewType("bytes32", "", nil)
+)

--- a/op-deployer/pkg/deployer/constants.go
+++ b/op-deployer/pkg/deployer/constants.go
@@ -1,0 +1,10 @@
+package deployer
+
+import "github.com/ethereum/go-ethereum/common"
+
+// Constants for Sepolia chain.
+var (
+	SepoliaChainID                  uint64         = 11155111
+	DefaultL1ProxyAdminOwnerSepolia common.Address = common.HexToAddress("0x1Eb2fFc903729a0F03966B917003800b145F56E2")
+	DefaultSystemConfigProxySepolia common.Address = common.HexToAddress("0x034edD2A225f7f429A63E0f1D2084B9E0A93b538")
+)

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -935,10 +935,8 @@ func runEndToEndBootstrapAndApplyUpgradeTest(t *testing.T, afactsFS foundry.Stat
 			// Then test upgrade on the V2-deployed chain
 			t.Run("upgrade chain v2", func(t *testing.T) {
 				// ABI-encode game args for FaultDisputeGameConfig{absolutePrestate}
-				bytes32Type, err := abi.NewType("bytes32", "", nil)
-				require.NoError(t, err)
-				addressType, err := abi.NewType("address", "", nil)
-				require.NoError(t, err)
+				bytes32Type := deployer.Bytes32Type
+				addressType := deployer.AddressType
 
 				// FaultDisputeGameConfig just needs absolutePrestate (bytes32)
 				testPrestate := common.Hash{'P', 'R', 'E', 'S', 'T', 'A', 'T', 'E'}

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -871,7 +871,7 @@ func runEndToEndBootstrapAndApplyUpgradeTest(t *testing.T, afactsFS foundry.Stat
 				Opcm:  impls.Opcm,
 				ChainConfigs: []embedded.OPChainConfig{
 					{
-						SystemConfigProxy:  common.HexToAddress("034edD2A225f7f429A63E0f1D2084B9E0A93b538"),
+						SystemConfigProxy:  deployer.DefaultSystemConfigProxySepolia,
 						CannonPrestate:     common.Hash{'C', 'A', 'N', 'N', 'O', 'N'},
 						CannonKonaPrestate: common.Hash{'K', 'O', 'N', 'A'},
 					},
@@ -957,7 +957,7 @@ func runEndToEndBootstrapAndApplyUpgradeTest(t *testing.T, afactsFS foundry.Stat
 					Prank: superchainProxyAdminOwner,
 					Opcm:  impls.OpcmV2,
 					UpgradeInputV2: &embedded.UpgradeInputV2{
-						SystemConfig: common.HexToAddress("034edD2A225f7f429A63E0f1D2084B9E0A93b538"),
+						SystemConfig: deployer.DefaultSystemConfigProxySepolia,
 						DisputeGameConfigs: []embedded.DisputeGameConfig{
 							{
 								Enabled:  true,

--- a/op-deployer/pkg/deployer/integration_test/cli/manage_add_game_type_v2_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/manage_add_game_type_v2_test.go
@@ -107,11 +107,11 @@ func TestManageAddGameTypeV2_Integration(t *testing.T) {
 	workDir := runner.GetWorkDir()
 
 	// Test values - using arbitrary addresses for testing
-	l1ProxyAdminOwner := common.HexToAddress("0x1Eb2fFc903729a0F03966B917003800b145F56E2")
-	systemConfigProxy := common.HexToAddress("0x034edD2A225f7f429A63E0f1D2084B9E0A93b538")
+	l1ProxyAdminOwner := deployer.DefaultL1ProxyAdminOwnerSepolia
+	systemConfigProxy := deployer.DefaultSystemConfigProxySepolia
 
 	// Get OPCM V2 address from standard (using Sepolia chain ID for address lookup)
-	opcmV2, err := standard.OPCMImplAddressFor(11155111, standard.ContractsV500Tag)
+	opcmV2, err := standard.OPCMImplAddressFor(deployer.SepoliaChainID, standard.ContractsV500Tag)
 	require.NoError(t, err)
 
 	bytes32Type := deployer.Bytes32Type

--- a/op-deployer/pkg/deployer/integration_test/cli/manage_add_game_type_v2_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/manage_add_game_type_v2_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/embedded"
@@ -113,10 +114,8 @@ func TestManageAddGameTypeV2_Integration(t *testing.T) {
 	opcmV2, err := standard.OPCMImplAddressFor(11155111, standard.ContractsV500Tag)
 	require.NoError(t, err)
 
-	bytes32Type, err := abi.NewType("bytes32", "", nil)
-	require.NoError(t, err)
-	addressType, err := abi.NewType("address", "", nil)
-	require.NoError(t, err)
+	bytes32Type := deployer.Bytes32Type
+	addressType := deployer.AddressType
 
 	// FaultDisputeGameConfig just needs absolutePrestate (bytes32)
 	testPrestate := common.Hash{'P', 'R', 'E', 'S', 'T', 'A', 'T', 'E'}

--- a/op-deployer/pkg/deployer/opcm/contract.go
+++ b/op-deployer/pkg/deployer/opcm/contract.go
@@ -41,7 +41,7 @@ func (c *Contract) GetAddressByNameViaAddressManager(ctx context.Context, name s
 	inputs := abi.Arguments{
 		abi.Argument{
 			Name:    "_name",
-			Type:    mustType("string"),
+			Type:    MustType("string"),
 			Indexed: false,
 		},
 	}
@@ -64,7 +64,7 @@ func (c *Contract) callContractMethod(ctx context.Context, methodName string, in
 		abi.Arguments{
 			abi.Argument{
 				Name:    "address",
-				Type:    mustType("address"),
+				Type:    MustType("address"),
 				Indexed: false,
 			},
 		},
@@ -98,7 +98,7 @@ func (c *Contract) callContractMethod(ctx context.Context, methodName string, in
 	return addr, nil
 }
 
-func mustType(t string) abi.Type {
+func MustType(t string) abi.Type {
 	typ, err := abi.NewType(t, "", nil)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
- Moves hardcoded values to a `constants.go` file
- Replaces primitive ABI types in-place creation for default values