### PR TITLE
refactor: l2cm group impls

### DIFF
--- a/packages/contracts-bedrock/interfaces/L2/IL2ContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL2ContractsManager.sol
@@ -24,95 +24,15 @@ interface IL2ContractsManager is ISemver {
     /// @dev This function MUST be called via DELEGATECALL from the L2ProxyAdmin.
     function upgrade() external;
 
+    /// @notice Returns the implementation addresses for each predeploy upgraded by the L2ContractsManager.
+    /// @return implementations_ The implementation addresses for each predeploy upgraded by the L2ContractsManager.
+    function getImplementations()
+        external
+        view
+        returns (L2ContractsManagerTypes.Implementations memory implementations_);
+
     /// @notice Constructor for the L2ContractsManager contract.
     /// @param _implementations The implementation struct containing the new implementation addresses for the L2
     /// predeploys.
     function __constructor__(L2ContractsManagerTypes.Implementations memory _implementations) external;
-
-    /// @notice Returns the implementation address of the StorageSetter contract.
-    function storageSetterImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the GasPriceOracle contract.
-    function gasPriceOracleImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the L2CrossDomainMessenger contract.
-    function l2CrossDomainMessengerImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the L2StandardBridge contract.
-    function l2StandardBridgeImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the SequencerFeeWallet contract.
-    function sequencerFeeWalletImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the OptimismMintableERC20Factory contract.
-    function optimismMintableERC20FactoryImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the L2ERC721Bridge contract.
-    function l2ERC721BridgeImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the L1Block contract.
-    function l1BlockImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the L1Block contract for custom gas token networks.
-    function l1BlockCGTImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the L2ToL1MessagePasser contract.
-    function l2ToL1MessagePasserImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the L2ToL1MessagePasser contract for custom gas token networks.
-    function l2ToL1MessagePasserCGTImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the OptimismMintableERC721Factory contract.
-    function optimismMintableERC721FactoryImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the ProxyAdmin contract.
-    function proxyAdminImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the BaseFeeVault contract.
-    function baseFeeVaultImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the L1FeeVault contract.
-    function l1FeeVaultImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the OperatorFeeVault contract.
-    function operatorFeeVaultImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the SchemaRegistry contract.
-    function schemaRegistryImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the EAS contract.
-    function easImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the CrossL2Inbox contract.
-    function crossL2InboxImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the L2ToL2CrossDomainMessenger contract.
-    function l2ToL2CrossDomainMessengerImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the SuperchainETHBridge contract.
-    function superchainETHBridgeImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the ETHLiquidity contract.
-    function ethLiquidityImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the OptimismSuperchainERC20Factory contract.
-    function optimismSuperchainERC20FactoryImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the OptimismSuperchainERC20Beacon contract.
-    function optimismSuperchainERC20BeaconImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the SuperchainTokenBridge contract.
-    function superchainTokenBridgeImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the NativeAssetLiquidity contract.
-    function nativeAssetLiquidityImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the LiquidityController contract.
-    function liquidityControllerImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the FeeSplitter contract.
-    function feeSplitterImpl() external view returns (address);
-
-    /// @notice Returns the implementation address of the ConditionalDeployer contract.
-    function conditionalDeployerImpl() external view returns (address);
 }

--- a/packages/contracts-bedrock/snapshots/abi/L2ContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/L2ContractsManager.json
@@ -159,376 +159,159 @@
   },
   {
     "inputs": [],
-    "name": "baseFeeVaultImpl",
+    "name": "getImplementations",
     "outputs": [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "conditionalDeployerImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "crossL2InboxImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "easImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "ethLiquidityImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "feeSplitterImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "gasPriceOracleImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "l1BlockCGTImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "l1BlockImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "l1FeeVaultImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "l2CrossDomainMessengerImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "l2ERC721BridgeImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "l2StandardBridgeImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "l2ToL1MessagePasserCGTImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "l2ToL1MessagePasserImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "l2ToL2CrossDomainMessengerImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "liquidityControllerImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "nativeAssetLiquidityImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "operatorFeeVaultImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "optimismMintableERC20FactoryImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "optimismMintableERC721FactoryImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "optimismSuperchainERC20BeaconImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "optimismSuperchainERC20FactoryImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "proxyAdminImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "schemaRegistryImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "sequencerFeeWalletImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "storageSetterImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "superchainETHBridgeImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "superchainTokenBridgeImpl",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        "components": [
+          {
+            "internalType": "address",
+            "name": "storageSetterImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l2CrossDomainMessengerImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "gasPriceOracleImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l2StandardBridgeImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sequencerFeeWalletImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismMintableERC20FactoryImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l2ERC721BridgeImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1BlockImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1BlockCGTImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l2ToL1MessagePasserImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l2ToL1MessagePasserCGTImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismMintableERC721FactoryImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "proxyAdminImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "baseFeeVaultImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l1FeeVaultImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "operatorFeeVaultImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "schemaRegistryImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "easImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "crossL2InboxImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "l2ToL2CrossDomainMessengerImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "superchainETHBridgeImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "ethLiquidityImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismSuperchainERC20FactoryImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "optimismSuperchainERC20BeaconImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "superchainTokenBridgeImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "nativeAssetLiquidityImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "liquidityControllerImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "feeSplitterImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "conditionalDeployerImpl",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct L2ContractsManagerTypes.Implementations",
+        "name": "implementations_",
+        "type": "tuple"
       }
     ],
     "stateMutability": "view",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -96,8 +96,8 @@
     "sourceCodeHash": "0x7e438cbbe9a8248887b8c21f68c811f90a5cae4902cbbf7b0a1f6cd644dc42d9"
   },
   "src/L2/L2ContractsManager.sol:L2ContractsManager": {
-    "initCodeHash": "0xf93ed1ade549d0a29b09171b67911e39bf0347bbdd2f29aecda6acb2f7e17d74",
-    "sourceCodeHash": "0x5f69f14ab2a7a542892372bedfd775840f20a61dd9b78febc23237201c6a4942"
+    "initCodeHash": "0x58644c0f212039d802a93054d28b20b26694d92b8d7a7bcf1631d158bb95cfd2",
+    "sourceCodeHash": "0xa4fba8f6dd5f7e1cfcba63ca8b9d0fbe621d1fe33aeb6147a185045fcded7c14"
   },
   "src/L2/L2CrossDomainMessenger.sol:L2CrossDomainMessenger": {
     "initCodeHash": "0xe160be403df12709c371c33195d1b9c3b5e9499e902e86bdabc8eed749c3fd61",

--- a/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
+++ b/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
@@ -393,148 +393,41 @@ contract L2ContractsManager is ISemver {
         L2ContractsManagerUtils.upgradeTo(Predeploys.CONDITIONAL_DEPLOYER, CONDITIONAL_DEPLOYER_IMPL);
     }
 
-    /// @notice Returns the implementation address of the StorageSetter contract.
-    function storageSetterImpl() public view returns (address) {
-        return STORAGE_SETTER_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the GasPriceOracle contract.
-    function gasPriceOracleImpl() public view returns (address) {
-        return GAS_PRICE_ORACLE_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the L2CrossDomainMessenger contract.
-    function l2CrossDomainMessengerImpl() public view returns (address) {
-        return L2_CROSS_DOMAIN_MESSENGER_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the L2StandardBridge contract.
-    function l2StandardBridgeImpl() public view returns (address) {
-        return L2_STANDARD_BRIDGE_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the SequencerFeeWallet contract.
-    function sequencerFeeWalletImpl() public view returns (address) {
-        return SEQUENCER_FEE_WALLET_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the OptimismMintableERC20Factory contract.
-    function optimismMintableERC20FactoryImpl() public view returns (address) {
-        return OPTIMISM_MINTABLE_ERC20_FACTORY_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the L2ERC721Bridge contract.
-    function l2ERC721BridgeImpl() public view returns (address) {
-        return L2_ERC721_BRIDGE_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the L1Block contract.
-    function l1BlockImpl() public view returns (address) {
-        return L1_BLOCK_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the L1Block contract for custom gas token networks.
-    function l1BlockCGTImpl() public view returns (address) {
-        return L1_BLOCK_CGT_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the L2ToL1MessagePasser contract.
-    function l2ToL1MessagePasserImpl() public view returns (address) {
-        return L2_TO_L1_MESSAGE_PASSER_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the L2ToL1MessagePasser contract for custom gas token networks.
-    function l2ToL1MessagePasserCGTImpl() public view returns (address) {
-        return L2_TO_L1_MESSAGE_PASSER_CGT_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the OptimismMintableERC721Factory contract.
-    function optimismMintableERC721FactoryImpl() public view returns (address) {
-        return OPTIMISM_MINTABLE_ERC721_FACTORY_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the ProxyAdmin contract.
-    function proxyAdminImpl() public view returns (address) {
-        return PROXY_ADMIN_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the BaseFeeVault contract.
-    function baseFeeVaultImpl() public view returns (address) {
-        return BASE_FEE_VAULT_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the L1FeeVault contract.
-    function l1FeeVaultImpl() public view returns (address) {
-        return L1_FEE_VAULT_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the OperatorFeeVault contract.
-    function operatorFeeVaultImpl() public view returns (address) {
-        return OPERATOR_FEE_VAULT_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the SchemaRegistry contract.
-    function schemaRegistryImpl() public view returns (address) {
-        return SCHEMA_REGISTRY_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the EAS contract.
-    function easImpl() public view returns (address) {
-        return EAS_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the CrossL2Inbox contract.
-    function crossL2InboxImpl() public view returns (address) {
-        return CROSS_L2_INBOX_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the L2ToL2CrossDomainMessenger contract.
-    function l2ToL2CrossDomainMessengerImpl() public view returns (address) {
-        return L2_TO_L2_CROSS_DOMAIN_MESSENGER_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the SuperchainETHBridge contract.
-    function superchainETHBridgeImpl() public view returns (address) {
-        return SUPERCHAIN_ETH_BRIDGE_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the ETHLiquidity contract.
-    function ethLiquidityImpl() public view returns (address) {
-        return ETH_LIQUIDITY_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the OptimismSuperchainERC20Factory contract.
-    function optimismSuperchainERC20FactoryImpl() public view returns (address) {
-        return OPTIMISM_SUPERCHAIN_ERC20_FACTORY_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the OptimismSuperchainERC20Beacon contract.
-    function optimismSuperchainERC20BeaconImpl() public view returns (address) {
-        return OPTIMISM_SUPERCHAIN_ERC20_BEACON_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the SuperchainTokenBridge contract.
-    function superchainTokenBridgeImpl() public view returns (address) {
-        return SUPERCHAIN_TOKEN_BRIDGE_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the NativeAssetLiquidity contract.
-    function nativeAssetLiquidityImpl() public view returns (address) {
-        return NATIVE_ASSET_LIQUIDITY_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the LiquidityController contract.
-    function liquidityControllerImpl() public view returns (address) {
-        return LIQUIDITY_CONTROLLER_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the FeeSplitter contract.
-    function feeSplitterImpl() public view returns (address) {
-        return FEE_SPLITTER_IMPL;
-    }
-
-    /// @notice Returns the implementation address of the ConditionalDeployer contract.
-    function conditionalDeployerImpl() public view returns (address) {
-        return CONDITIONAL_DEPLOYER_IMPL;
+    /// @notice Returns the implementation addresses for each predeploy upgraded by the L2ContractsManager.
+    /// @return implementations_ The implementation addresses for each predeploy upgraded by the L2ContractsManager.
+    function getImplementations()
+        external
+        view
+        returns (L2ContractsManagerTypes.Implementations memory implementations_)
+    {
+        implementations_.storageSetterImpl = STORAGE_SETTER_IMPL;
+        implementations_.l2CrossDomainMessengerImpl = L2_CROSS_DOMAIN_MESSENGER_IMPL;
+        implementations_.gasPriceOracleImpl = GAS_PRICE_ORACLE_IMPL;
+        implementations_.l2StandardBridgeImpl = L2_STANDARD_BRIDGE_IMPL;
+        implementations_.sequencerFeeWalletImpl = SEQUENCER_FEE_WALLET_IMPL;
+        implementations_.optimismMintableERC20FactoryImpl = OPTIMISM_MINTABLE_ERC20_FACTORY_IMPL;
+        implementations_.l2ERC721BridgeImpl = L2_ERC721_BRIDGE_IMPL;
+        implementations_.l1BlockImpl = L1_BLOCK_IMPL;
+        implementations_.l1BlockCGTImpl = L1_BLOCK_CGT_IMPL;
+        implementations_.l2ToL1MessagePasserImpl = L2_TO_L1_MESSAGE_PASSER_IMPL;
+        implementations_.l2ToL1MessagePasserCGTImpl = L2_TO_L1_MESSAGE_PASSER_CGT_IMPL;
+        implementations_.optimismMintableERC721FactoryImpl = OPTIMISM_MINTABLE_ERC721_FACTORY_IMPL;
+        implementations_.proxyAdminImpl = PROXY_ADMIN_IMPL;
+        implementations_.baseFeeVaultImpl = BASE_FEE_VAULT_IMPL;
+        implementations_.l1FeeVaultImpl = L1_FEE_VAULT_IMPL;
+        implementations_.operatorFeeVaultImpl = OPERATOR_FEE_VAULT_IMPL;
+        implementations_.schemaRegistryImpl = SCHEMA_REGISTRY_IMPL;
+        implementations_.easImpl = EAS_IMPL;
+        implementations_.crossL2InboxImpl = CROSS_L2_INBOX_IMPL;
+        implementations_.l2ToL2CrossDomainMessengerImpl = L2_TO_L2_CROSS_DOMAIN_MESSENGER_IMPL;
+        implementations_.superchainETHBridgeImpl = SUPERCHAIN_ETH_BRIDGE_IMPL;
+        implementations_.ethLiquidityImpl = ETH_LIQUIDITY_IMPL;
+        implementations_.optimismSuperchainERC20FactoryImpl = OPTIMISM_SUPERCHAIN_ERC20_FACTORY_IMPL;
+        implementations_.optimismSuperchainERC20BeaconImpl = OPTIMISM_SUPERCHAIN_ERC20_BEACON_IMPL;
+        implementations_.superchainTokenBridgeImpl = SUPERCHAIN_TOKEN_BRIDGE_IMPL;
+        implementations_.nativeAssetLiquidityImpl = NATIVE_ASSET_LIQUIDITY_IMPL;
+        implementations_.liquidityControllerImpl = LIQUIDITY_CONTROLLER_IMPL;
+        implementations_.feeSplitterImpl = FEE_SPLITTER_IMPL;
+        implementations_.conditionalDeployerImpl = CONDITIONAL_DEPLOYER_IMPL;
     }
 }

--- a/packages/contracts-bedrock/test/L2/L2ContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ContractsManager.t.sol
@@ -687,6 +687,129 @@ contract L2ContractsManager_Upgrade_DowngradePrevention_Test is L2ContractsManag
     }
 }
 
+/// @title L2ContractsManager_GetImplementations_Test
+/// @notice Tests for the getImplementations() getter function.
+contract L2ContractsManager_GetImplementations_Test is L2ContractsManager_Upgrade_Test {
+    /// @notice Tests that getImplementations returns all implementation addresses matching the constructor input.
+    function test_getImplementations_returnsAllImplementations_succeeds() public view {
+        L2ContractsManagerTypes.Implementations memory result = l2cm.getImplementations();
+
+        assertEq(result.storageSetterImpl, implementations.storageSetterImpl, "storageSetterImpl mismatch");
+        assertEq(
+            result.l2CrossDomainMessengerImpl,
+            implementations.l2CrossDomainMessengerImpl,
+            "l2CrossDomainMessengerImpl mismatch"
+        );
+        assertEq(result.gasPriceOracleImpl, implementations.gasPriceOracleImpl, "gasPriceOracleImpl mismatch");
+        assertEq(result.l2StandardBridgeImpl, implementations.l2StandardBridgeImpl, "l2StandardBridgeImpl mismatch");
+        assertEq(
+            result.sequencerFeeWalletImpl, implementations.sequencerFeeWalletImpl, "sequencerFeeWalletImpl mismatch"
+        );
+        assertEq(
+            result.optimismMintableERC20FactoryImpl,
+            implementations.optimismMintableERC20FactoryImpl,
+            "optimismMintableERC20FactoryImpl mismatch"
+        );
+        assertEq(result.l2ERC721BridgeImpl, implementations.l2ERC721BridgeImpl, "l2ERC721BridgeImpl mismatch");
+        assertEq(result.l1BlockImpl, implementations.l1BlockImpl, "l1BlockImpl mismatch");
+        assertEq(result.l1BlockCGTImpl, implementations.l1BlockCGTImpl, "l1BlockCGTImpl mismatch");
+        assertEq(
+            result.l2ToL1MessagePasserImpl, implementations.l2ToL1MessagePasserImpl, "l2ToL1MessagePasserImpl mismatch"
+        );
+        assertEq(
+            result.l2ToL1MessagePasserCGTImpl,
+            implementations.l2ToL1MessagePasserCGTImpl,
+            "l2ToL1MessagePasserCGTImpl mismatch"
+        );
+        assertEq(
+            result.optimismMintableERC721FactoryImpl,
+            implementations.optimismMintableERC721FactoryImpl,
+            "optimismMintableERC721FactoryImpl mismatch"
+        );
+        assertEq(result.proxyAdminImpl, implementations.proxyAdminImpl, "proxyAdminImpl mismatch");
+        assertEq(result.baseFeeVaultImpl, implementations.baseFeeVaultImpl, "baseFeeVaultImpl mismatch");
+        assertEq(result.l1FeeVaultImpl, implementations.l1FeeVaultImpl, "l1FeeVaultImpl mismatch");
+        assertEq(result.operatorFeeVaultImpl, implementations.operatorFeeVaultImpl, "operatorFeeVaultImpl mismatch");
+        assertEq(result.schemaRegistryImpl, implementations.schemaRegistryImpl, "schemaRegistryImpl mismatch");
+        assertEq(result.easImpl, implementations.easImpl, "easImpl mismatch");
+        assertEq(result.crossL2InboxImpl, implementations.crossL2InboxImpl, "crossL2InboxImpl mismatch");
+        assertEq(
+            result.l2ToL2CrossDomainMessengerImpl,
+            implementations.l2ToL2CrossDomainMessengerImpl,
+            "l2ToL2CrossDomainMessengerImpl mismatch"
+        );
+        assertEq(
+            result.superchainETHBridgeImpl, implementations.superchainETHBridgeImpl, "superchainETHBridgeImpl mismatch"
+        );
+        assertEq(result.ethLiquidityImpl, implementations.ethLiquidityImpl, "ethLiquidityImpl mismatch");
+        assertEq(
+            result.optimismSuperchainERC20FactoryImpl,
+            implementations.optimismSuperchainERC20FactoryImpl,
+            "optimismSuperchainERC20FactoryImpl mismatch"
+        );
+        assertEq(
+            result.optimismSuperchainERC20BeaconImpl,
+            implementations.optimismSuperchainERC20BeaconImpl,
+            "optimismSuperchainERC20BeaconImpl mismatch"
+        );
+        assertEq(
+            result.superchainTokenBridgeImpl,
+            implementations.superchainTokenBridgeImpl,
+            "superchainTokenBridgeImpl mismatch"
+        );
+        assertEq(
+            result.nativeAssetLiquidityImpl,
+            implementations.nativeAssetLiquidityImpl,
+            "nativeAssetLiquidityImpl mismatch"
+        );
+        assertEq(
+            result.liquidityControllerImpl, implementations.liquidityControllerImpl, "liquidityControllerImpl mismatch"
+        );
+        assertEq(result.feeSplitterImpl, implementations.feeSplitterImpl, "feeSplitterImpl mismatch");
+        assertEq(
+            result.conditionalDeployerImpl, implementations.conditionalDeployerImpl, "conditionalDeployerImpl mismatch"
+        );
+    }
+
+    /// @notice Tests that no field in getImplementations() is left uninitialized
+    ///         when all implementations are provided to the constructor.
+    function test_getImplementations_noFieldIsZero_succeeds() public view {
+        L2ContractsManagerTypes.Implementations memory result = l2cm.getImplementations();
+
+        assertTrue(result.storageSetterImpl != address(0), "storageSetterImpl is zero");
+        assertTrue(result.l2CrossDomainMessengerImpl != address(0), "l2CrossDomainMessengerImpl is zero");
+        assertTrue(result.gasPriceOracleImpl != address(0), "gasPriceOracleImpl is zero");
+        assertTrue(result.l2StandardBridgeImpl != address(0), "l2StandardBridgeImpl is zero");
+        assertTrue(result.sequencerFeeWalletImpl != address(0), "sequencerFeeWalletImpl is zero");
+        assertTrue(result.optimismMintableERC20FactoryImpl != address(0), "optimismMintableERC20FactoryImpl is zero");
+        assertTrue(result.l2ERC721BridgeImpl != address(0), "l2ERC721BridgeImpl is zero");
+        assertTrue(result.l1BlockImpl != address(0), "l1BlockImpl is zero");
+        assertTrue(result.l1BlockCGTImpl != address(0), "l1BlockCGTImpl is zero");
+        assertTrue(result.l2ToL1MessagePasserImpl != address(0), "l2ToL1MessagePasserImpl is zero");
+        assertTrue(result.l2ToL1MessagePasserCGTImpl != address(0), "l2ToL1MessagePasserCGTImpl is zero");
+        assertTrue(result.optimismMintableERC721FactoryImpl != address(0), "optimismMintableERC721FactoryImpl is zero");
+        assertTrue(result.proxyAdminImpl != address(0), "proxyAdminImpl is zero");
+        assertTrue(result.baseFeeVaultImpl != address(0), "baseFeeVaultImpl is zero");
+        assertTrue(result.l1FeeVaultImpl != address(0), "l1FeeVaultImpl is zero");
+        assertTrue(result.operatorFeeVaultImpl != address(0), "operatorFeeVaultImpl is zero");
+        assertTrue(result.schemaRegistryImpl != address(0), "schemaRegistryImpl is zero");
+        assertTrue(result.easImpl != address(0), "easImpl is zero");
+        assertTrue(result.crossL2InboxImpl != address(0), "crossL2InboxImpl is zero");
+        assertTrue(result.l2ToL2CrossDomainMessengerImpl != address(0), "l2ToL2CrossDomainMessengerImpl is zero");
+        assertTrue(result.superchainETHBridgeImpl != address(0), "superchainETHBridgeImpl is zero");
+        assertTrue(result.ethLiquidityImpl != address(0), "ethLiquidityImpl is zero");
+        assertTrue(
+            result.optimismSuperchainERC20FactoryImpl != address(0), "optimismSuperchainERC20FactoryImpl is zero"
+        );
+        assertTrue(result.optimismSuperchainERC20BeaconImpl != address(0), "optimismSuperchainERC20BeaconImpl is zero");
+        assertTrue(result.superchainTokenBridgeImpl != address(0), "superchainTokenBridgeImpl is zero");
+        assertTrue(result.nativeAssetLiquidityImpl != address(0), "nativeAssetLiquidityImpl is zero");
+        assertTrue(result.liquidityControllerImpl != address(0), "liquidityControllerImpl is zero");
+        assertTrue(result.feeSplitterImpl != address(0), "feeSplitterImpl is zero");
+        assertTrue(result.conditionalDeployerImpl != address(0), "conditionalDeployerImpl is zero");
+    }
+}
+
 /// @title L2ContractsManager_Upgrade_Coverage_Test
 /// @notice Test that verifies all predeploys receive upgrade calls during L2CM upgrade.
 ///         Uses Predeploys.sol as the source of truth for which predeploys should be upgraded.


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor L2ContractsManager interface to replace 29 individual implementation getter functions with a single struct-based getter method for improved API efficiency and maintainability.

Main changes:
- Replaced 29 separate getter functions with single getImplementations() method returning Implementations struct in L2ContractsManager interface
- Updated L2ContractsManager implementation to populate all 29 implementation addresses in struct format via new getter
- Added comprehensive test coverage for getImplementations() validating all struct fields match constructor inputs

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
