### PR TITLE
fix: opcm2 review comments

### DIFF
--- a/op-deployer/pkg/deployer/integration_test/cli/migrate_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/migrate_test.go
@@ -30,6 +30,64 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestCLIMigrateRequiredFlags tests that required flags are validated for both OPCM v1 and v2
+func TestCLIMigrateRequiredFlags(t *testing.T) {
+	// Test common required flags (apply to both v1 and v2)
+
+	t.Run("missing l1-rpc-url", func(t *testing.T) {
+		runner := NewCLITestRunner(t)
+		runner.ExpectErrorContains(t, []string{
+			"manage", "migrate",
+			"--private-key", "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			"--opcm-impl-address", common.Address{0x02}.Hex(),
+			// Intentionally omit --l1-rpc-url
+		}, nil, "missing required flag: l1-rpc-url")
+	})
+
+	t.Run("missing private-key", func(t *testing.T) {
+		runner := NewCLITestRunner(t)
+		runner.ExpectErrorContains(t, []string{
+			"manage", "migrate",
+			"--l1-rpc-url", "http://localhost:8545",
+			"--opcm-impl-address", common.Address{0x02}.Hex(),
+			// Intentionally omit --private-key
+		}, nil, "missing required flag: private-key")
+	})
+
+	t.Run("missing opcm-impl-address", func(t *testing.T) {
+		runner := NewCLITestRunner(t)
+		runner.ExpectErrorContains(t, []string{
+			"manage", "migrate",
+			"--l1-rpc-url", "http://localhost:8545",
+			"--private-key", "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			// Intentionally omit --opcm-impl-address
+		}, nil, "missing required flag: opcm-impl-address")
+	})
+
+	t.Run("missing system-config-proxy-address", func(t *testing.T) {
+		runner := NewCLITestRunner(t)
+		runner.ExpectErrorContains(t, []string{
+			"manage", "migrate",
+			"--l1-rpc-url", "http://localhost:8545",
+			"--private-key", "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			"--opcm-impl-address", common.Address{0x02}.Hex(),
+			// Intentionally omit --system-config-proxy-address
+		}, nil, "missing required flag: system-config-proxy-address")
+	})
+
+	t.Run("missing starting-anchor-root", func(t *testing.T) {
+		runner := NewCLITestRunner(t)
+		runner.ExpectErrorContains(t, []string{
+			"manage", "migrate",
+			"--l1-rpc-url", "http://localhost:8545",
+			"--private-key", "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			"--opcm-impl-address", common.Address{0x02}.Hex(),
+			"--system-config-proxy-address", common.Address{0x03}.Hex(),
+			// Intentionally omit --starting-anchor-root
+		}, nil, "missing required flag: starting-anchor-root")
+	})
+}
+
 // TestCLIMigrateV1 tests the migrate-v1 CLI command for OPCM v1
 func TestCLIMigrateV1(t *testing.T) {
 	lgr := testlog.Logger(t, slog.LevelDebug)
@@ -202,7 +260,7 @@ func TestCLIMigrateV1(t *testing.T) {
 		"--l1-proxy-admin-owner-address", superchainProxyAdminOwner.Hex(),
 		"--opcm-impl-address", impls.Opcm.Hex(),
 		"--system-config-proxy-address", systemConfigProxy.Hex(),
-		"--permissionless", "true",
+		"--permissionless",
 		"--proposer-address", common.Address{'P'}.Hex(),
 		"--challenger-address", common.Address{'C'}.Hex(),
 		"--starting-anchor-root", "0x0000000000000000000000000000000000000000000000000000000000000abc",
@@ -421,7 +479,7 @@ func TestCLIMigrateV2(t *testing.T) {
 	// Game type 4 is only for starting-respected-game-type
 	output := runner.ExpectSuccessWithNetwork(t, []string{
 		"manage",
-		"migrate-v2",
+		"migrate",
 		"--l1-proxy-admin-owner-address", superchainProxyAdminOwner.Hex(),
 		"--l1-rpc-url", l1RPC,
 		"--private-key", pkHex,

--- a/op-deployer/pkg/deployer/manage/flags.go
+++ b/op-deployer/pkg/deployer/manage/flags.go
@@ -119,18 +119,6 @@ var (
 		Usage:   "Starting anchor L2 sequence number.",
 		EnvVars: deployer.PrefixEnvVar("STARTING_ANCHOR_L2_SEQUENCE_NUMBER"),
 	}
-	StartingRespectedGameTypeFlag = &cli.Uint64Flag{
-		Name:    "starting-respected-game-type",
-		Usage:   "Starting respected game type for OPCM v2 migration. Defaults to 4 (Super Cannon).",
-		EnvVars: deployer.PrefixEnvVar("STARTING_RESPECTED_GAME_TYPE"),
-		Value:   4,
-	}
-	DisputeGameEnabledFlag = &cli.BoolFlag{
-		Name:    "dispute-game-enabled",
-		Usage:   "Whether the dispute game should be enabled. Used for OPCM v2 migration.",
-		EnvVars: deployer.PrefixEnvVar("DISPUTE_GAME_ENABLED"),
-		Value:   true,
-	}
 	SaltMixerFlag = &cli.StringFlag{
 		Name:    "salt-mixer",
 		Usage:   "String value for the salt mixer, used in CREATE2 address calculation. Default to keccak256(\"op-stack-contract-impls-salt-v0\").",
@@ -146,6 +134,19 @@ var (
 		Name:    "l2-chain-id",
 		Usage:   "Chain ID of the L2 network to retrieve from state. Must be specified when --workdir is set.",
 		EnvVars: deployer.PrefixEnvVar("CHAIN_ID"),
+	}
+	// OPCM v2 flags
+	StartingRespectedGameTypeFlag = &cli.Uint64Flag{
+		Name:    "starting-respected-game-type",
+		Usage:   "Starting respected game type for OPCM v2 migration. Defaults to 4 (Super Cannon).",
+		EnvVars: deployer.PrefixEnvVar("STARTING_RESPECTED_GAME_TYPE"),
+		Value:   4,
+	}
+	DisputeGameEnabledFlag = &cli.BoolFlag{
+		Name:    "dispute-game-enabled",
+		Usage:   "Whether the dispute game should be enabled. Used for OPCM v2 migration.",
+		EnvVars: deployer.PrefixEnvVar("DISPUTE_GAME_ENABLED"),
+		Value:   true,
 	}
 )
 
@@ -190,7 +191,7 @@ var Commands = cli.Commands{
 	},
 	&cli.Command{
 		Name:  "migrate",
-		Usage: "Migrates the chain to use superproofs (OPCM v1, version < 7.0.0)",
+		Usage: "migrates the chain to use superproofs. It supports both OPCM v1 and v2.",
 		Flags: append([]cli.Flag{
 			deployer.CacheDirFlag,
 			deployer.L1RPCURLFlag,
@@ -215,28 +216,12 @@ var Commands = cli.Commands{
 			OPChainProxyAdminFlag,
 			DisputeAbsolutePrestateCannonFlag,
 			DisputeAbsolutePrestateCannonKonaFlag,
-		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
-		Action: MigrateCLI,
-	},
-	&cli.Command{
-		Name:  "migrate-v2",
-		Usage: "Migrates the chain to use superproofs (OPCM v2, version >= 7.0.0)",
-		Flags: append([]cli.Flag{
-			deployer.CacheDirFlag,
-			deployer.L1RPCURLFlag,
-			deployer.PrivateKeyFlag,
-			deployer.ArtifactsLocatorFlag,
-			L1ProxyAdminOwnerFlag,
-			OPCMImplFlag,
-			StartingAnchorRootFlag,
-			StartingAnchorL2SequenceNumberFlag,
-			InitialBondFlag,
-			SystemConfigProxyFlag,
+			// OPCM v2 flags
 			StartingRespectedGameTypeFlag,
 			DisputeGameEnabledFlag,
 			DisputeGameTypeFlag,
 			DisputeAbsolutePrestateFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
-		Action: MigrateCLIV2,
+		Action: MigrateCLI,
 	},
 }

--- a/op-deployer/pkg/deployer/manage/flags.go
+++ b/op-deployer/pkg/deployer/manage/flags.go
@@ -213,7 +213,6 @@ var Commands = cli.Commands{
 			// The following flags represent one item in The EncodedChainConfigs array
 			//
 			SystemConfigProxyFlag,
-			OPChainProxyAdminFlag,
 			DisputeAbsolutePrestateCannonFlag,
 			DisputeAbsolutePrestateCannonKonaFlag,
 			// OPCM v2 flags

--- a/op-deployer/pkg/deployer/manage/flags.go
+++ b/op-deployer/pkg/deployer/manage/flags.go
@@ -136,13 +136,13 @@ var (
 		EnvVars: deployer.PrefixEnvVar("CHAIN_ID"),
 	}
 	// OPCM v2 flags
-	StartingRespectedGameTypeFlag = &cli.Uint64Flag{
+	MigrateStartingRespectedGameTypeFlag = &cli.Uint64Flag{
 		Name:    "starting-respected-game-type",
 		Usage:   "Starting respected game type for OPCM v2 migration. Defaults to 4 (Super Cannon).",
 		EnvVars: deployer.PrefixEnvVar("STARTING_RESPECTED_GAME_TYPE"),
 		Value:   4,
 	}
-	DisputeGameEnabledFlag = &cli.BoolFlag{
+	MigrateDisputeGameEnabledFlag = &cli.BoolFlag{
 		Name:    "dispute-game-enabled",
 		Usage:   "Whether the dispute game should be enabled. Used for OPCM v2 migration.",
 		EnvVars: deployer.PrefixEnvVar("DISPUTE_GAME_ENABLED"),
@@ -217,8 +217,8 @@ var Commands = cli.Commands{
 			DisputeAbsolutePrestateCannonFlag,
 			DisputeAbsolutePrestateCannonKonaFlag,
 			// OPCM v2 flags
-			StartingRespectedGameTypeFlag,
-			DisputeGameEnabledFlag,
+			MigrateStartingRespectedGameTypeFlag,
+			MigrateDisputeGameEnabledFlag,
 			DisputeGameTypeFlag,
 			DisputeAbsolutePrestateFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),

--- a/op-deployer/pkg/deployer/manage/flags.go
+++ b/op-deployer/pkg/deployer/manage/flags.go
@@ -232,7 +232,6 @@ var Commands = cli.Commands{
 			StartingAnchorL2SequenceNumberFlag,
 			InitialBondFlag,
 			SystemConfigProxyFlag,
-			OPChainProxyAdminFlag,
 			StartingRespectedGameTypeFlag,
 			DisputeGameEnabledFlag,
 			DisputeGameTypeFlag,

--- a/op-deployer/pkg/deployer/manage/migrate.go
+++ b/op-deployer/pkg/deployer/manage/migrate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/lmittmann/w3"
 	"github.com/urfave/cli/v2"
@@ -222,12 +223,6 @@ func MigrateCLI(cliCtx *cli.Context) error {
 		return fmt.Errorf("missing required flag: %s", deployer.L1RPCURLFlag.Name)
 	}
 
-	privateKey := cliCtx.String(deployer.PrivateKeyFlag.Name)
-	privateKeyECDSA, err := crypto.HexToECDSA(strings.TrimPrefix(privateKey, "0x"))
-	if err != nil {
-		return fmt.Errorf("failed to parse private key: %w", err)
-	}
-
 	l1RPC, err := rpc.Dial(l1RPCUrl)
 	if err != nil {
 		return fmt.Errorf("failed to dial RPC %s: %w", l1RPCUrl, err)
@@ -237,6 +232,35 @@ func MigrateCLI(cliCtx *cli.Context) error {
 	defer l1Client.Close()
 
 	opcmAddr := common.HexToAddress(cliCtx.String(OPCMImplFlag.Name))
+
+	// Create contract wrapper for OPCM
+	opcmContract := opcm.NewContract(opcmAddr, l1Client)
+
+	// Obtain the actual version of the OPCM contract.
+	version, err := opcmContract.GenericStringGetter(ctx, "version")
+	if err != nil {
+		return fmt.Errorf("failed to get OPCM version: %w", err)
+	}
+
+	isOPCMv2, err := deployer.IsVersionAtLeast(version, 7, 0, 0)
+	if err != nil {
+		return fmt.Errorf("failed to check OPCM version: %w", err)
+	}
+
+	if isOPCMv2 {
+		return migrateCLIV2(cliCtx, ctx, l1Client, lgr, l1RPC, opcmAddr)
+	} else {
+		return migrateCLIV1(cliCtx, ctx, l1Client, lgr, l1RPC, opcmAddr)
+	}
+}
+
+// / Migrates the chain to use superproofs (OPCM v1, version < 7.0.0)
+func migrateCLIV1(cliCtx *cli.Context, ctx context.Context, l1Client *ethclient.Client, lgr log.Logger, l1RPC *rpc.Client, opcmAddr common.Address) error {
+	privateKey := cliCtx.String(deployer.PrivateKeyFlag.Name)
+	privateKeyECDSA, err := crypto.HexToECDSA(strings.TrimPrefix(privateKey, "0x"))
+	if err != nil {
+		return fmt.Errorf("failed to parse private key: %w", err)
+	}
 
 	initBondStr := cliCtx.String(InitialBondFlag.Name)
 	initBond, ok := new(big.Int).SetString(initBondStr, 10)
@@ -328,34 +352,13 @@ func MigrateCLI(cliCtx *cli.Context) error {
 	return nil
 }
 
-func MigrateCLIV2(cliCtx *cli.Context) error {
-	logCfg := oplog.ReadCLIConfig(cliCtx)
-	lgr := oplog.NewLogger(oplog.AppOut(cliCtx), logCfg)
-	oplog.SetGlobalLogHandler(lgr.Handler())
-
-	ctx, cancel := context.WithCancel(cliCtx.Context)
-	defer cancel()
-
-	l1RPCUrl := cliCtx.String(deployer.L1RPCURLFlag.Name)
-	if l1RPCUrl == "" {
-		return fmt.Errorf("missing required flag: %s", deployer.L1RPCURLFlag.Name)
-	}
-
+// Migrates the chain to use superproofs (OPCM v2, version >= 7.0.0)
+func migrateCLIV2(cliCtx *cli.Context, ctx context.Context, l1Client *ethclient.Client, lgr log.Logger, l1RPC *rpc.Client, opcmAddr common.Address) error {
 	privateKey := cliCtx.String(deployer.PrivateKeyFlag.Name)
 	privateKeyECDSA, err := crypto.HexToECDSA(strings.TrimPrefix(privateKey, "0x"))
 	if err != nil {
 		return fmt.Errorf("failed to parse private key: %w", err)
 	}
-
-	l1RPC, err := rpc.Dial(l1RPCUrl)
-	if err != nil {
-		return fmt.Errorf("failed to dial RPC %s: %w", l1RPCUrl, err)
-	}
-
-	l1Client := ethclient.NewClient(l1RPC)
-	defer l1Client.Close()
-
-	opcmAddr := common.HexToAddress(cliCtx.String(OPCMImplFlag.Name))
 
 	initBondStr := cliCtx.String(InitialBondFlag.Name)
 	initBond, ok := new(big.Int).SetString(initBondStr, 10)

--- a/op-deployer/pkg/deployer/manage/migrate.go
+++ b/op-deployer/pkg/deployer/manage/migrate.go
@@ -299,6 +299,12 @@ func MigrateCLI(cliCtx *cli.Context) error {
 			return fmt.Errorf("missing required flag for OPCM v2: %s", DisputeAbsolutePrestateFlag.Name)
 		}
 
+		disputeGameTypeU64 := cliCtx.Uint64(DisputeGameTypeFlag.Name)
+		if disputeGameTypeU64 > 0xFFFFFFFF {
+			return fmt.Errorf("disputeGameType %d exceeds uint32 max value", disputeGameTypeU64)
+		}
+		disputeGameType := uint32(disputeGameTypeU64)
+
 		// V2 Migration Input
 		input.MigrateInputV2 = &MigrateInputV2{
 			ChainSystemConfigs: []common.Address{
@@ -308,7 +314,7 @@ func MigrateCLI(cliCtx *cli.Context) error {
 				{
 					Enabled:  cliCtx.Bool(MigrateDisputeGameEnabledFlag.Name),
 					InitBond: initBond,
-					GameType: uint32(cliCtx.Uint64(DisputeGameTypeFlag.Name)),
+					GameType: disputeGameType,
 					GameArgs: common.FromHex(disputeAbsolutePrestateFlag),
 				},
 			},

--- a/op-deployer/pkg/deployer/manage/migrate.go
+++ b/op-deployer/pkg/deployer/manage/migrate.go
@@ -155,6 +155,11 @@ func (i *InteropMigrationInput) EncodedMigrateInputV1() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode migrate input v1: %w", err)
 	}
+
+	if len(data) < 4 {
+		return nil, fmt.Errorf("failed to encode migrate input v1: data is too short")
+	}
+
 	// Skip the function selector (first 4 bytes)
 	return data[4:], nil
 }
@@ -167,6 +172,11 @@ func (i *InteropMigrationInput) EncodedMigrateInputV2() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode migrate input v2: %w", err)
 	}
+
+	if len(data) < 4 {
+		return nil, fmt.Errorf("failed to encode migrate input v2: data is too short")
+	}
+
 	// Skip the function selector (first 4 bytes)
 	return data[4:], nil
 }

--- a/op-deployer/pkg/deployer/manage/migrate.go
+++ b/op-deployer/pkg/deployer/manage/migrate.go
@@ -391,13 +391,13 @@ func MigrateCLI(cliCtx *cli.Context) error {
 	}
 
 	signer := opcrypto.SignerFnFromBind(opcrypto.PrivateKeySignerFn(privateKeyECDSA, l1ChainID))
-	deployer := crypto.PubkeyToAddress(privateKeyECDSA.PublicKey)
+	deployerAddr := crypto.PubkeyToAddress(privateKeyECDSA.PublicKey)
 	bcaster, err := broadcaster.NewKeyedBroadcaster(broadcaster.KeyedBroadcasterOpts{
 		Logger:  lgr,
 		ChainID: l1ChainID,
 		Client:  l1Client,
 		Signer:  signer,
-		From:    deployer,
+		From:    deployerAddr,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create broadcaster: %w", err)
@@ -407,7 +407,7 @@ func MigrateCLI(cliCtx *cli.Context) error {
 		ctx,
 		bcaster,
 		lgr,
-		deployer,
+		deployerAddr,
 		artifactsFS,
 		l1RPC,
 	)

--- a/op-deployer/pkg/deployer/manage/migrate.go
+++ b/op-deployer/pkg/deployer/manage/migrate.go
@@ -305,6 +305,12 @@ func MigrateCLI(cliCtx *cli.Context) error {
 		}
 		disputeGameType := uint32(disputeGameTypeU64)
 
+		startingRespectedGameTypeU64 := cliCtx.Uint64(MigrateStartingRespectedGameTypeFlag.Name)
+		if startingRespectedGameTypeU64 > 0xFFFFFFFF {
+			return fmt.Errorf("startingRespectedGameType %d exceeds uint32 max value", startingRespectedGameTypeU64)
+		}
+		startingRespectedGameType := uint32(startingRespectedGameTypeU64)
+
 		// V2 Migration Input
 		input.MigrateInputV2 = &MigrateInputV2{
 			ChainSystemConfigs: []common.Address{
@@ -322,7 +328,7 @@ func MigrateCLI(cliCtx *cli.Context) error {
 				Root:             common.HexToHash(startingAnchorRootFlag),
 				L2SequenceNumber: new(big.Int).SetUint64(cliCtx.Uint64(StartingAnchorL2SequenceNumberFlag.Name)),
 			},
-			StartingRespectedGameType: uint32(cliCtx.Uint64(MigrateStartingRespectedGameTypeFlag.Name)),
+			StartingRespectedGameType: startingRespectedGameType,
 		}
 	} else {
 		// Validate V1-specific required flags

--- a/op-deployer/pkg/deployer/manage/migrate.go
+++ b/op-deployer/pkg/deployer/manage/migrate.go
@@ -305,7 +305,7 @@ func MigrateCLI(cliCtx *cli.Context) error {
 			},
 			DisputeGameConfigs: []DisputeGameConfig{
 				{
-					Enabled:  cliCtx.Bool(DisputeGameEnabledFlag.Name),
+					Enabled:  cliCtx.Bool(MigrateDisputeGameEnabledFlag.Name),
 					InitBond: initBond,
 					GameType: uint32(cliCtx.Uint64(DisputeGameTypeFlag.Name)),
 					GameArgs: common.FromHex(disputeAbsolutePrestateFlag),
@@ -315,7 +315,7 @@ func MigrateCLI(cliCtx *cli.Context) error {
 				Root:             common.HexToHash(startingAnchorRootFlag),
 				L2SequenceNumber: new(big.Int).SetUint64(cliCtx.Uint64(StartingAnchorL2SequenceNumberFlag.Name)),
 			},
-			StartingRespectedGameType: uint32(cliCtx.Uint64(StartingRespectedGameTypeFlag.Name)),
+			StartingRespectedGameType: uint32(cliCtx.Uint64(MigrateStartingRespectedGameTypeFlag.Name)),
 		}
 	} else {
 		// Validate V1-specific required flags

--- a/op-deployer/pkg/deployer/manage/migrate.go
+++ b/op-deployer/pkg/deployer/manage/migrate.go
@@ -312,7 +312,7 @@ func MigrateCLI(cliCtx *cli.Context) error {
 		if migrateStartingRespectedGameTypeU64 > 0xFFFFFFFF {
 			return fmt.Errorf("startingRespectedGameType %d exceeds uint32 max value", migrateStartingRespectedGameTypeU64)
 		}
-		startingRespectedGameType := uint32(migrateStartingRespectedGameTypeU64)
+		migrateStartingRespectedGameType := uint32(migrateStartingRespectedGameTypeU64)
 
 		// ABI-encode the FaultDisputeGameConfig struct
 		// FaultDisputeGameConfig contains a single field: absolutePrestate (bytes32)
@@ -346,7 +346,7 @@ func MigrateCLI(cliCtx *cli.Context) error {
 				Root:             common.HexToHash(startingAnchorRootFlag),
 				L2SequenceNumber: new(big.Int).SetUint64(cliCtx.Uint64(StartingAnchorL2SequenceNumberFlag.Name)),
 			},
-			StartingRespectedGameType: startingRespectedGameType,
+			StartingRespectedGameType: migrateStartingRespectedGameType,
 		}
 	} else {
 		// Validate V1-specific required flags

--- a/op-deployer/pkg/deployer/manage/migrate.go
+++ b/op-deployer/pkg/deployer/manage/migrate.go
@@ -222,7 +222,9 @@ func MigrateCLI(cliCtx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to dial RPC %s: %w", l1RPCUrl, err)
 	}
+
 	l1Client := ethclient.NewClient(l1RPC)
+	defer l1Client.Close()
 
 	opcmAddr := common.HexToAddress(cliCtx.String(OPCMImplFlag.Name))
 
@@ -339,7 +341,9 @@ func MigrateCLIV2(cliCtx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to dial RPC %s: %w", l1RPCUrl, err)
 	}
+
 	l1Client := ethclient.NewClient(l1RPC)
+	defer l1Client.Close()
 
 	opcmAddr := common.HexToAddress(cliCtx.String(OPCMImplFlag.Name))
 

--- a/op-deployer/pkg/deployer/manage/migrate.go
+++ b/op-deployer/pkg/deployer/manage/migrate.go
@@ -266,6 +266,7 @@ func MigrateCLI(cliCtx *cli.Context) error {
 		return fmt.Errorf("failed to dial RPC %s: %w", l1RPCUrl, err)
 	}
 	l1Client := ethclient.NewClient(l1RPC)
+	defer l1Client.Close()
 
 	opcmContract := opcm.NewContract(opcmAddr, l1Client)
 

--- a/op-deployer/pkg/deployer/manage/migrate.go
+++ b/op-deployer/pkg/deployer/manage/migrate.go
@@ -17,11 +17,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/lmittmann/w3"
 	"github.com/urfave/cli/v2"
@@ -218,82 +216,154 @@ func MigrateCLI(cliCtx *cli.Context) error {
 	ctx, cancel := context.WithCancel(cliCtx.Context)
 	defer cancel()
 
+	// Validate common required flags for both OPCM v1 and v2 before version detection
 	l1RPCUrl := cliCtx.String(deployer.L1RPCURLFlag.Name)
 	if l1RPCUrl == "" {
 		return fmt.Errorf("missing required flag: %s", deployer.L1RPCURLFlag.Name)
 	}
 
-	l1RPC, err := rpc.Dial(l1RPCUrl)
-	if err != nil {
-		return fmt.Errorf("failed to dial RPC %s: %w", l1RPCUrl, err)
-	}
-
-	l1Client := ethclient.NewClient(l1RPC)
-	defer l1Client.Close()
-
-	opcmAddr := common.HexToAddress(cliCtx.String(OPCMImplFlag.Name))
-
-	// Create contract wrapper for OPCM
-	opcmContract := opcm.NewContract(opcmAddr, l1Client)
-
-	// Obtain the actual version of the OPCM contract.
-	version, err := opcmContract.GenericStringGetter(ctx, "version")
-	if err != nil {
-		return fmt.Errorf("failed to get OPCM version: %w", err)
-	}
-
-	isOPCMv2, err := deployer.IsVersionAtLeast(version, 7, 0, 0)
-	if err != nil {
-		return fmt.Errorf("failed to check OPCM version: %w", err)
-	}
-
-	if isOPCMv2 {
-		return migrateCLIV2(cliCtx, ctx, l1Client, lgr, l1RPC, opcmAddr)
-	} else {
-		return migrateCLIV1(cliCtx, ctx, l1Client, lgr, l1RPC, opcmAddr)
-	}
-}
-
-// / Migrates the chain to use superproofs (OPCM v1, version < 7.0.0)
-func migrateCLIV1(cliCtx *cli.Context, ctx context.Context, l1Client *ethclient.Client, lgr log.Logger, l1RPC *rpc.Client, opcmAddr common.Address) error {
 	privateKey := cliCtx.String(deployer.PrivateKeyFlag.Name)
+	if privateKey == "" {
+		return fmt.Errorf("missing required flag: %s", deployer.PrivateKeyFlag.Name)
+	}
 	privateKeyECDSA, err := crypto.HexToECDSA(strings.TrimPrefix(privateKey, "0x"))
 	if err != nil {
 		return fmt.Errorf("failed to parse private key: %w", err)
 	}
 
+	// Get OPCM address
+	opcmFlag := cliCtx.String(OPCMImplFlag.Name)
+	if opcmFlag == "" {
+		return fmt.Errorf("missing required flag: %s", OPCMImplFlag.Name)
+	}
+	opcmAddr := common.HexToAddress(opcmFlag)
+
+	// Get system config proxy address
+	systemConfigProxyFlag := cliCtx.String(SystemConfigProxyFlag.Name)
+	if systemConfigProxyFlag == "" {
+		return fmt.Errorf("missing required flag: %s", SystemConfigProxyFlag.Name)
+	}
+
+	// Get starting anchor root
+	startingAnchorRootFlag := cliCtx.String(StartingAnchorRootFlag.Name)
+	if startingAnchorRootFlag == "" {
+		return fmt.Errorf("missing required flag: %s", StartingAnchorRootFlag.Name)
+	}
+
+	// Get initial bond
 	initBondStr := cliCtx.String(InitialBondFlag.Name)
+	if initBondStr == "" {
+		return fmt.Errorf("missing required flag: %s", InitialBondFlag.Name)
+	}
 	initBond, ok := new(big.Int).SetString(initBondStr, 10)
 	if !ok {
 		return fmt.Errorf("failed to parse initial bond: %s", initBondStr)
 	}
 
+	// Get L1 RPC to check OPCM version
+	l1RPC, err := rpc.Dial(l1RPCUrl)
+	if err != nil {
+		return fmt.Errorf("failed to dial RPC %s: %w", l1RPCUrl, err)
+	}
+	l1Client := ethclient.NewClient(l1RPC)
+
+	opcmContract := opcm.NewContract(opcmAddr, l1Client)
+
+	versionStr, err := opcmContract.GenericStringGetter(ctx, "version")
+	if err != nil {
+		return fmt.Errorf("failed to get OPCM version: %w", err)
+	}
+
+	// Parse version string (format: "major.minor.patch")
+	// If version < 7.0.0, use v1, otherwise use v2
+	isOPCMv2, err := deployer.IsVersionAtLeast(versionStr, 7, 0, 0)
+	if err != nil {
+		return fmt.Errorf("failed to parse OPCM version %s: %w", versionStr, err)
+	}
+
+	// Get L1 proxy admin owner address
+	l1ProxyAdminOwnerFlag := cliCtx.String(L1ProxyAdminOwnerFlag.Name)
+	if l1ProxyAdminOwnerFlag == "" {
+		return fmt.Errorf("missing required flag: %s", L1ProxyAdminOwnerFlag.Name)
+	}
+
 	input := InteropMigrationInput{
-		Prank: common.HexToAddress(cliCtx.String(L1ProxyAdminOwnerFlag.Name)),
+		Prank: common.HexToAddress(l1ProxyAdminOwnerFlag),
 		Opcm:  opcmAddr,
-		MigrateInputV1: &MigrateInputV1{
+	}
+
+	if isOPCMv2 {
+		disputeAbsolutePrestateFlag := cliCtx.String(DisputeAbsolutePrestateFlag.Name)
+		if disputeAbsolutePrestateFlag == "" {
+			return fmt.Errorf("missing required flag for OPCM v2: %s", DisputeAbsolutePrestateFlag.Name)
+		}
+
+		// V2 Migration Input
+		input.MigrateInputV2 = &MigrateInputV2{
+			ChainSystemConfigs: []common.Address{
+				common.HexToAddress(systemConfigProxyFlag),
+			},
+			DisputeGameConfigs: []DisputeGameConfig{
+				{
+					Enabled:  cliCtx.Bool(DisputeGameEnabledFlag.Name),
+					InitBond: initBond,
+					GameType: uint32(cliCtx.Uint64(DisputeGameTypeFlag.Name)),
+					GameArgs: common.FromHex(disputeAbsolutePrestateFlag),
+				},
+			},
+			StartingAnchorRoot: Proposal{
+				Root:             common.HexToHash(startingAnchorRootFlag),
+				L2SequenceNumber: new(big.Int).SetUint64(cliCtx.Uint64(StartingAnchorL2SequenceNumberFlag.Name)),
+			},
+			StartingRespectedGameType: uint32(cliCtx.Uint64(StartingRespectedGameTypeFlag.Name)),
+		}
+	} else {
+		// Validate V1-specific required flags
+		proposerFlag := cliCtx.String(ProposerFlag.Name)
+		if proposerFlag == "" {
+			return fmt.Errorf("missing required flag for OPCM v1: %s", ProposerFlag.Name)
+		}
+
+		challengerFlag := cliCtx.String(ChallengerFlag.Name)
+		if challengerFlag == "" {
+			return fmt.Errorf("missing required flag for OPCM v1: %s", ChallengerFlag.Name)
+		}
+
+		cannonPrestateFlag := cliCtx.String(DisputeAbsolutePrestateCannonFlag.Name)
+		if cannonPrestateFlag == "" {
+			return fmt.Errorf("missing required flag for OPCM v1: %s", DisputeAbsolutePrestateCannonFlag.Name)
+		}
+
+		cannonKonaPrestateFlag := cliCtx.String(DisputeAbsolutePrestateCannonKonaFlag.Name)
+		if cannonKonaPrestateFlag == "" {
+			return fmt.Errorf("missing required flag for OPCM v1: %s", DisputeAbsolutePrestateCannonKonaFlag.Name)
+		}
+
+		// V1 Migration Input
+		input.MigrateInputV1 = &MigrateInputV1{
 			UsePermissionlessGame: cliCtx.Bool(PermissionlessFlag.Name),
 			StartingAnchorRoot: Proposal{
-				Root:             common.HexToHash(cliCtx.String(StartingAnchorRootFlag.Name)),
+				Root:             common.HexToHash(startingAnchorRootFlag),
 				L2SequenceNumber: new(big.Int).SetUint64(cliCtx.Uint64(StartingAnchorL2SequenceNumberFlag.Name)),
 			},
 			GameParameters: GameParameters{
-				Proposer:         common.HexToAddress(cliCtx.String(ProposerFlag.Name)),
-				Challenger:       common.HexToAddress(cliCtx.String(ChallengerFlag.Name)),
+				Proposer:         common.HexToAddress(proposerFlag),
+				Challenger:       common.HexToAddress(challengerFlag),
 				MaxGameDepth:     cliCtx.Uint64(DisputeMaxGameDepthFlag.Name),
 				SplitDepth:       cliCtx.Uint64(DisputeSplitDepthFlag.Name),
 				InitBond:         initBond,
 				ClockExtension:   cliCtx.Uint64(DisputeClockExtensionFlag.Name),
 				MaxClockDuration: cliCtx.Uint64(DisputeMaxClockDurationFlag.Name),
 			},
+			// At the moment we only support a single chain config
 			OpChainConfigs: []OPChainConfig{
 				{
-					SystemConfigProxy:  common.HexToAddress(cliCtx.String(SystemConfigProxyFlag.Name)),
-					CannonPrestate:     common.HexToHash(cliCtx.String(DisputeAbsolutePrestateCannonFlag.Name)),
-					CannonKonaPrestate: common.HexToHash(cliCtx.String(DisputeAbsolutePrestateCannonKonaFlag.Name)),
+					SystemConfigProxy:  common.HexToAddress(systemConfigProxyFlag),
+					CannonPrestate:     common.HexToHash(cannonPrestateFlag),
+					CannonKonaPrestate: common.HexToHash(cannonKonaPrestateFlag),
 				},
 			},
-		},
+		}
 	}
 
 	artifactsLocatorStr := cliCtx.String(deployer.ArtifactsLocatorFlag.Name)
@@ -314,13 +384,13 @@ func migrateCLIV1(cliCtx *cli.Context, ctx context.Context, l1Client *ethclient.
 	}
 
 	signer := opcrypto.SignerFnFromBind(opcrypto.PrivateKeySignerFn(privateKeyECDSA, l1ChainID))
-	deployerAddr := crypto.PubkeyToAddress(privateKeyECDSA.PublicKey)
+	deployer := crypto.PubkeyToAddress(privateKeyECDSA.PublicKey)
 	bcaster, err := broadcaster.NewKeyedBroadcaster(broadcaster.KeyedBroadcasterOpts{
 		Logger:  lgr,
 		ChainID: l1ChainID,
 		Client:  l1Client,
 		Signer:  signer,
-		From:    deployerAddr,
+		From:    deployer,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create broadcaster: %w", err)
@@ -330,136 +400,7 @@ func migrateCLIV1(cliCtx *cli.Context, ctx context.Context, l1Client *ethclient.
 		ctx,
 		bcaster,
 		lgr,
-		deployerAddr,
-		artifactsFS,
-		l1RPC,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create script host: %w", err)
-	}
-
-	output, err := Migrate(l1Host, input)
-	if err != nil {
-		return fmt.Errorf("failed to run interop migration: %w", err)
-	}
-
-	enc := json.NewEncoder(cliCtx.App.Writer)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(output); err != nil {
-		return fmt.Errorf("failed to encode interop migration output: %w", err)
-	}
-
-	return nil
-}
-
-// Migrates the chain to use superproofs (OPCM v2, version >= 7.0.0)
-func migrateCLIV2(cliCtx *cli.Context, ctx context.Context, l1Client *ethclient.Client, lgr log.Logger, l1RPC *rpc.Client, opcmAddr common.Address) error {
-	privateKey := cliCtx.String(deployer.PrivateKeyFlag.Name)
-	privateKeyECDSA, err := crypto.HexToECDSA(strings.TrimPrefix(privateKey, "0x"))
-	if err != nil {
-		return fmt.Errorf("failed to parse private key: %w", err)
-	}
-
-	initBondStr := cliCtx.String(InitialBondFlag.Name)
-	initBond, ok := new(big.Int).SetString(initBondStr, 10)
-	if !ok {
-		return fmt.Errorf("failed to parse initial bond: %s", initBondStr)
-	}
-
-	// ABI-encode the FaultDisputeGameConfig struct
-	// FaultDisputeGameConfig contains a single field: absolutePrestate (bytes32)
-	absolutePrestateHex := cliCtx.String(DisputeAbsolutePrestateFlag.Name)
-	absolutePrestate := common.HexToHash(absolutePrestateHex)
-
-	bytes32Type, err := abi.NewType("bytes32", "", nil)
-	if err != nil {
-		return fmt.Errorf("failed to create bytes32 ABI type: %w", err)
-	}
-
-	gameArgs, err := abi.Arguments{{Type: bytes32Type}}.Pack(absolutePrestate)
-	if err != nil {
-		return fmt.Errorf("failed to ABI-encode game args: %w", err)
-	}
-
-	startingRespectedGameTypeU64 := cliCtx.Uint64(StartingRespectedGameTypeFlag.Name)
-	if startingRespectedGameTypeU64 > 0xFFFFFFFF {
-		return fmt.Errorf("startingRespectedGameType %d exceeds uint32 max value", startingRespectedGameTypeU64)
-	}
-	startingRespectedGameType := uint32(startingRespectedGameTypeU64)
-
-	systemConfigProxy := common.HexToAddress(cliCtx.String(SystemConfigProxyFlag.Name))
-
-	disputeGameTypeU64 := cliCtx.Uint64(DisputeGameTypeFlag.Name)
-	if disputeGameTypeU64 > 0xFFFFFFFF {
-		return fmt.Errorf("disputeGameType %d exceeds uint32 max value", disputeGameTypeU64)
-	}
-	disputeGameType := uint32(disputeGameTypeU64)
-
-	var prankAddr common.Address
-	if prankFlag := cliCtx.String(L1ProxyAdminOwnerFlag.Name); prankFlag != "" {
-		prankAddr = common.HexToAddress(prankFlag)
-	} else {
-		return fmt.Errorf("missing required flag: %s", L1ProxyAdminOwnerFlag.Name)
-	}
-
-	input := InteropMigrationInput{
-		Prank: prankAddr,
-		Opcm:  opcmAddr,
-		MigrateInputV2: &MigrateInputV2{
-			ChainSystemConfigs: []common.Address{
-				systemConfigProxy,
-			},
-			DisputeGameConfigs: []DisputeGameConfig{
-				{
-					Enabled:  cliCtx.Bool(DisputeGameEnabledFlag.Name),
-					InitBond: initBond,
-					GameType: disputeGameType,
-					GameArgs: gameArgs,
-				},
-			},
-			StartingAnchorRoot: Proposal{
-				Root:             common.HexToHash(cliCtx.String(StartingAnchorRootFlag.Name)),
-				L2SequenceNumber: new(big.Int).SetUint64(cliCtx.Uint64(StartingAnchorL2SequenceNumberFlag.Name)),
-			},
-			StartingRespectedGameType: startingRespectedGameType,
-		},
-	}
-
-	artifactsLocatorStr := cliCtx.String(deployer.ArtifactsLocatorFlag.Name)
-	artifactsLocator := new(artifacts.Locator)
-	if err := artifactsLocator.UnmarshalText([]byte(artifactsLocatorStr)); err != nil {
-		return fmt.Errorf("failed to parse artifacts locator: %w", err)
-	}
-
-	cacheDir := cliCtx.String(deployer.CacheDirFlag.Name)
-	artifactsFS, err := artifacts.Download(ctx, artifactsLocator, ioutil.BarProgressor(), cacheDir)
-	if err != nil {
-		return fmt.Errorf("failed to download artifacts: %w", err)
-	}
-
-	l1ChainID, err := l1Client.ChainID(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get chain ID: %w", err)
-	}
-
-	signer := opcrypto.SignerFnFromBind(opcrypto.PrivateKeySignerFn(privateKeyECDSA, l1ChainID))
-	deployerAddr := crypto.PubkeyToAddress(privateKeyECDSA.PublicKey)
-	bcaster, err := broadcaster.NewKeyedBroadcaster(broadcaster.KeyedBroadcasterOpts{
-		Logger:  lgr,
-		ChainID: l1ChainID,
-		Client:  l1Client,
-		Signer:  signer,
-		From:    deployerAddr,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create broadcaster: %w", err)
-	}
-
-	l1Host, err := env.DefaultForkedScriptHost(
-		ctx,
-		bcaster,
-		lgr,
-		deployerAddr,
+		deployer,
 		artifactsFS,
 		l1RPC,
 	)

--- a/op-deployer/pkg/deployer/manage/migrate.go
+++ b/op-deployer/pkg/deployer/manage/migrate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -208,6 +209,8 @@ func Migrate(host *script.Host, input InteropMigrationInput) (InteropMigrationOu
 	return opcm.RunScriptSingle[ScriptInput, InteropMigrationOutput](host, scriptInput, "InteropMigration.s.sol", "InteropMigration")
 }
 
+// MigrateCLI is the main function for the migrate command. It validates required flags and runs the migration,
+// using the OPCM to determine the input version it should use.
 func MigrateCLI(cliCtx *cli.Context) error {
 	logCfg := oplog.ReadCLIConfig(cliCtx)
 	lgr := oplog.NewLogger(oplog.AppOut(cliCtx), logCfg)
@@ -305,11 +308,26 @@ func MigrateCLI(cliCtx *cli.Context) error {
 		}
 		disputeGameType := uint32(disputeGameTypeU64)
 
-		startingRespectedGameTypeU64 := cliCtx.Uint64(MigrateStartingRespectedGameTypeFlag.Name)
-		if startingRespectedGameTypeU64 > 0xFFFFFFFF {
-			return fmt.Errorf("startingRespectedGameType %d exceeds uint32 max value", startingRespectedGameTypeU64)
+		migrateStartingRespectedGameTypeU64 := cliCtx.Uint64(MigrateStartingRespectedGameTypeFlag.Name)
+		if migrateStartingRespectedGameTypeU64 > 0xFFFFFFFF {
+			return fmt.Errorf("startingRespectedGameType %d exceeds uint32 max value", migrateStartingRespectedGameTypeU64)
 		}
-		startingRespectedGameType := uint32(startingRespectedGameTypeU64)
+		startingRespectedGameType := uint32(migrateStartingRespectedGameTypeU64)
+
+		// ABI-encode the FaultDisputeGameConfig struct
+		// FaultDisputeGameConfig contains a single field: absolutePrestate (bytes32)
+		absolutePrestateHex := cliCtx.String(DisputeAbsolutePrestateFlag.Name)
+		absolutePrestate := common.HexToHash(absolutePrestateHex)
+
+		bytes32Type, err := abi.NewType("bytes32", "", nil)
+		if err != nil {
+			return fmt.Errorf("failed to create bytes32 ABI type: %w", err)
+		}
+
+		gameArgs, err := abi.Arguments{{Type: bytes32Type}}.Pack(absolutePrestate)
+		if err != nil {
+			return fmt.Errorf("failed to ABI-encode game args: %w", err)
+		}
 
 		// V2 Migration Input
 		input.MigrateInputV2 = &MigrateInputV2{
@@ -321,7 +339,7 @@ func MigrateCLI(cliCtx *cli.Context) error {
 					Enabled:  cliCtx.Bool(MigrateDisputeGameEnabledFlag.Name),
 					InitBond: initBond,
 					GameType: disputeGameType,
-					GameArgs: common.FromHex(disputeAbsolutePrestateFlag),
+					GameArgs: gameArgs,
 				},
 			},
 			StartingAnchorRoot: Proposal{

--- a/op-deployer/pkg/deployer/manage/migrate_test.go
+++ b/op-deployer/pkg/deployer/manage/migrate_test.go
@@ -327,47 +327,6 @@ func TestMigrateCLIV2Flags(t *testing.T) {
 	require.Equal(t, uint32(0), startingRespectedGameType)
 }
 
-func TestMigrateCLIMissingRequiredFlags(t *testing.T) {
-	testCases := []struct {
-		name        string
-		setupFlags  func(*flag.FlagSet)
-		expectedErr string
-	}{
-		{
-			name: "missing opcm impl",
-			setupFlags: func(fs *flag.FlagSet) {
-				fs.String(SystemConfigProxyFlag.Name, "0x034edD2A225f7f429A63E0f1D2084B9E0A93b538", "doc")
-			},
-			expectedErr: OPCMImplFlag.Name,
-		},
-		{
-			name: "missing system config proxy",
-			setupFlags: func(fs *flag.FlagSet) {
-				fs.String(OPCMImplFlag.Name, "0xaf334f4537e87f5155d135392ff6d52f1866465e", "doc")
-			},
-			expectedErr: SystemConfigProxyFlag.Name,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			app := cli.NewApp()
-			flagSet := flag.NewFlagSet(fmt.Sprintf("test-%s", tc.name), flag.ContinueOnError)
-			tc.setupFlags(flagSet)
-
-			ctx := cli.NewContext(app, flagSet, nil)
-
-			// Verify that the expected flag is not set
-			switch tc.expectedErr {
-			case OPCMImplFlag.Name:
-				require.Empty(t, ctx.String(OPCMImplFlag.Name))
-			case SystemConfigProxyFlag.Name:
-				require.Empty(t, ctx.String(SystemConfigProxyFlag.Name))
-			}
-		})
-	}
-}
-
 func TestMigrateCLIV2Uint32Overflow(t *testing.T) {
 	testCases := []struct {
 		name                      string

--- a/op-deployer/pkg/deployer/manage/migrate_test.go
+++ b/op-deployer/pkg/deployer/manage/migrate_test.go
@@ -292,20 +292,20 @@ func TestMigrateCLIV2Flags(t *testing.T) {
 	// Set V2-specific flags
 	flagSet.String(OPCMImplFlag.Name, "0xaf334f4537e87f5155d135392ff6d52f1866465e", "doc")
 	flagSet.String(SystemConfigProxyFlag.Name, "0x034edD2A225f7f429A63E0f1D2084B9E0A93b538", "doc")
-	flagSet.Bool(DisputeGameEnabledFlag.Name, true, "doc")
+	flagSet.Bool(MigrateDisputeGameEnabledFlag.Name, true, "doc")
 	flagSet.String(InitialBondFlag.Name, "1000000000000000000", "doc")
 	flagSet.Uint64(DisputeGameTypeFlag.Name, 0, "doc")
 	flagSet.String(DisputeAbsolutePrestateFlag.Name, "0x0000000000000000000000000000000000000000000000000000000000000abc", "doc")
 	flagSet.String(StartingAnchorRootFlag.Name, "0x0000000000000000000000000000000000000000000000000000000000000def", "doc")
 	flagSet.Uint64(StartingAnchorL2SequenceNumberFlag.Name, 1, "doc")
-	flagSet.Uint64(StartingRespectedGameTypeFlag.Name, 0, "doc")
+	flagSet.Uint64(MigrateStartingRespectedGameTypeFlag.Name, 0, "doc")
 
 	ctx := cli.NewContext(app, flagSet, nil)
 
 	// Parse V2 flags
 	opcmAddr := common.HexToAddress(ctx.String(OPCMImplFlag.Name))
 	systemConfigProxy := common.HexToAddress(ctx.String(SystemConfigProxyFlag.Name))
-	disputeGameEnabled := ctx.Bool(DisputeGameEnabledFlag.Name)
+	disputeGameEnabled := ctx.Bool(MigrateDisputeGameEnabledFlag.Name)
 	initBondStr := ctx.String(InitialBondFlag.Name)
 	initBond, ok := new(big.Int).SetString(initBondStr, 10)
 	require.True(t, ok)
@@ -313,7 +313,7 @@ func TestMigrateCLIV2Flags(t *testing.T) {
 	gameArgs := common.FromHex(ctx.String(DisputeAbsolutePrestateFlag.Name))
 	startingAnchorRoot := common.HexToHash(ctx.String(StartingAnchorRootFlag.Name))
 	startingAnchorL2SeqNum := ctx.Uint64(StartingAnchorL2SequenceNumberFlag.Name)
-	startingRespectedGameType := uint32(ctx.Uint64(StartingRespectedGameTypeFlag.Name))
+	startingRespectedGameType := uint32(ctx.Uint64(MigrateStartingRespectedGameTypeFlag.Name))
 
 	// Verify values
 	require.Equal(t, common.HexToAddress("0xaf334f4537e87f5155d135392ff6d52f1866465e"), opcmAddr)
@@ -429,13 +429,13 @@ func TestMigrateCLIV2Uint32Overflow(t *testing.T) {
 			flagSet.String(OPCMImplFlag.Name, "0xaf334f4537e87f5155d135392ff6d52f1866465e", "doc")
 			flagSet.String(SystemConfigProxyFlag.Name, "0x034edD2A225f7f429A63E0f1D2084B9E0A93b538", "doc")
 			flagSet.String(L1ProxyAdminOwnerFlag.Name, "0x1Eb2fFc903729a0F03966B917003800b145F56E2", "doc")
-			flagSet.Bool(DisputeGameEnabledFlag.Name, true, "doc")
+			flagSet.Bool(MigrateDisputeGameEnabledFlag.Name, true, "doc")
 			flagSet.String(InitialBondFlag.Name, "1000000000000000000", "doc")
 			flagSet.Uint64(DisputeGameTypeFlag.Name, tc.disputeGameType, "doc")
 			flagSet.String(DisputeAbsolutePrestateFlag.Name, "0x0000000000000000000000000000000000000000000000000000000000000abc", "doc")
 			flagSet.String(StartingAnchorRootFlag.Name, "0x0000000000000000000000000000000000000000000000000000000000000def", "doc")
 			flagSet.Uint64(StartingAnchorL2SequenceNumberFlag.Name, 1, "doc")
-			flagSet.Uint64(StartingRespectedGameTypeFlag.Name, tc.startingRespectedGameType, "doc")
+			flagSet.Uint64(MigrateStartingRespectedGameTypeFlag.Name, tc.startingRespectedGameType, "doc")
 			flagSet.String(deployer.ArtifactsLocatorFlag.Name, "tag://op-contracts/v1.6.0", "doc")
 			flagSet.String(deployer.CacheDirFlag.Name, t.TempDir(), "doc")
 
@@ -443,7 +443,7 @@ func TestMigrateCLIV2Uint32Overflow(t *testing.T) {
 
 			// Parse the flags to validate uint32 bounds
 			disputeGameTypeU64 := ctx.Uint64(DisputeGameTypeFlag.Name)
-			startingRespectedGameTypeU64 := ctx.Uint64(StartingRespectedGameTypeFlag.Name)
+			startingRespectedGameTypeU64 := ctx.Uint64(MigrateStartingRespectedGameTypeFlag.Name)
 
 			// Simulate the validation logic from MigrateCLIV2
 			var validationErr error

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -7,12 +7,11 @@ import (
 	"math/big"
 	"os"
 	"path"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
@@ -346,24 +345,15 @@ var (
 	versionFn             = w3.MustNewFunc("version()", "string")
 )
 
+// isOPCMV2 is a helper function that checks the OPCM version and returns true if it is at least 7.0.0
 func isOPCMV2(t devtest.CommonT, client *w3.Client, opcmAddr common.Address) bool {
 	var version string
 	err := client.Call(w3eth.CallFunc(opcmAddr, versionFn).Returns(&version))
 	t.Require().NoError(err, "failed to get OPCM version")
 
-	// Parse version string (format: "major.minor.patch")
-	// V2 starts at version 7.0.0
-	parts := strings.Split(strings.TrimPrefix(version, "v"), ".")
-	if len(parts) < 1 {
-		return false
-	}
-
-	major := 0
-	if n, err := strconv.Atoi(parts[0]); err == nil {
-		major = n
-	}
-
-	return major >= 7
+	isVersionAtLeast, err := deployer.IsVersionAtLeast(version, 7, 0, 0)
+	t.Require().NoError(err, "failed to check OPCM version")
+	return isVersionAtLeast
 }
 
 func getOptimismPortal(t devtest.CommonT, client *w3.Client, systemConfigProxy common.Address) common.Address {


### PR DESCRIPTION
## Changes
- Closes underlying RPC client in interop migration code path                                                                                                                                    
- Adds validation for encoded migrate input data length (minimum 4 bytes)                                                                                                                        
- Refactors `op-devstack/sysgo/superroot.go` to use `isVersionAtLeast` for OPCM version checks                                                                                                   
- Renames OPCM v2-specific flags to indicate they are migrate-exclusive (adds `Migrate` prefix)                                                                                                  
- Unifies `migrate` and `migrate-v2` commands into a single `migrate` command that automatically detects OPCM version and executes the appropriate code path    