### PR TITLE
chore: Address review comments

### DIFF
--- a/op-deployer/pkg/deployer/integration_test/cli/manage_add_game_type_v2_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/manage_add_game_type_v2_test.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -191,15 +192,39 @@ func TestManageAddGameTypeV2_Integration(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(configFile, configData, 0o644))
 
+	// Create a custom cache directory
+	customCacheDir := filepath.Join(workDir, "custom-cache")
+	require.NoError(t, os.MkdirAll(customCacheDir, 0755))
+
 	// Run the CLI command
 	output := runner.ExpectSuccess(t, []string{
 		"manage", "add-game-type-v2",
 		"--config", configFile,
 		"--l1-rpc-url", runner.l1RPC,
 		"--outfile", outputFile,
+		"--cache-dir", customCacheDir,
 	}, nil)
 
 	t.Logf("Command output (logs):\n%s", output)
+
+	// Verify the cache directory was created
+	entries, err := os.ReadDir(customCacheDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "cache directory should not be empty")
+
+	// Verify the cache directory contains the expected files
+	hasCacheFile := false
+	for _, entry := range entries {
+		if !entry.IsDir() && (strings.HasSuffix(entry.Name(), ".tgz") || strings.HasSuffix(entry.Name(), ".tzst")) {
+			hasCacheFile = true
+			// Verify the file has content
+			info, err := entry.Info()
+			require.NoError(t, err)
+			require.Greater(t, info.Size(), int64(0), "Cache file should not be empty")
+			break
+		}
+	}
+	require.True(t, hasCacheFile, "Cache directory should contain a cached artifact file")
 
 	// Verify output file was created
 	require.FileExists(t, outputFile)

--- a/op-deployer/pkg/deployer/integration_test/cli/manage_add_game_type_v2_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/manage_add_game_type_v2_test.go
@@ -30,7 +30,7 @@ func TestManageAddGameTypeV2_CLI(t *testing.T) {
 	t.Run("missing required flag --config", func(t *testing.T) {
 		runner := NewCLITestRunnerWithNetwork(t)
 		runner.ExpectErrorContains(t, []string{
-			"manage", "add-game-type-opcm-v2",
+			"manage", "add-game-type-v2",
 			"--l1-rpc-url", runner.l1RPC,
 		}, nil, "missing required flag: config")
 	})
@@ -55,7 +55,7 @@ func TestManageAddGameTypeV2_CLI(t *testing.T) {
 		require.NoError(t, os.WriteFile(configFile, configData, 0o644))
 
 		runner.ExpectErrorContains(t, []string{
-			"manage", "add-game-type-opcm-v2",
+			"manage", "add-game-type-v2",
 			"--config", configFile,
 		}, nil, "missing required flag: l1-rpc-url")
 	})
@@ -63,7 +63,7 @@ func TestManageAddGameTypeV2_CLI(t *testing.T) {
 	t.Run("invalid config file path", func(t *testing.T) {
 		runner := NewCLITestRunnerWithNetwork(t)
 		runner.ExpectErrorContains(t, []string{
-			"manage", "add-game-type-opcm-v2",
+			"manage", "add-game-type-v2",
 			"--config", "/nonexistent/path/config.json",
 			"--l1-rpc-url", runner.l1RPC,
 		}, nil, "failed to read config file")
@@ -78,7 +78,7 @@ func TestManageAddGameTypeV2_CLI(t *testing.T) {
 		require.NoError(t, os.WriteFile(configFile, []byte("{invalid json}"), 0o644))
 
 		runner.ExpectErrorContains(t, []string{
-			"manage", "add-game-type-opcm-v2",
+			"manage", "add-game-type-v2",
 			"--config", configFile,
 			"--l1-rpc-url", runner.l1RPC,
 		}, nil, "failed to upgrade")
@@ -99,14 +99,14 @@ func TestManageAddGameTypeV2_CLI(t *testing.T) {
 		require.NoError(t, os.WriteFile(configFile, configData, 0o644))
 
 		runner.ExpectErrorContains(t, []string{
-			"manage", "add-game-type-opcm-v2",
+			"manage", "add-game-type-v2",
 			"--config", configFile,
 			"--l1-rpc-url", runner.l1RPC,
 		}, nil, "failed to upgrade")
 	})
 }
 
-// Tests the manage add-game-type-opcm-v2 command, from the CLI to the actual contract execution through the Solidity scripts.
+// Tests the manage add-game-type-v2 command, from the CLI to the actual contract execution through the Solidity scripts.
 func TestManageAddGameTypeV2_Integration(t *testing.T) {
 	// TODO(#18718): Update this to use an actual deployed OPCM V2 contract once we have one.
 	// For now, we manually deploy the OPCM V2 contract using bootstrap.Implementations.
@@ -193,7 +193,7 @@ func TestManageAddGameTypeV2_Integration(t *testing.T) {
 
 	// Run the CLI command
 	output := runner.ExpectSuccess(t, []string{
-		"manage", "add-game-type-opcm-v2",
+		"manage", "add-game-type-v2",
 		"--config", configFile,
 		"--l1-rpc-url", runner.l1RPC,
 		"--outfile", outputFile,

--- a/op-deployer/pkg/deployer/manage/flags.go
+++ b/op-deployer/pkg/deployer/manage/flags.go
@@ -165,7 +165,7 @@ var Commands = cli.Commands{
 		Action: AddGameTypeCLI,
 	},
 	&cli.Command{
-		Name:  "add-game-type-opcm-v2",
+		Name:  "add-game-type-v2",
 		Usage: "allows to add new game types to the chain using the OPContractsManager V2",
 		Flags: append([]cli.Flag{
 			deployer.L1RPCURLFlag,

--- a/op-deployer/pkg/deployer/manage/flags.go
+++ b/op-deployer/pkg/deployer/manage/flags.go
@@ -3,6 +3,7 @@ package manage
 import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/urfave/cli/v2"
 )
@@ -134,22 +135,6 @@ var (
 		Usage:   "Chain ID of the L2 network to retrieve from state. Must be specified when --workdir is set.",
 		EnvVars: deployer.PrefixEnvVar("CHAIN_ID"),
 	}
-
-	// AddGameType & Migrate Interop OPCM V2 Flags
-	// These flags are used for the upgrade command, which is used under the hood for the add-game-type-v2 and migrate-v2 commands.
-	ConfigFlag = &cli.StringFlag{
-		Name:  "config",
-		Usage: "path to the config file",
-	}
-	OverrideArtifactsURLFlag = &cli.StringFlag{
-		Name:  "override-artifacts-url",
-		Usage: "override the artifacts URL",
-	}
-	OutfileFlag = &cli.StringFlag{
-		Name:  "outfile",
-		Usage: "path to write the output to, or - for stdout",
-		Value: "-",
-	}
 )
 
 var Commands = cli.Commands{
@@ -184,9 +169,10 @@ var Commands = cli.Commands{
 		Usage: "allows to add new game types to the chain using the OPContractsManager V2",
 		Flags: append([]cli.Flag{
 			deployer.L1RPCURLFlag,
-			ConfigFlag,
-			OverrideArtifactsURLFlag,
-			OutfileFlag,
+			upgrade.ConfigFlag,
+			upgrade.OverrideArtifactsURLFlag,
+			upgrade.OutfileFlag,
+			deployer.CacheDirFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: AddGameTypeOPCMV2CLI,
 	},

--- a/op-deployer/pkg/deployer/upgrade/flags.go
+++ b/op-deployer/pkg/deployer/upgrade/flags.go
@@ -73,7 +73,6 @@ var Commands = cli.Commands{
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v410.DefaultUpgrader),
 	},
-	// TODO: Add v5.0.0 test case
 	&cli.Command{
 		Name:  "v5.0.0",
 		Usage: "upgrades a chain to version v5.0.0 (U17)",


### PR DESCRIPTION
- Removes re-declared upgrade flags used in `add-game-type-v2` and imports them from upgrade package instead
- Rename `add-game-type-opmc-v2` to `add-game-type-v2`
- Adds cache dir flag
- Adds a check for cache-dir flag in e2e test
