### PR TITLE
test: opcm2 deploy test

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -108,9 +108,12 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 	opcmAddr := st.ImplementationsDeployment.OpcmImpl
 	if devFeatureBitmap, ok := intent.GlobalDeployOverrides["devFeatureBitmap"].(common.Hash); ok {
 		opcmV2Flag := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000010000")
-		if isDevFeatureEnabled(devFeatureBitmap, opcmV2Flag) && st.ImplementationsDeployment.OpcmV2Impl != (common.Address{}) {
+		if isDevFeatureEnabled(devFeatureBitmap, opcmV2Flag) {
 			opcmAddr = st.ImplementationsDeployment.OpcmV2Impl
 		}
+	}
+	if opcmAddr == (common.Address{}) {
+		return opcm.DeployOPChainInput{}, fmt.Errorf("OPCM implementation is not deployed")
 	}
 
 	return opcm.DeployOPChainInput{

--- a/op-deployer/pkg/deployer/pipeline/opchain_test.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
@@ -51,6 +52,7 @@ func Test_makeDCI_OpcmAddress(t *testing.T) {
 		st             *state.State
 		expectedOpcm   common.Address
 		shouldThrowErr bool
+		expectedErrMsg string
 	}{
 		{
 			name:           "default_uses_opcm_v1",
@@ -60,6 +62,7 @@ func Test_makeDCI_OpcmAddress(t *testing.T) {
 			st:             baseState,
 			expectedOpcm:   opcmV1Addr,
 			shouldThrowErr: false,
+			expectedErrMsg: "",
 		},
 		{
 			name: "opcm_v2_flag_enabled_with_v2_impl_uses_v2",
@@ -82,9 +85,10 @@ func Test_makeDCI_OpcmAddress(t *testing.T) {
 			},
 			expectedOpcm:   opcmV2Addr,
 			shouldThrowErr: false,
+			expectedErrMsg: "",
 		},
 		{
-			name: "opcm_v2_flag_enabled_but_v2_impl_zero_falls_back_to_v1",
+			name: "opcm_v2_flag_enabled_but_v2_impl_zero_reverts",
 			intent: &state.Intent{
 				GlobalDeployOverrides: map[string]any{
 					"devFeatureBitmap": opcmV2Flag,
@@ -102,8 +106,28 @@ func Test_makeDCI_OpcmAddress(t *testing.T) {
 					OpcmV2Impl: common.Address{}, // zero address
 				},
 			},
-			expectedOpcm:   opcmV1Addr,
-			shouldThrowErr: false,
+			expectedOpcm:   common.Address{},
+			shouldThrowErr: true,
+			expectedErrMsg: "OPCM implementation is not deployed",
+		},
+		{
+			name:       "opcm_v2_flag_disabled_but_opcm_impl_zero_reverts",
+			intent:     baseIntent,
+			thisIntent: baseChainIntent,
+			chainID:    chainID,
+			st: &state.State{
+				Create2Salt: salt,
+				SuperchainDeployment: &addresses.SuperchainContracts{
+					SuperchainConfigProxy: superchainConfig,
+				},
+				ImplementationsDeployment: &addresses.ImplementationsContracts{
+					OpcmImpl:   common.Address{}, // zero address
+					OpcmV2Impl: opcmV2Addr,
+				},
+			},
+			expectedOpcm:   common.Address{},
+			shouldThrowErr: true,
+			expectedErrMsg: "OPCM implementation is not deployed",
 		},
 		{
 			name: "opcm_v2_flag_not_enabled_uses_v1_even_if_v2_impl_set",
@@ -126,6 +150,7 @@ func Test_makeDCI_OpcmAddress(t *testing.T) {
 			},
 			expectedOpcm:   opcmV1Addr,
 			shouldThrowErr: false,
+			expectedErrMsg: "",
 		},
 		{
 			name: "no_dev_feature_bitmap_uses_v1",
@@ -146,6 +171,7 @@ func Test_makeDCI_OpcmAddress(t *testing.T) {
 			},
 			expectedOpcm:   opcmV1Addr,
 			shouldThrowErr: false,
+			expectedErrMsg: "",
 		},
 	}
 
@@ -155,6 +181,9 @@ func Test_makeDCI_OpcmAddress(t *testing.T) {
 			if gotErr != nil {
 				if !tt.shouldThrowErr {
 					t.Errorf("makeDCI() failed: %v", gotErr)
+				}
+				if tt.expectedErrMsg != "" && !strings.Contains(gotErr.Error(), tt.expectedErrMsg) {
+					t.Errorf("makeDCI() error = %v, want error containing %q", gotErr, tt.expectedErrMsg)
 				}
 				return
 			}

--- a/op-deployer/pkg/deployer/pipeline/opchain_test.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain_test.go
@@ -1,0 +1,169 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func Test_makeDCI_OpcmAddress(t *testing.T) {
+	opcmV1Addr := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	opcmV2Addr := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	opcmV2Flag := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000010000")
+	chainID := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000300")
+	salt := common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234")
+	superchainConfig := common.HexToAddress("0x3333333333333333333333333333333333333333")
+
+	baseIntent := &state.Intent{
+		GlobalDeployOverrides: make(map[string]any),
+	}
+
+	baseChainIntent := &state.ChainIntent{
+		ID: chainID,
+		Roles: state.ChainRoles{
+			L1ProxyAdminOwner: common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+			SystemConfigOwner: common.HexToAddress("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"),
+			Batcher:           common.HexToAddress("0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+			UnsafeBlockSigner: common.HexToAddress("0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"),
+			Proposer:          common.HexToAddress("0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"),
+			Challenger:        common.HexToAddress("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
+		},
+		GasLimit: 60_000_000,
+	}
+
+	baseState := &state.State{
+		Create2Salt: salt,
+		SuperchainDeployment: &addresses.SuperchainContracts{
+			SuperchainConfigProxy: superchainConfig,
+		},
+		ImplementationsDeployment: &addresses.ImplementationsContracts{
+			OpcmImpl: opcmV1Addr,
+		},
+	}
+
+	tests := []struct {
+		name           string
+		intent         *state.Intent
+		thisIntent     *state.ChainIntent
+		chainID        common.Hash
+		st             *state.State
+		expectedOpcm   common.Address
+		shouldThrowErr bool
+	}{
+		{
+			name:           "default_uses_opcm_v1",
+			intent:         baseIntent,
+			thisIntent:     baseChainIntent,
+			chainID:        chainID,
+			st:             baseState,
+			expectedOpcm:   opcmV1Addr,
+			shouldThrowErr: false,
+		},
+		{
+			name: "opcm_v2_flag_enabled_with_v2_impl_uses_v2",
+			intent: &state.Intent{
+				GlobalDeployOverrides: map[string]any{
+					"devFeatureBitmap": opcmV2Flag,
+				},
+			},
+			thisIntent: baseChainIntent,
+			chainID:    chainID,
+			st: &state.State{
+				Create2Salt: salt,
+				SuperchainDeployment: &addresses.SuperchainContracts{
+					SuperchainConfigProxy: superchainConfig,
+				},
+				ImplementationsDeployment: &addresses.ImplementationsContracts{
+					OpcmImpl:   opcmV1Addr,
+					OpcmV2Impl: opcmV2Addr,
+				},
+			},
+			expectedOpcm:   opcmV2Addr,
+			shouldThrowErr: false,
+		},
+		{
+			name: "opcm_v2_flag_enabled_but_v2_impl_zero_falls_back_to_v1",
+			intent: &state.Intent{
+				GlobalDeployOverrides: map[string]any{
+					"devFeatureBitmap": opcmV2Flag,
+				},
+			},
+			thisIntent: baseChainIntent,
+			chainID:    chainID,
+			st: &state.State{
+				Create2Salt: salt,
+				SuperchainDeployment: &addresses.SuperchainContracts{
+					SuperchainConfigProxy: superchainConfig,
+				},
+				ImplementationsDeployment: &addresses.ImplementationsContracts{
+					OpcmImpl:   opcmV1Addr,
+					OpcmV2Impl: common.Address{}, // zero address
+				},
+			},
+			expectedOpcm:   opcmV1Addr,
+			shouldThrowErr: false,
+		},
+		{
+			name: "opcm_v2_flag_not_enabled_uses_v1_even_if_v2_impl_set",
+			intent: &state.Intent{
+				GlobalDeployOverrides: map[string]any{
+					"devFeatureBitmap": common.Hash{}, // flag not set
+				},
+			},
+			thisIntent: baseChainIntent,
+			chainID:    chainID,
+			st: &state.State{
+				Create2Salt: salt,
+				SuperchainDeployment: &addresses.SuperchainContracts{
+					SuperchainConfigProxy: superchainConfig,
+				},
+				ImplementationsDeployment: &addresses.ImplementationsContracts{
+					OpcmImpl:   opcmV1Addr,
+					OpcmV2Impl: opcmV2Addr,
+				},
+			},
+			expectedOpcm:   opcmV1Addr,
+			shouldThrowErr: false,
+		},
+		{
+			name: "no_dev_feature_bitmap_uses_v1",
+			intent: &state.Intent{
+				GlobalDeployOverrides: make(map[string]any), // no devFeatureBitmap key
+			},
+			thisIntent: baseChainIntent,
+			chainID:    chainID,
+			st: &state.State{
+				Create2Salt: salt,
+				SuperchainDeployment: &addresses.SuperchainContracts{
+					SuperchainConfigProxy: superchainConfig,
+				},
+				ImplementationsDeployment: &addresses.ImplementationsContracts{
+					OpcmImpl:   opcmV1Addr,
+					OpcmV2Impl: opcmV2Addr,
+				},
+			},
+			expectedOpcm:   opcmV1Addr,
+			shouldThrowErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := makeDCI(tt.intent, tt.thisIntent, tt.chainID, tt.st)
+			if gotErr != nil {
+				if !tt.shouldThrowErr {
+					t.Errorf("makeDCI() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.shouldThrowErr {
+				t.Fatal("makeDCI() succeeded unexpectedly")
+			}
+			if got.Opcm != tt.expectedOpcm {
+				t.Errorf("makeDCI() Opcm = %v, want %v", got.Opcm, tt.expectedOpcm)
+			}
+		})
+	}
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -926,6 +926,7 @@ contract DeployImplementations is Script {
             address(_input.superchainProxyAdmin) != address(0), "DeployImplementations: superchainProxyAdmin not set"
         );
         require(address(_input.l1ProxyAdminOwner) != address(0), "DeployImplementations: L1ProxyAdminOwner not set");
+        require(address(_input.challenger) != address(0), "DeployImplementations: challenger not set");
     }
 
     function assertValidOutput(Input memory _input, Output memory _output) private {

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -150,6 +150,12 @@ contract DeployImplementations is Script {
 
     // --- OP Contracts Manager ---
 
+    /// @notice Deploys the OPCM v1 contract.
+    ///         Sets the OPCM v2 addresses to zero to indicate that OPCM v2 was not deployed.
+    /// @param _input The deployment input parameters.
+    /// @param _output The deployment output parameters.
+    /// @param _blueprints The blueprints for the OPCM v1 contract.
+    /// @return opcm_ The deployed OPCM v1 contract.
     function createOPCMContract(
         Input memory _input,
         Output memory _output,
@@ -205,6 +211,12 @@ contract DeployImplementations is Script {
         _output.opcmContainer = IOPContractsManagerContainer(address(0));
     }
 
+    /// @notice Deploys the OPCM v2 contract and all the necessary components it uses, including the OPCM v2 container.
+    ///         Sets the OPCM v1 addresses to zero to indicate that OPCM v1 was not deployed.
+    /// @param _input The deployment input parameters.
+    /// @param _output The deployment output parameters.
+    /// @param _blueprints The blueprints for the OPCM v2 contract.
+    /// @return opcmV2_ The deployed OPCM v2 contract.
     function createOPCMContractV2(
         Input memory _input,
         Output memory _output,
@@ -291,6 +303,9 @@ contract DeployImplementations is Script {
         );
     }
 
+    /// @notice Deploys the OPCM contract depending on the dev feature bitmap.
+    /// @param _input The deployment input parameters.
+    /// @param _output The deployment output parameters.
     function deployOPContractsManager(Input memory _input, Output memory _output) private {
         // First we deploy the blueprints for the singletons deployed by OPCM.
         // forgefmt: disable-start

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -30,6 +30,11 @@ import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { GameTypes } from "src/dispute/lib/Types.sol";
 
 contract DeployOPChain is Script {
+    /// @notice The default init bond for the dispute games.
+    uint256 internal constant DEFAULT_INIT_BOND = 0.08 ether;
+
+    /// @notice The output of the DeployOPChain script. This is the same as the DeployOPChainOutput type in the
+    /// op-deployer package.
     struct Output {
         IProxyAdmin opChainProxyAdmin;
         IAddressManager addressManager;
@@ -161,7 +166,7 @@ contract DeployOPChain is Script {
 
         disputeGameConfigs[0] = IOPContractsManagerV2.DisputeGameConfig({
             enabled: cannonEnabled,
-            initBond: cannonEnabled ? 0.08 ether : 0, // Standard init bond if enabled
+            initBond: cannonEnabled ? DEFAULT_INIT_BOND : 0,
             gameType: GameTypes.CANNON,
             gameArgs: abi.encode(cannonConfig)
         });
@@ -176,7 +181,7 @@ contract DeployOPChain is Script {
 
         disputeGameConfigs[1] = IOPContractsManagerV2.DisputeGameConfig({
             enabled: permissionedCannonEnabled,
-            initBond: 0.08 ether, // Standard init bond
+            initBond: DEFAULT_INIT_BOND,
             gameType: GameTypes.PERMISSIONED_CANNON,
             gameArgs: abi.encode(pdgConfig)
         });
@@ -187,7 +192,7 @@ contract DeployOPChain is Script {
 
         disputeGameConfigs[2] = IOPContractsManagerV2.DisputeGameConfig({
             enabled: cannonKonaEnabled,
-            initBond: cannonKonaEnabled ? 0.08 ether : 0, // Standard init bond if enabled
+            initBond: cannonKonaEnabled ? DEFAULT_INIT_BOND : 0,
             gameType: GameTypes.CANNON_KONA,
             gameArgs: abi.encode(cannonKonaConfig)
         });

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -53,33 +53,39 @@ contract DeployOPChain is Script {
         IDelayedWETH delayedWETHPermissionlessGameProxy;
     }
 
+    /// @notice Runs the DeployOPChain script with the given input.
+    /// @param _input The input to the script.
+    /// @return output_ The output of the script.
     function runWithBytes(bytes memory _input) public returns (bytes memory) {
         Types.DeployOPChainInput memory input = abi.decode(_input, (Types.DeployOPChainInput));
         Output memory output_ = run(input);
         return abi.encode(output_);
     }
 
+    /// @notice Runs the DeployOPChain script with the given input.
+    /// @param _input The input to the script.
+    /// @return output_ The output of the script.
     function run(Types.DeployOPChainInput memory _input) public returns (Output memory output_) {
         checkInput(_input);
 
         // Check if OPCM v2 should be used.
-        bool useV2 = isDevFeatureOpcmV2Enabled(_input.opcm);
+        bool useV2 = _isDevFeatureOpcmV2Enabled(_input.opcm);
 
         if (useV2) {
             IOPContractsManagerV2 opcmV2 = IOPContractsManagerV2(_input.opcm);
-            IOPContractsManagerV2.FullConfig memory config = toOPCMV2DeployInput(_input);
+            IOPContractsManagerV2.FullConfig memory config = _toOPCMV2DeployInput(_input);
 
             vm.broadcast(msg.sender);
             IOPContractsManagerV2.ChainContracts memory chainContracts = opcmV2.deploy(config);
-            output_ = fromOPCMV2OutputToOutput(chainContracts);
+            output_ = _fromOPCMV2OutputToOutput(chainContracts);
         } else {
             IOPContractsManager opcm = IOPContractsManager(_input.opcm);
-            IOPContractsManager.DeployInput memory deployInput = toOPCMV1DeployInput(_input);
+            IOPContractsManager.DeployInput memory deployInput = _toOPCMV1DeployInput(_input);
 
             vm.broadcast(msg.sender);
             IOPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);
 
-            output_ = fromOPCMV1OutputToOutput(deployOutput);
+            output_ = _fromOPCMV1OutputToOutput(deployOutput);
         }
 
         checkOutput(_input, output_);
@@ -103,8 +109,10 @@ contract DeployOPChain is Script {
 
     // -------- Features --------
 
-    /// @notice Checks if OPCM v2 dev feature flag is enabled from the contract's dev feature bitmap.
-    function isDevFeatureOpcmV2Enabled(address _opcmAddr) internal view returns (bool) {
+    /// @notice Checks if OPCM v2 dev feature flag is enabled.
+    /// @param _opcmAddr The address of the OPCM contract being used.
+    /// @return True if OPCM v2 is enabled, false otherwise.
+    function _isDevFeatureOpcmV2Enabled(address _opcmAddr) internal view returns (bool) {
         // Both v1 and v2 share the same interface for this function.
         return IOPContractsManager(_opcmAddr).isDevFeatureEnabled(DevFeatures.OPCM_V2);
     }
@@ -112,7 +120,7 @@ contract DeployOPChain is Script {
     /// @notice Converts Types.DeployOPChainInput to IOPContractsManager.DeployInput.
     /// @param _input The input parameters.
     /// @return deployInput_ The deployed input parameters.
-    function toOPCMV1DeployInput(Types.DeployOPChainInput memory _input)
+    function _toOPCMV1DeployInput(Types.DeployOPChainInput memory _input)
         internal
         pure
         returns (IOPContractsManager.DeployInput memory deployInput_)
@@ -146,7 +154,7 @@ contract DeployOPChain is Script {
     /// @notice Converts Types.DeployOPChainInput to IOPContractsManagerV2.FullConfig.
     /// @param _input The input parameters.
     /// @return config_ The deployed input parameters.
-    function toOPCMV2DeployInput(Types.DeployOPChainInput memory _input)
+    function _toOPCMV2DeployInput(Types.DeployOPChainInput memory _input)
         internal
         pure
         returns (IOPContractsManagerV2.FullConfig memory config_)
@@ -219,7 +227,7 @@ contract DeployOPChain is Script {
     /// @notice Converts IOPContractsManagerV2.ChainContracts to Output.
     /// @param _chainContracts The chain contracts.
     /// @return output_ The output parameters.
-    function fromOPCMV2OutputToOutput(IOPContractsManagerV2.ChainContracts memory _chainContracts)
+    function _fromOPCMV2OutputToOutput(IOPContractsManagerV2.ChainContracts memory _chainContracts)
         internal
         pure
         returns (Output memory output_)
@@ -246,7 +254,7 @@ contract DeployOPChain is Script {
     /// @notice Converts IOPContractsManager.DeployOutput to Output.
     /// @param _deployOutput The deploy output.
     /// @return output_ The output parameters.
-    function fromOPCMV1OutputToOutput(IOPContractsManager.DeployOutput memory _deployOutput)
+    function _fromOPCMV1OutputToOutput(IOPContractsManager.DeployOutput memory _deployOutput)
         internal
         pure
         returns (Output memory output_)
@@ -272,6 +280,8 @@ contract DeployOPChain is Script {
 
     // -------- Validations --------
 
+    /// @notice Checks if the input is valid.
+    /// @param _i The input to check.
     function checkInput(Types.DeployOPChainInput memory _i) public view {
         require(_i.opChainProxyAdminOwner != address(0), "DeployOPChainInput: opChainProxyAdminOwner not set");
         require(_i.systemConfigOwner != address(0), "DeployOPChainInput: systemConfigOwner not set");
@@ -296,6 +306,9 @@ contract DeployOPChain is Script {
         require(_i.disputeAbsolutePrestate.raw() != bytes32(0), "DeployOPChainInput: disputeAbsolutePrestate not set");
     }
 
+    /// @notice Checks if the output is valid.
+    /// @param _i The input to check.
+    /// @param _o The output to check.
     function checkOutput(Types.DeployOPChainInput memory _i, Output memory _o) public {
         // With 16 addresses, we'd get a stack too deep error if we tried to do this inline as a
         // single call to `Solarray.addresses`. So we split it into two calls.
@@ -320,6 +333,9 @@ contract DeployOPChain is Script {
         _assertValidDeploy(_i, _o);
     }
 
+    /// @notice Asserts that the deploy is valid.
+    /// @param _i The input to check.
+    /// @param _o The output to check.
     function _assertValidDeploy(Types.DeployOPChainInput memory _i, Output memory _o) internal {
         Types.ContractSet memory proxies = Types.ContractSet({
             L1CrossDomainMessenger: address(_o.l1CrossDomainMessengerProxy),
@@ -341,7 +357,7 @@ contract DeployOPChain is Script {
         // Check dispute games and get superchain config
         address expectedPDGImpl = address(_o.permissionedDisputeGame);
 
-        if (isDevFeatureOpcmV2Enabled(_i.opcm)) {
+        if (_isDevFeatureOpcmV2Enabled(_i.opcm)) {
             // OPCM v2: use implementations from v2 contract
             IOPContractsManagerV2 opcmV2 = IOPContractsManagerV2(_i.opcm);
             expectedPDGImpl = opcmV2.implementations().permissionedDisputeGameV2Impl;
@@ -396,10 +412,13 @@ contract DeployOPChain is Script {
         });
 
         require(_o.addressManager.owner() == address(_o.opChainProxyAdmin), "AM-10");
-        assertValidOPChainProxyAdmin(_i, _o);
+        _assertValidOPChainProxyAdmin(_i, _o);
     }
 
-    function assertValidOPChainProxyAdmin(Types.DeployOPChainInput memory _doi, Output memory _doo) internal {
+    /// @notice Asserts that the OPChainProxyAdmin is valid based on the input and output of the deployment.
+    /// @param _doi The input to the deployment.
+    /// @param _doo The output of the deployment.
+    function _assertValidOPChainProxyAdmin(Types.DeployOPChainInput memory _doi, Output memory _doo) internal {
         IProxyAdmin admin = _doo.opChainProxyAdmin;
         require(admin.owner() == _doi.opChainProxyAdminOwner, "OPCPA-10");
         require(
@@ -457,6 +476,7 @@ contract DeployOPChain is Script {
         );
     }
 
+    /// @notice Returns the starting anchor root for the permissioned game.
     function startingAnchorRoot() public pure returns (bytes memory) {
         // WARNING: For now always hardcode the starting permissioned game anchor root to 0xdead,
         // and we do not set anything for the permissioned game. This is because we currently only

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -68,8 +68,8 @@ contract DeployOPChain is Script {
     function run(Types.DeployOPChainInput memory _input) public returns (Output memory output_) {
         checkInput(_input);
 
-        // Check if OPCM v2 should be used.
-        bool useV2 = _isDevFeatureOpcmV2Enabled(_input.opcm);
+        // Check if OPCM v2 should be used, both v1 and v2 share the same interface for this function.
+        bool useV2 = IOPContractsManager(_input.opcm).isDevFeatureEnabled(DevFeatures.OPCM_V2);
 
         if (useV2) {
             IOPContractsManagerV2 opcmV2 = IOPContractsManagerV2(_input.opcm);
@@ -108,14 +108,6 @@ contract DeployOPChain is Script {
     }
 
     // -------- Features --------
-
-    /// @notice Checks if OPCM v2 dev feature flag is enabled.
-    /// @param _opcmAddr The address of the OPCM contract being used.
-    /// @return True if OPCM v2 is enabled, false otherwise.
-    function _isDevFeatureOpcmV2Enabled(address _opcmAddr) internal view returns (bool) {
-        // Both v1 and v2 share the same interface for this function.
-        return IOPContractsManager(_opcmAddr).isDevFeatureEnabled(DevFeatures.OPCM_V2);
-    }
 
     /// @notice Converts Types.DeployOPChainInput to IOPContractsManager.DeployInput.
     /// @param _input The input parameters.
@@ -357,7 +349,7 @@ contract DeployOPChain is Script {
         // Check dispute games and get superchain config
         address expectedPDGImpl = address(_o.permissionedDisputeGame);
 
-        if (_isDevFeatureOpcmV2Enabled(_i.opcm)) {
+        if (IOPContractsManager(_i.opcm).isDevFeatureEnabled(DevFeatures.OPCM_V2)) {
             // OPCM v2: use implementations from v2 contract
             IOPContractsManagerV2 opcmV2 = IOPContractsManagerV2(_i.opcm);
             expectedPDGImpl = opcmV2.implementations().permissionedDisputeGameV2Impl;

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -31,7 +31,7 @@ import { GameTypes } from "src/dispute/lib/Types.sol";
 
 contract DeployOPChain is Script {
     /// @notice The default init bond for the dispute games.
-    uint256 internal constant DEFAULT_INIT_BOND = 0.08 ether;
+    uint256 public constant DEFAULT_INIT_BOND = 0.08 ether;
 
     /// @notice The output of the DeployOPChain script. This is the same as the DeployOPChainOutput type in the
     /// op-deployer package.

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -104,11 +104,6 @@ contract DeployOPChain is Script {
         return IOPContractsManager(_opcmAddr).isDevFeatureEnabled(DevFeatures.OPCM_V2);
     }
 
-    function isDevFeatureV2DisputeGamesEnabled(address _opcmAddr) internal view returns (bool) {
-        IOPContractsManager opcm = IOPContractsManager(_opcmAddr);
-        return DevFeatures.isDevFeatureEnabled(opcm.devFeatureBitmap(), DevFeatures.DEPLOY_V2_DISPUTE_GAMES);
-    }
-
     /// @notice Converts Types.DeployOPChainInput to IOPContractsManager.DeployInput.
     /// @param _input The input parameters.
     /// @return deployInput_ The deployed input parameters.

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -46,6 +46,8 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         deployImplementations = new DeployImplementations();
     }
 
+    /// @notice Test that the deployImplementations script succeeds when deploying the implementation contracts with a
+    /// valid input.
     function test_deployImplementation_succeeds() public {
         DeployImplementations.Input memory input = defaultInput();
         DeployImplementations.Output memory output = deployImplementations.run(input);
@@ -147,6 +149,8 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         }
     }
 
+    /// @notice Test that the deployImplementations function succeeds when reusing the same valid input.
+    /// It should produce the same output addresses for each deployment.
     function test_reuseImplementation_succeeds() public {
         DeployImplementations.Input memory input = defaultInput();
         DeployImplementations.Output memory output1 = deployImplementations.run(input);
@@ -175,6 +179,7 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         assertNotEq(address(output1.permissionedDisputeGameV2Impl), address(0), "V2 contracts should not be null");
     }
 
+    /// @notice Test that the deployImplementations script succeeds with a range of input values.
     function testFuzz_run_memory_succeeds(
         uint256 _withdrawalDelaySeconds,
         uint256 _minProposalSizeBytes,
@@ -414,6 +419,8 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         assertEq(address(output.mipsSingleton.oracle()), address(output.preimageOracleSingleton), "600");
     }
 
+    /// @notice Test that the deployImplementations script reverts when the Mips version is set to 1 on Mainnet or
+    /// Sepolia.
     function test_run_deployMipsV1OnMainnetOrSepolia_reverts() public {
         DeployImplementations.Input memory input = defaultInput();
         input.mipsVersion = 1;
@@ -427,6 +434,8 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         deployImplementations.run(input);
     }
 
+    /// @notice Test that the deployImplementations script reverts when the challenge period seconds value is too
+    /// large.
     function test_challengePeriodSeconds_valueTooLarge_reverts(uint256 _challengePeriodSeconds) public {
         vm.assume(_challengePeriodSeconds > uint256(type(uint64).max));
 
@@ -437,8 +446,8 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         deployImplementations.run(input);
     }
 
-    /// @notice Test that the deployImplementations function reverts when a required input property is set to not set or
-    /// zero.
+    /// @notice Test that the deployImplementations script reverts when a required input property is set to zero
+    /// value.
     function test_run_nullInput_reverts() public {
         DeployImplementations.Input memory input;
 
@@ -498,6 +507,7 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         deployImplementations.run(input);
     }
 
+    /// @notice Test that the deployImplementations script reverts when the V2 game parameters are invalid.
     function test_invalidV2GameParams_withV2Enabled_reverts() public {
         DeployImplementations.Input memory input;
 

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -437,13 +437,8 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         deployImplementations.run(input);
     }
 
-    function test_challenger_zeroAddress_reverts() public {
-        DeployImplementations.Input memory input = defaultInput();
-        input.challenger = address(0);
-        vm.expectRevert("DeployImplementations: challenger not set");
-        deployImplementations.run(input);
-    }
-
+    /// @notice Test that the deployImplementations function reverts when a required input property is set to not set or
+    /// zero.
     function test_run_nullInput_reverts() public {
         DeployImplementations.Input memory input;
 
@@ -495,6 +490,11 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         input = defaultInput();
         input.l1ProxyAdminOwner = address(0);
         vm.expectRevert("DeployImplementations: L1ProxyAdminOwner not set");
+        deployImplementations.run(input);
+
+        input = defaultInput();
+        input.challenger = address(0);
+        vm.expectRevert("DeployImplementations: challenger not set");
         deployImplementations.run(input);
     }
 

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -437,6 +437,13 @@ contract DeployImplementations_Test is Test, FeatureFlags {
         deployImplementations.run(input);
     }
 
+    function test_challenger_zeroAddress_reverts() public {
+        DeployImplementations.Input memory input = defaultInput();
+        input.challenger = address(0);
+        vm.expectRevert("DeployImplementations: challenger not set");
+        deployImplementations.run(input);
+    }
+
     function test_run_nullInput_reverts() public {
         DeployImplementations.Input memory input;
 

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -280,4 +280,192 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
     {
         return IPermissionedDisputeGame(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.PERMISSIONED_CANNON)));
     }
+
+    function test_runWithBytes_succeeds() public {
+        bytes memory inputBytes = abi.encode(deployOPChainInput);
+        bytes memory outputBytes = deployOPChain.runWithBytes(inputBytes);
+        DeployOPChain.Output memory doo = abi.decode(outputBytes, (DeployOPChain.Output));
+
+        // Verify basic outputs
+        assertNotEq(address(doo.opChainProxyAdmin), address(0), "opChainProxyAdmin should be non-zero");
+        assertNotEq(address(doo.systemConfigProxy), address(0), "systemConfigProxy should be non-zero");
+        assertNotEq(address(doo.disputeGameFactoryProxy), address(0), "disputeGameFactoryProxy should be non-zero");
+    }
+
+    function test_run_cannonGameType_succeeds() public {
+        // Skip test if OPCM v2 is not enabled because OPCM v1 registers PERMISSIONED_CANNON only regardles of the game
+        // type.
+        skipIfDevFeatureDisabled(DevFeatures.OPCM_V2);
+
+        deployOPChainInput.disputeGameType = GameTypes.CANNON;
+        DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
+
+        // CANNON should be enabled with init bond
+        assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), 0.08 ether, "CANNON init bond");
+        assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON)), address(0), "CANNON impl");
+
+        // PERMISSIONED_CANNON must always be enabled
+        assertEq(
+            doo.disputeGameFactoryProxy.initBonds(GameTypes.PERMISSIONED_CANNON),
+            0.08 ether,
+            "PERMISSIONED_CANNON init bond"
+        );
+        assertNotEq(
+            address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.PERMISSIONED_CANNON)),
+            address(0),
+            "PERMISSIONED_CANNON impl"
+        );
+
+        // CANNON_KONA should not be enabled
+        assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA), 0, "CANNON_KONA init bond");
+    }
+
+    function test_run_cannonKonaGameType_succeeds() public {
+        // Skip test if OPCM v2 is not enabled because OPCM v1 registers PERMISSIONED_CANNON only regardles of the game
+        // type.
+        skipIfDevFeatureDisabled(DevFeatures.OPCM_V2);
+
+        deployOPChainInput.disputeGameType = GameTypes.CANNON_KONA;
+        DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
+
+        // CANNON_KONA should be enabled with init bond
+        assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA), 0.08 ether, "CANNON_KONA init bond");
+        assertNotEq(
+            address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON_KONA)), address(0), "CANNON_KONA impl"
+        );
+
+        // PERMISSIONED_CANNON must always be enabled in OPCM v2
+        assertEq(
+            doo.disputeGameFactoryProxy.initBonds(GameTypes.PERMISSIONED_CANNON),
+            0.08 ether,
+            "PERMISSIONED_CANNON init bond"
+        );
+        assertNotEq(
+            address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.PERMISSIONED_CANNON)),
+            address(0),
+            "PERMISSIONED_CANNON impl"
+        );
+
+        // CANNON should not be enabled
+        assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), 0, "CANNON init bond");
+    }
+}
+
+contract DeployOPChain_TestFail is DeployOPChain_TestBase {
+    function test_run_zeroOpChainProxyAdminOwner_reverts() public {
+        deployOPChainInput.opChainProxyAdminOwner = address(0);
+        vm.expectRevert("DeployOPChainInput: opChainProxyAdminOwner not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroSystemConfigOwner_reverts() public {
+        deployOPChainInput.systemConfigOwner = address(0);
+        vm.expectRevert("DeployOPChainInput: systemConfigOwner not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroBatcher_reverts() public {
+        deployOPChainInput.batcher = address(0);
+        vm.expectRevert("DeployOPChainInput: batcher not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroUnsafeBlockSigner_reverts() public {
+        deployOPChainInput.unsafeBlockSigner = address(0);
+        vm.expectRevert("DeployOPChainInput: unsafeBlockSigner not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroProposer_reverts() public {
+        deployOPChainInput.proposer = address(0);
+        vm.expectRevert("DeployOPChainInput: proposer not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroChallenger_reverts() public {
+        deployOPChainInput.challenger = address(0);
+        vm.expectRevert("DeployOPChainInput: challenger not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroBasefeeScalar_reverts() public {
+        deployOPChainInput.basefeeScalar = 0;
+        vm.expectRevert("DeployOPChainInput: basefeeScalar not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroBlobBaseFeeScalar_reverts() public {
+        deployOPChainInput.blobBaseFeeScalar = 0;
+        vm.expectRevert("DeployOPChainInput: blobBaseFeeScalar not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroGasLimit_reverts() public {
+        deployOPChainInput.gasLimit = 0;
+        vm.expectRevert("DeployOPChainInput: gasLimit not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroL2ChainId_reverts() public {
+        deployOPChainInput.l2ChainId = 0;
+        vm.expectRevert("DeployOPChainInput: l2ChainId not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_l2ChainIdMatchesBlockChainId_reverts() public {
+        deployOPChainInput.l2ChainId = block.chainid;
+        vm.expectRevert("DeployOPChainInput: l2ChainId matches block.chainid");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroOpcm_reverts() public {
+        deployOPChainInput.opcm = address(0);
+        vm.expectRevert("DeployOPChainInput: opcm not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_invalidOpcmAddress_reverts() public {
+        // It should revert if the opcm address is not a contract.
+        address eoaAddress = makeAddr("EOA");
+        deployOPChainInput.opcm = eoaAddress;
+        vm.expectRevert();
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroDisputeMaxGameDepth_reverts() public {
+        deployOPChainInput.disputeMaxGameDepth = 0;
+        vm.expectRevert("DeployOPChainInput: disputeMaxGameDepth not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroDisputeSplitDepth_reverts() public {
+        deployOPChainInput.disputeSplitDepth = 0;
+        vm.expectRevert("DeployOPChainInput: disputeSplitDepth not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroDisputeMaxClockDuration_reverts() public {
+        deployOPChainInput.disputeMaxClockDuration = Duration.wrap(0);
+        vm.expectRevert("DeployOPChainInput: disputeMaxClockDuration not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_run_zeroDisputeAbsolutePrestate_reverts() public {
+        deployOPChainInput.disputeAbsolutePrestate = Claim.wrap(bytes32(0));
+        vm.expectRevert("DeployOPChainInput: disputeAbsolutePrestate not set");
+        deployOPChain.run(deployOPChainInput);
+    }
+
+    function test_runWithBytes_invalidInput_reverts() public {
+        // It should revert if the input bytes cannot be decoded.
+        bytes memory invalidInput = "invalid";
+        vm.expectRevert();
+        deployOPChain.runWithBytes(invalidInput);
+    }
+
+    function test_runWithBytes_emptyInput_reverts() public {
+        bytes memory emptyInput = "";
+        vm.expectRevert();
+        deployOPChain.runWithBytes(emptyInput);
+    }
 }

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -155,55 +155,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
         // Basic non-zero and code checks are covered inside run->checkOutput.
         // Additonal targeted assertions added below.
-
-        IPermissionedDisputeGame pdg = getPermissionedDisputeGame(doo);
-        assertEq(pdg.splitDepth(), disputeSplitDepth, "PDG splitDepth");
-        assertEq(pdg.maxGameDepth(), disputeMaxGameDepth, "PDG maxGameDepth");
-        assertEq(Duration.unwrap(pdg.clockExtension()), Duration.unwrap(disputeClockExtension), "PDG clockExtension");
-        assertEq(
-            Duration.unwrap(pdg.maxClockDuration()), Duration.unwrap(disputeMaxClockDuration), "PDG maxClockDuration"
-        );
-
-        // For v2 contracts, some immutable args are passed in at game creation time from DGF.gameArgs
-        assertEq(address(pdg.proposer()), address(0), "PDG proposer");
-        assertEq(address(pdg.challenger()), address(0), "PDG challenger");
-        assertEq(Claim.unwrap(pdg.absolutePrestate()), bytes32(0), "PDG absolutePrestate");
-
-        // Custom gas token feature should reflect input
-        assertEq(doo.systemConfigProxy.isCustomGasToken(), useCustomGasToken, "SystemConfig isCustomGasToken");
-        assertEq(
-            doo.systemConfigProxy.isFeatureEnabled(Features.CUSTOM_GAS_TOKEN),
-            useCustomGasToken,
-            "SystemConfig CUSTOM_GAS_TOKEN feature"
-        );
-
-        // Verify superchainConfig is set correctly
-        assertEq(
-            address(doo.systemConfigProxy.superchainConfig()),
-            address(deployOPChainInput.superchainConfig),
-            "superchainConfig mismatch"
-        );
-
-        // OPCM v2 specific assertions
-        if (isDevFeatureEnabled(DevFeatures.OPCM_V2)) {
-            // PERMISSIONED_CANNON must always be enabled with 0.08 ether init bond
-            assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.PERMISSIONED_CANNON), 0.08 ether);
-            assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.PERMISSIONED_CANNON)), address(0));
-
-            // CANNON is only enabled if it's the starting game type
-            bool cannonEnabled = deployOPChainInput.disputeGameType.raw() == GameTypes.CANNON.raw();
-            assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), cannonEnabled ? 0.08 ether : 0);
-            if (cannonEnabled) {
-                assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON)), address(0));
-            }
-
-            // CANNON_KONA is only enabled if it's the starting game type
-            bool cannonKonaEnabled = deployOPChainInput.disputeGameType.raw() == GameTypes.CANNON_KONA.raw();
-            assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA), cannonKonaEnabled ? 0.08 ether : 0);
-            if (cannonKonaEnabled) {
-                assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON_KONA)), address(0));
-            }
-        }
+        _checkDeploymentAssertions(doo);
     }
 
     function testFuzz_run_memory_succeeds(bytes32 _seed) public {
@@ -286,10 +238,8 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         bytes memory outputBytes = deployOPChain.runWithBytes(inputBytes);
         DeployOPChain.Output memory doo = abi.decode(outputBytes, (DeployOPChain.Output));
 
-        // Verify basic outputs
-        assertNotEq(address(doo.opChainProxyAdmin), address(0), "opChainProxyAdmin should be non-zero");
-        assertNotEq(address(doo.systemConfigProxy), address(0), "systemConfigProxy should be non-zero");
-        assertNotEq(address(doo.disputeGameFactoryProxy), address(0), "disputeGameFactoryProxy should be non-zero");
+        // covers basic non-zero and code checks are covered inside run->checkOutput.
+        _checkDeploymentAssertions(doo);
     }
 
     function test_run_cannonGameType_succeeds() public {
@@ -348,6 +298,60 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
 
         // CANNON should not be enabled
         assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), 0, "CANNON init bond");
+    }
+
+    /// @notice Checks for additional assertions that are not covered by the basic non-zero and code checks in
+    /// `DeployOPChain.checkOutput`.
+    /// @param doo The output of the deployment.
+    function _checkDeploymentAssertions(DeployOPChain.Output memory doo) internal view {
+        IPermissionedDisputeGame pdg = getPermissionedDisputeGame(doo);
+        assertEq(pdg.splitDepth(), disputeSplitDepth, "PDG splitDepth");
+        assertEq(pdg.maxGameDepth(), disputeMaxGameDepth, "PDG maxGameDepth");
+        assertEq(Duration.unwrap(pdg.clockExtension()), Duration.unwrap(disputeClockExtension), "PDG clockExtension");
+        assertEq(
+            Duration.unwrap(pdg.maxClockDuration()), Duration.unwrap(disputeMaxClockDuration), "PDG maxClockDuration"
+        );
+
+        // For v2 contracts, some immutable args are passed in at game creation time from DGF.gameArgs
+        assertEq(address(pdg.proposer()), address(0), "PDG proposer");
+        assertEq(address(pdg.challenger()), address(0), "PDG challenger");
+        assertEq(Claim.unwrap(pdg.absolutePrestate()), bytes32(0), "PDG absolutePrestate");
+
+        // Custom gas token feature should reflect input
+        assertEq(doo.systemConfigProxy.isCustomGasToken(), useCustomGasToken, "SystemConfig isCustomGasToken");
+        assertEq(
+            doo.systemConfigProxy.isFeatureEnabled(Features.CUSTOM_GAS_TOKEN),
+            useCustomGasToken,
+            "SystemConfig CUSTOM_GAS_TOKEN feature"
+        );
+
+        // Verify superchainConfig is set correctly
+        assertEq(
+            address(doo.systemConfigProxy.superchainConfig()),
+            address(deployOPChainInput.superchainConfig),
+            "superchainConfig mismatch"
+        );
+
+        // OPCM v2 specific assertions
+        if (isDevFeatureEnabled(DevFeatures.OPCM_V2)) {
+            // PERMISSIONED_CANNON must always be enabled with 0.08 ether init bond
+            assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.PERMISSIONED_CANNON), 0.08 ether);
+            assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.PERMISSIONED_CANNON)), address(0));
+
+            // CANNON is only enabled if it's the starting game type
+            bool cannonEnabled = deployOPChainInput.disputeGameType.raw() == GameTypes.CANNON.raw();
+            assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), cannonEnabled ? 0.08 ether : 0);
+            if (cannonEnabled) {
+                assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON)), address(0));
+            }
+
+            // CANNON_KONA is only enabled if it's the starting game type
+            bool cannonKonaEnabled = deployOPChainInput.disputeGameType.raw() == GameTypes.CANNON_KONA.raw();
+            assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA), cannonKonaEnabled ? 0.08 ether : 0);
+            if (cannonKonaEnabled) {
+                assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON_KONA)), address(0));
+            }
+        }
     }
 }
 

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -251,13 +251,17 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
 
         // CANNON should be enabled with init bond
-        assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), 0.08 ether, "CANNON init bond");
+        assertEq(
+            doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON),
+            deployOPChain.DEFAULT_INIT_BOND(),
+            "CANNON init bond"
+        );
         assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON)), address(0), "CANNON impl");
 
         // PERMISSIONED_CANNON must always be enabled
         assertEq(
             doo.disputeGameFactoryProxy.initBonds(GameTypes.PERMISSIONED_CANNON),
-            0.08 ether,
+            deployOPChain.DEFAULT_INIT_BOND(),
             "PERMISSIONED_CANNON init bond"
         );
         assertNotEq(
@@ -279,7 +283,11 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
 
         // CANNON_KONA should be enabled with init bond
-        assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA), 0.08 ether, "CANNON_KONA init bond");
+        assertEq(
+            doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA),
+            deployOPChain.DEFAULT_INIT_BOND(),
+            "CANNON_KONA init bond"
+        );
         assertNotEq(
             address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON_KONA)), address(0), "CANNON_KONA impl"
         );
@@ -287,7 +295,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         // PERMISSIONED_CANNON must always be enabled in OPCM v2
         assertEq(
             doo.disputeGameFactoryProxy.initBonds(GameTypes.PERMISSIONED_CANNON),
-            0.08 ether,
+            deployOPChain.DEFAULT_INIT_BOND(),
             "PERMISSIONED_CANNON init bond"
         );
         assertNotEq(
@@ -334,20 +342,28 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
 
         // OPCM v2 specific assertions
         if (isDevFeatureEnabled(DevFeatures.OPCM_V2)) {
-            // PERMISSIONED_CANNON must always be enabled with 0.08 ether init bond
-            assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.PERMISSIONED_CANNON), 0.08 ether);
+            // PERMISSIONED_CANNON must always be enabled with DEFAULT_INIT_BOND init bond
+            assertEq(
+                doo.disputeGameFactoryProxy.initBonds(GameTypes.PERMISSIONED_CANNON), deployOPChain.DEFAULT_INIT_BOND()
+            );
             assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.PERMISSIONED_CANNON)), address(0));
 
             // CANNON is only enabled if it's the starting game type
             bool cannonEnabled = deployOPChainInput.disputeGameType.raw() == GameTypes.CANNON.raw();
-            assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), cannonEnabled ? 0.08 ether : 0);
+            assertEq(
+                doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON),
+                cannonEnabled ? deployOPChain.DEFAULT_INIT_BOND() : 0
+            );
             if (cannonEnabled) {
                 assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON)), address(0));
             }
 
             // CANNON_KONA is only enabled if it's the starting game type
             bool cannonKonaEnabled = deployOPChainInput.disputeGameType.raw() == GameTypes.CANNON_KONA.raw();
-            assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA), cannonKonaEnabled ? 0.08 ether : 0);
+            assertEq(
+                doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA),
+                cannonKonaEnabled ? deployOPChain.DEFAULT_INIT_BOND() : 0
+            );
             if (cannonKonaEnabled) {
                 assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON_KONA)), address(0));
             }


### PR DESCRIPTION
- Adds unit test for `makeDCI` function, ensures the right OPCM address is used depending on the Dev Flag.
- Adds test cases for `DeployOPChain.s.sol`:
    - Tests for the `require`s in `checkInput`
    - Tests for enabled games on OPCM v2

Closes OPT-1384
Closes OPT-1348
Closes OPT-1344