### PR TITLE
chore: bump solidity version

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployPolicyEngineStaking.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployPolicyEngineStaking.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.30;
 
 import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";

--- a/packages/contracts-bedrock/snapshots/abi/PolicyEngineStaking.json
+++ b/packages/contracts-bedrock/snapshots/abi/PolicyEngineStaking.json
@@ -45,12 +45,12 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "beneficiary",
         "type": "address"
       },
       {
         "internalType": "address",
-        "name": "",
+        "name": "staker",
         "type": "address"
       }
     ],
@@ -58,7 +58,7 @@
     "outputs": [
       {
         "internalType": "bool",
-        "name": "",
+        "name": "allowed",
         "type": "bool"
       }
     ],
@@ -115,7 +115,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "account",
         "type": "address"
       }
     ],
@@ -193,7 +193,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "account",
         "type": "address"
       }
     ],

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.30;
 
 // Interfaces
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -250,11 +250,8 @@ contract PolicyEngineStaking {
     function setAllowedStakers(address[] calldata _stakers, bool _allowed) external {
         uint256 stakersLength = _stakers.length;
 
-        for (uint256 i; i < stakersLength;) {
+        for (uint256 i; i < stakersLength; ++i) {
             setAllowedStaker(_stakers[i], _allowed);
-            unchecked {
-                ++i;
-            }
         }
     }
 

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -44,13 +44,13 @@ contract PolicyEngineStaking {
     IERC20 public immutable STAKING_TOKEN;
 
     /// @notice Slot 0: PE data mapping.
-    mapping(address => PEData) public peData;
+    mapping(address account => PEData) public peData;
 
     /// @notice Allowlist: beneficiary => staker => allowed.
-    mapping(address => mapping(address => bool)) public allowlist;
+    mapping(address beneficiary => mapping(address staker => bool allowed)) public allowlist;
 
     /// @notice Staking data mapping.
-    mapping(address => StakedData) public stakingData;
+    mapping(address account => StakedData) public stakingData;
 
     /// @notice Paused state.
     bool public paused;

--- a/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
+++ b/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
@@ -5,11 +5,9 @@ pragma solidity 0.8.15;
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { TestERC20 } from "test/mocks/TestERC20.sol";
 
-// Contracts
-import { PolicyEngineStaking } from "src/periphery/staking/PolicyEngineStaking.sol";
-
 // Interfaces
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IPolicyEngineStaking } from "interfaces/periphery/staking/IPolicyEngineStaking.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
@@ -19,7 +17,7 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 abstract contract PolicyEngineStaking_TestInit is CommonTest {
     address internal carol = address(0xC4101);
 
-    PolicyEngineStaking internal staking;
+    IPolicyEngineStaking internal staking;
     address internal owner;
 
     event Staked(address indexed account, uint256 amount);
@@ -34,7 +32,9 @@ abstract contract PolicyEngineStaking_TestInit is CommonTest {
     function setUp() public virtual override {
         super.setUp();
         owner = makeAddr("owner");
-        staking = new PolicyEngineStaking(owner, Predeploys.GOVERNANCE_TOKEN);
+        staking = IPolicyEngineStaking(
+            vm.deployCode("PolicyEngineStaking.sol:PolicyEngineStaking", abi.encode(owner, Predeploys.GOVERNANCE_TOKEN))
+        );
 
         _setupMockOPToken();
 
@@ -85,7 +85,7 @@ contract PolicyEngineStaking_Pause_Test is PolicyEngineStaking_TestInit {
     /// @notice Tests that non-owner cannot pause.
     function testFuzz_pause_notOwner_reverts(address _caller) external {
         vm.assume(_caller != owner && _caller != address(0));
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_OnlyOwner.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_OnlyOwner.selector);
         vm.prank(_caller);
         staking.pause();
     }
@@ -96,7 +96,7 @@ contract PolicyEngineStaking_Pause_Test is PolicyEngineStaking_TestInit {
         staking.pause();
 
         vm.assume(_caller != owner && _caller != address(0));
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_OnlyOwner.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_OnlyOwner.selector);
         vm.prank(_caller);
         staking.unpause();
     }
@@ -106,7 +106,7 @@ contract PolicyEngineStaking_Pause_Test is PolicyEngineStaking_TestInit {
         vm.prank(owner);
         staking.pause();
 
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_Paused.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_Paused.selector);
         vm.prank(alice);
         staking.stake(100 ether, alice);
     }
@@ -270,21 +270,21 @@ contract PolicyEngineStaking_Stake_Test is PolicyEngineStaking_TestInit {
     /// @notice Tests that stake with zero amount reverts.
     function test_stake_zeroAmount_reverts() external {
         vm.prank(alice);
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_ZeroAmount.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_ZeroAmount.selector);
         staking.stake(0, alice);
     }
 
     /// @notice Tests that stake with zero beneficiary reverts.
     function test_stake_zeroBeneficiary_reverts() external {
         vm.prank(alice);
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_ZeroBeneficiary.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_ZeroBeneficiary.selector);
         staking.stake(100 ether, address(0));
     }
 
     /// @notice Tests that stake to beneficiary without allowlist reverts.
     function test_stake_toBeneficiaryWithoutAllowlist_reverts() external {
         vm.prank(alice);
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_NotAllowedToLink.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_NotAllowedToLink.selector);
         staking.stake(100 ether, bob);
     }
 
@@ -294,7 +294,7 @@ contract PolicyEngineStaking_Stake_Test is PolicyEngineStaking_TestInit {
         staking.stake(100 ether, alice);
 
         vm.prank(alice);
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_NotAllowedToLink.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_NotAllowedToLink.selector);
         staking.stake(50 ether, bob);
     }
 }
@@ -333,14 +333,14 @@ contract PolicyEngineStaking_Unstake_Test is PolicyEngineStaking_TestInit {
         staking.stake(100 ether, alice);
 
         vm.prank(alice);
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_ZeroAmount.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_ZeroAmount.selector);
         staking.unstake(0);
     }
 
     /// @notice Tests that unstake with no stake reverts.
     function test_unstake_noStake_reverts() external {
         vm.prank(alice);
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_InsufficientStake.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_InsufficientStake.selector);
         staking.unstake(100 ether);
     }
 
@@ -350,7 +350,7 @@ contract PolicyEngineStaking_Unstake_Test is PolicyEngineStaking_TestInit {
         staking.stake(100 ether, alice);
 
         vm.prank(alice);
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_InsufficientStake.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_InsufficientStake.selector);
         staking.unstake(101 ether);
     }
 
@@ -504,7 +504,7 @@ contract PolicyEngineStaking_ChangeBeneficiary_Test is PolicyEngineStaking_TestI
         staking.stake(100 ether, alice);
 
         vm.prank(alice);
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_ZeroBeneficiary.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_ZeroBeneficiary.selector);
         staking.changeBeneficiary(address(0));
     }
 
@@ -514,14 +514,14 @@ contract PolicyEngineStaking_ChangeBeneficiary_Test is PolicyEngineStaking_TestI
         staking.stake(100 ether, alice);
 
         vm.prank(alice);
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_NotAllowedToLink.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_NotAllowedToLink.selector);
         staking.changeBeneficiary(bob);
     }
 
     /// @notice Tests that changeBeneficiary with no stake reverts.
     function test_changeBeneficiary_noStake_reverts() external {
         vm.prank(alice);
-        vm.expectRevert(PolicyEngineStaking.PolicyEngineStaking_NoStake.selector);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_NoStake.selector);
         staking.changeBeneficiary(bob);
     }
 }


### PR DESCRIPTION
for review only. don't approve nor merge. pre-pr must be run

upgraded solidity version allows:

- named mappings
- remove unchecked block we hate those
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update Solidity compiler version from 0.8.15 to 0.8.30 across PolicyEngineStaking contract and related files to leverage compiler improvements and security patches.

Main changes:
- Bumped pragma solidity version to 0.8.30 in PolicyEngineStaking contract and deployment script
- Updated mapping declarations to use named parameter syntax for improved code readability
- Refactored loop implementation to use modern Solidity increment operator without unchecked block

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
