### PR TITLE
fix: minors

### DIFF
--- a/packages/contracts-bedrock/interfaces/periphery/staking/IPolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/interfaces/periphery/staking/IPolicyEngineStaking.sol
@@ -61,6 +61,9 @@ interface IPolicyEngineStaking is ISemver {
     /// @notice Thrown when trying to change beneficiary to the current beneficiary.
     error PolicyEngineStaking_SameBeneficiary();
 
+    /// @notice Thrown when trying to allowlist/disallow yourself.
+    error PolicyEngineStaking_SelfAllowlist();
+
     /// @notice Returns the contract owner.
     function owner() external view returns (address);
 

--- a/packages/contracts-bedrock/interfaces/periphery/staking/IPolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/interfaces/periphery/staking/IPolicyEngineStaking.sol
@@ -109,7 +109,10 @@ interface IPolicyEngineStaking is ISemver {
     /// @param _amount The amount of OP tokens to unstake.
     function unstake(uint128 _amount) external;
 
-    /// @notice Sets whether a staker can set the caller as beneficiary.
+    /// @notice Sets whether a staker can set the caller as beneficiary. When disallowing,
+    ///         if the staker's current beneficiary is the caller, their stake attribution is
+    ///         moved back to the staker (beneficiary reset to self).
+    ///
     /// @param _staker  The staker address.
     /// @param _allowed Whether the staker is allowed to set the caller as beneficiary.
     function setAllowedStaker(address _staker, bool _allowed) external;

--- a/packages/contracts-bedrock/snapshots/abi/PolicyEngineStaking.json
+++ b/packages/contracts-bedrock/snapshots/abi/PolicyEngineStaking.json
@@ -442,6 +442,11 @@
   },
   {
     "inputs": [],
+    "name": "PolicyEngineStaking_SelfAllowlist",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "PolicyEngineStaking_ZeroAddress",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -236,8 +236,8 @@
     "sourceCodeHash": "0x955bd0c9b47e43219865e4e92abf28d916c96de20cbdf2f94c8ab14d02083759"
   },
   "src/periphery/staking/PolicyEngineStaking.sol:PolicyEngineStaking": {
-    "initCodeHash": "0xb6862d7055bce4d60afc2fea2d1de249e555353f3109a78bffa223aff8e5a69b",
-    "sourceCodeHash": "0x3effa22f135ebf47a7e637e4dc13256e1dcd343a604df9aeedfcfd74836766a4"
+    "initCodeHash": "0xc0c04b0dddbf7831bf5abfccc6a569d92f9b7ab0ec53278f6d1cf7113041d59d",
+    "sourceCodeHash": "0x998ddc9f24e3c85b1d588c263838261442edaad1dde5424fd55c2d4e1243592a"
   },
   "src/safe/DeputyPauseModule.sol:DeputyPauseModule": {
     "initCodeHash": "0x18422b48c4901ed6fd9338d76d3c5aecfff9a7add34b05c6e21c23d0011ed6bf",

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -272,7 +272,10 @@ contract PolicyEngineStaking is ISemver {
         emit Unstaked(msg.sender, _amount);
     }
 
-    /// @notice Sets whether a staker can set the caller as beneficiary.
+    /// @notice Sets whether a staker can set the caller as beneficiary. When disallowing,
+    ///         if the staker's current beneficiary is the caller, their stake attribution is
+    ///         moved back to the staker (beneficiary reset to self).
+    ///
     /// @param _staker The staker to allow or deny.
     /// @param _allowed The allowed state.
     function setAllowedStaker(address _staker, bool _allowed) public {

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -127,6 +127,9 @@ contract PolicyEngineStaking is ISemver {
     /// @notice Thrown when trying to change beneficiary to the current beneficiary.
     error PolicyEngineStaking_SameBeneficiary();
 
+    /// @notice Thrown when trying to allowlist/disallow yourself.
+    error PolicyEngineStaking_SelfAllowlist();
+
     /// @notice Constructs the PolicyEngineStaking contract.
     /// @param _ownerAddr The address that can pause and unpause staking.
     /// @param _token The ERC20 token used for staking.
@@ -273,12 +276,14 @@ contract PolicyEngineStaking is ISemver {
     /// @param _staker The staker to allow or deny.
     /// @param _allowed The allowed state.
     function setAllowedStaker(address _staker, bool _allowed) public {
+        if (_staker == msg.sender) revert PolicyEngineStaking_SelfAllowlist();
+
         allowlist[msg.sender][_staker] = _allowed;
         emit BeneficiaryAllowlistUpdated(msg.sender, _staker, _allowed);
 
         if (!_allowed) {
             StakedData storage stakedData = stakingData[_staker];
-            if (stakedData.beneficiary == msg.sender && _staker != msg.sender) {
+            if (stakedData.beneficiary == msg.sender) {
                 _decreasePeData(msg.sender, stakedData.stakedAmount);
                 emit BeneficiaryRemoved(_staker, msg.sender);
 

--- a/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
+++ b/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
@@ -683,6 +683,13 @@ contract PolicyEngineStaking_SetAllowedStaker_Test is PolicyEngineStaking_TestIn
         assertFalse(aliceAllowed);
         assertFalse(carolAllowed);
     }
+
+    /// @notice Tests that setAllowedStaker reverts when staker is msg.sender.
+    function test_setAllowedStaker_selfAllowlist_reverts() external {
+        vm.prank(bob);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_SelfAllowlist.selector);
+        staking.setAllowedStaker(bob, true);
+    }
 }
 
 /// @title PolicyEngineStaking_Integration_Test


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix PolicyEngineStaking allowlist logic to prevent self-allowlisting and correct beneficiary reset condition when disallowing stakers.

Main changes:
- Added PolicyEngineStaking_SelfAllowlist error and validation check to prevent users from allowlisting themselves
- Fixed setAllowedStaker beneficiary reset logic by removing redundant self-check condition
- Enhanced function documentation to clarify beneficiary reset behavior when disallowing stakers

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
