### PR TITLE
fix: staking audit fixes

### DIFF
--- a/packages/contracts-bedrock/interfaces/periphery/staking/IPolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/interfaces/periphery/staking/IPolicyEngineStaking.sol
@@ -34,6 +34,9 @@ interface IPolicyEngineStaking is ISemver {
     /// @notice Emitted when ownership is transferred.
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
+    /// @notice Emitted when a new owner is nominated via `transferOwnership`.
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+
     /// @notice Thrown when the caller is not the owner.
     error PolicyEngineStaking_OnlyOwner();
 
@@ -61,6 +64,9 @@ interface IPolicyEngineStaking is ISemver {
     /// @notice Thrown when trying to change beneficiary to the current beneficiary.
     error PolicyEngineStaking_SameBeneficiary();
 
+    /// @notice Thrown when the caller is not the pending owner.
+    error PolicyEngineStaking_NotPendingOwner();
+
     /// @notice Thrown when trying to allowlist/disallow yourself.
     error PolicyEngineStaking_SelfAllowlist();
 
@@ -69,9 +75,17 @@ interface IPolicyEngineStaking is ISemver {
     /// @notice Returns the contract owner.
     function owner() external view returns (address);
 
-    /// @notice Transfers ownership of the contract to a new account. Only callable by owner.
-    /// @param _newOwner The address of the new owner.
+    /// @notice Returns the pending owner nominated via `transferOwnership`.
+    function pendingOwner() external view returns (address);
+
+    /// @notice Nominates a new owner. The nominated address must call `acceptOwnership`
+    ///         to finalize the transfer (two-step pattern). Only callable by owner.
+    ///
+    /// @param _newOwner The address of the nominated owner.
     function transferOwnership(address _newOwner) external;
+
+    /// @notice Accepts ownership after being nominated via `transferOwnership`.
+    function acceptOwnership() external;
 
     /// @notice Returns whether the contract is paused.
     function paused() external view returns (bool);

--- a/packages/contracts-bedrock/interfaces/periphery/staking/IPolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/interfaces/periphery/staking/IPolicyEngineStaking.sol
@@ -78,8 +78,10 @@ interface IPolicyEngineStaking is ISemver {
     /// @notice Returns the pending owner nominated via `transferOwnership`.
     function pendingOwner() external view returns (address);
 
-    /// @notice Nominates a new owner. The nominated address must call `acceptOwnership`
-    ///         to finalize the transfer (two-step pattern). Only callable by owner.
+    /// @notice Starts the ownership transfer of the contract to a new account. Replaces the
+    ///         pending transfer if there is one. The nominated address must call
+    ///         `acceptOwnership` to finalize the transfer (two-step pattern). Only callable
+    ///         by owner. Setting `_newOwner` to the zero address cancels a pending transfer.
     ///
     /// @param _newOwner The address of the nominated owner.
     function transferOwnership(address _newOwner) external;

--- a/packages/contracts-bedrock/interfaces/periphery/staking/IPolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/interfaces/periphery/staking/IPolicyEngineStaking.sol
@@ -85,6 +85,7 @@ interface IPolicyEngineStaking is ISemver {
     function transferOwnership(address _newOwner) external;
 
     /// @notice Accepts ownership after being nominated via `transferOwnership`.
+    ///         Only callable by the pending owner.
     function acceptOwnership() external;
 
     /// @notice Returns whether the contract is paused.
@@ -128,6 +129,7 @@ interface IPolicyEngineStaking is ISemver {
     /// @notice Sets whether a staker can set the caller as beneficiary. When disallowing,
     ///         if the staker's current beneficiary is the caller, their stake attribution is
     ///         moved back to the staker (beneficiary reset to self).
+    ///         This function is callable even when the contract is paused.
     ///
     /// @param _staker  The staker address.
     /// @param _allowed Whether the staker is allowed to set the caller as beneficiary.

--- a/packages/contracts-bedrock/snapshots/abi/PolicyEngineStaking.json
+++ b/packages/contracts-bedrock/snapshots/abi/PolicyEngineStaking.json
@@ -29,6 +29,13 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -117,6 +124,19 @@
         "internalType": "uint128",
         "name": "lastUpdate",
         "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -357,6 +377,25 @@
         "type": "address"
       }
     ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
     "name": "OwnershipTransferred",
     "type": "event"
   },
@@ -423,6 +462,11 @@
   {
     "inputs": [],
     "name": "PolicyEngineStaking_NotAllowedToSetBeneficiary",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PolicyEngineStaking_NotPendingOwner",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -240,8 +240,8 @@
     "sourceCodeHash": "0x955bd0c9b47e43219865e4e92abf28d916c96de20cbdf2f94c8ab14d02083759"
   },
   "src/periphery/staking/PolicyEngineStaking.sol:PolicyEngineStaking": {
-    "initCodeHash": "0xc0c04b0dddbf7831bf5abfccc6a569d92f9b7ab0ec53278f6d1cf7113041d59d",
-    "sourceCodeHash": "0x998ddc9f24e3c85b1d588c263838261442edaad1dde5424fd55c2d4e1243592a"
+    "initCodeHash": "0x18d7a16057b473fd15ed5aa030dac3b5daadb599ec0bfd54f6473e378787ee18",
+    "sourceCodeHash": "0x1c6abf39b31c9b036512e263bcb6f52ba3ee4d1555d36ad9a3386dab5a596979"
   },
   "src/safe/DeputyPauseModule.sol:DeputyPauseModule": {
     "initCodeHash": "0x18422b48c4901ed6fd9338d76d3c5aecfff9a7add34b05c6e21c23d0011ed6bf",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -240,8 +240,8 @@
     "sourceCodeHash": "0x955bd0c9b47e43219865e4e92abf28d916c96de20cbdf2f94c8ab14d02083759"
   },
   "src/periphery/staking/PolicyEngineStaking.sol:PolicyEngineStaking": {
-    "initCodeHash": "0xfbec8d7bbf0a40951a96ae5d0a72c1fd54f7b830328f0d0fac91a28704c75865",
-    "sourceCodeHash": "0x1fa6aa33980a79cc109368a14232394e7313fd6373cd71d7876adc0f13c149ca"
+    "initCodeHash": "0x3894e0f03945fd854319ded12593f24e2a90eb819301191c52a1d991f1d0cf27",
+    "sourceCodeHash": "0xf0d11999dc93d2120d6d901f011eea40337d9867278a6afc9fe17587963b58d4"
   },
   "src/safe/DeputyPauseModule.sol:DeputyPauseModule": {
     "initCodeHash": "0x18422b48c4901ed6fd9338d76d3c5aecfff9a7add34b05c6e21c23d0011ed6bf",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -240,8 +240,8 @@
     "sourceCodeHash": "0x955bd0c9b47e43219865e4e92abf28d916c96de20cbdf2f94c8ab14d02083759"
   },
   "src/periphery/staking/PolicyEngineStaking.sol:PolicyEngineStaking": {
-    "initCodeHash": "0x18d7a16057b473fd15ed5aa030dac3b5daadb599ec0bfd54f6473e378787ee18",
-    "sourceCodeHash": "0x1c6abf39b31c9b036512e263bcb6f52ba3ee4d1555d36ad9a3386dab5a596979"
+    "initCodeHash": "0xfbec8d7bbf0a40951a96ae5d0a72c1fd54f7b830328f0d0fac91a28704c75865",
+    "sourceCodeHash": "0x1fa6aa33980a79cc109368a14232394e7313fd6373cd71d7876adc0f13c149ca"
   },
   "src/safe/DeputyPauseModule.sol:DeputyPauseModule": {
     "initCodeHash": "0x18422b48c4901ed6fd9338d76d3c5aecfff9a7add34b05c6e21c23d0011ed6bf",

--- a/packages/contracts-bedrock/snapshots/storageLayout/PolicyEngineStaking.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/PolicyEngineStaking.json
@@ -29,14 +29,14 @@
   },
   {
     "bytes": "20",
-    "label": "_owner",
+    "label": "owner",
     "offset": 1,
     "slot": "3",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "_pendingOwner",
+    "label": "pendingOwner",
     "offset": 0,
     "slot": "4",
     "type": "address"

--- a/packages/contracts-bedrock/snapshots/storageLayout/PolicyEngineStaking.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/PolicyEngineStaking.json
@@ -33,5 +33,12 @@
     "offset": 1,
     "slot": "3",
     "type": "address"
+  },
+  {
+    "bytes": "20",
+    "label": "_pendingOwner",
+    "offset": 0,
+    "slot": "4",
+    "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -170,12 +170,14 @@ contract PolicyEngineStaking is ISemver {
         return STAKING_TOKEN;
     }
 
-    /// @notice Nominates a new owner. The nominated address must call `acceptOwnership`
-    ///         to finalize the transfer (two-step pattern).
+    /// @notice Starts the ownership transfer of the contract to a new account. Replaces the
+    ///         pending transfer if there is one. The nominated address must call
+    ///         `acceptOwnership` to finalize the transfer (two-step pattern).
+    ///         Setting `_newOwner` to the zero address is allowed; this can be used to cancel
+    ///         an initiated ownership transfer.
     ///
     /// @param _newOwner The address of the nominated owner.
     function transferOwnership(address _newOwner) external onlyOwner {
-        if (_newOwner == address(0)) revert PolicyEngineStaking_ZeroAddress();
         pendingOwner = _newOwner;
         emit OwnershipTransferStarted(owner, _newOwner);
     }

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -301,16 +301,15 @@ contract PolicyEngineStaking is ISemver {
     /// @notice Sets whether a staker can set the caller as beneficiary. When disallowing,
     ///         if the staker's current beneficiary is the caller, their stake attribution is
     ///         moved back to the staker (beneficiary reset to self).
-    ///         This function is intentionally NOT gated by `whenNotPaused`. Allowlist
+    /// @dev    This function is intentionally NOT gated by `whenNotPaused`. Allowlist
     ///         mutations remain available during pause so that beneficiaries can revoke
     ///         stakers at any time. Note that disallowing a staker who is currently
     ///         delegated to the caller will move effective stake attribution back to the
     ///         staker, changing ordering-power state even while the contract is paused.
-    ///         Trust assumption: stakers who delegate to a beneficiary implicitly trust
+    /// @dev    Trust assumption: stakers who delegate to a beneficiary implicitly trust
     ///         that the beneficiary will not remove them from the allowlist at a
     ///         disadvantageous time. Removal triggers `_increasePeData` on the staker,
     ///         which resets their `lastUpdate` and thus their accumulated staking weight.
-    ///
     /// @param _staker The staker to allow or deny.
     /// @param _allowed The allowed state.
     function setAllowedStaker(address _staker, bool _allowed) public {

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -323,13 +323,18 @@ contract PolicyEngineStaking is ISemver {
         emit EffectiveStakeChanged(_account, pe.effectiveStake);
     }
 
-    /// @notice Decreases effective stake for an account and updates timestamp.
+    /// @notice Decreases effective stake for an account. Only resets `lastUpdate` when
+    ///         the effective stake reaches zero to avoid stale timestamps; otherwise the
+    ///         existing timestamp is preserved so remaining stake keeps its staking weight.
+    ///
     /// @param _account The account address.
     /// @param _amount  The amount to subtract.
     function _decreasePeData(address _account, uint128 _amount) internal {
         PEData storage pe = peData[_account];
         pe.effectiveStake -= _amount;
-        pe.lastUpdate = uint128(block.timestamp);
+        if (pe.effectiveStake == 0) {
+            pe.lastUpdate = uint128(block.timestamp);
+        }
         emit EffectiveStakeChanged(_account, pe.effectiveStake);
     }
 }

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -193,9 +193,9 @@ contract PolicyEngineStaking is ISemver {
     /// @notice Accepts ownership after being nominated via `transferOwnership`.
     function acceptOwnership() external {
         if (msg.sender != _pendingOwner) revert PolicyEngineStaking_NotPendingOwner();
-        emit OwnershipTransferred(_owner, msg.sender);
         _owner = msg.sender;
         _pendingOwner = address(0);
+        emit OwnershipTransferred(_owner, msg.sender);
     }
 
     /// @notice Pauses the contract. Stake is disabled while paused.

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -275,6 +275,11 @@ contract PolicyEngineStaking is ISemver {
     /// @notice Sets whether a staker can set the caller as beneficiary. When disallowing,
     ///         if the staker's current beneficiary is the caller, their stake attribution is
     ///         moved back to the staker (beneficiary reset to self).
+    ///         This function is intentionally NOT gated by `whenNotPaused`. Allowlist
+    ///         mutations remain available during pause so that beneficiaries can revoke
+    ///         stakers at any time. Note that disallowing a staker who is currently
+    ///         delegated to the caller will move effective stake attribution back to the
+    ///         staker, changing ordering-power state even while the contract is paused.
     ///
     /// @param _staker The staker to allow or deny.
     /// @param _allowed The allowed state.

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -56,10 +56,10 @@ contract PolicyEngineStaking is ISemver {
     bool public paused;
 
     /// @notice The owner of the contract. Can pause, unpause, and transfer ownership.
-    address private _owner;
+    address public owner;
 
     /// @notice The pending owner nominated via `transferOwnership`.
-    address private _pendingOwner;
+    address public pendingOwner;
 
     /// @notice Emitted when a user stakes OP tokens.
     /// @param account The address that staked tokens.
@@ -147,7 +147,7 @@ contract PolicyEngineStaking is ISemver {
     constructor(address _ownerAddr, address _token) {
         if (_ownerAddr == address(0)) revert PolicyEngineStaking_ZeroAddress();
         if (_token == address(0)) revert PolicyEngineStaking_ZeroAddress();
-        _owner = _ownerAddr;
+        owner = _ownerAddr;
         STAKING_TOKEN = IERC20(_token);
     }
 
@@ -159,18 +159,8 @@ contract PolicyEngineStaking is ISemver {
 
     /// @notice Modifier that reverts when the caller is not the owner.
     modifier onlyOwner() {
-        if (msg.sender != _owner) revert PolicyEngineStaking_OnlyOwner();
+        if (msg.sender != owner) revert PolicyEngineStaking_OnlyOwner();
         _;
-    }
-
-    /// @notice Returns the owner address.
-    function owner() external view returns (address) {
-        return _owner;
-    }
-
-    /// @notice Returns the pending owner address.
-    function pendingOwner() external view returns (address) {
-        return _pendingOwner;
     }
 
     /// @notice Returns the staking token address.
@@ -186,18 +176,18 @@ contract PolicyEngineStaking is ISemver {
     /// @param _newOwner The address of the nominated owner.
     function transferOwnership(address _newOwner) external onlyOwner {
         if (_newOwner == address(0)) revert PolicyEngineStaking_ZeroAddress();
-        _pendingOwner = _newOwner;
-        emit OwnershipTransferStarted(_owner, _newOwner);
+        pendingOwner = _newOwner;
+        emit OwnershipTransferStarted(owner, _newOwner);
     }
 
     /// @notice Accepts ownership after being nominated via `transferOwnership`.
     function acceptOwnership() external {
-        if (msg.sender != _pendingOwner) revert PolicyEngineStaking_NotPendingOwner();
-        _pendingOwner = address(0);
+        if (msg.sender != pendingOwner) revert PolicyEngineStaking_NotPendingOwner();
+        pendingOwner = address(0);
 
         // Emit event before owner change
-        emit OwnershipTransferred(_owner, msg.sender);
-        _owner = msg.sender;
+        emit OwnershipTransferred(owner, msg.sender);
+        owner = msg.sender;
     }
 
     /// @notice Pauses the contract. Stake is disabled while paused.

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -32,8 +32,8 @@ contract PolicyEngineStaking is ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.1.0
+    string public constant version = "1.1.0";
 
     /// @notice Base storage slot for PE stakingData mapping. Policy Engine reads from
     ///         keccak256(abi.encode(account, PE_DATA_SLOT)).
@@ -57,6 +57,9 @@ contract PolicyEngineStaking is ISemver {
 
     /// @notice The owner of the contract. Can pause, unpause, and transfer ownership.
     address private _owner;
+
+    /// @notice The pending owner nominated via `transferOwnership`.
+    address private _pendingOwner;
 
     /// @notice Emitted when a user stakes OP tokens.
     /// @param account The address that staked tokens.
@@ -100,6 +103,11 @@ contract PolicyEngineStaking is ISemver {
     /// @param newOwner      The address of the new owner.
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
+    /// @notice Emitted when a new owner is nominated via `transferOwnership`.
+    /// @param previousOwner The current owner who initiated the transfer.
+    /// @param newOwner      The nominated pending owner.
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+
     /// @notice Thrown when the caller is not the owner.
     error PolicyEngineStaking_OnlyOwner();
 
@@ -126,6 +134,9 @@ contract PolicyEngineStaking is ISemver {
 
     /// @notice Thrown when trying to change beneficiary to the current beneficiary.
     error PolicyEngineStaking_SameBeneficiary();
+
+    /// @notice Thrown when the caller is not the pending owner.
+    error PolicyEngineStaking_NotPendingOwner();
 
     /// @notice Thrown when trying to allowlist/disallow yourself.
     error PolicyEngineStaking_SelfAllowlist();
@@ -157,6 +168,11 @@ contract PolicyEngineStaking is ISemver {
         return _owner;
     }
 
+    /// @notice Returns the pending owner address.
+    function pendingOwner() external view returns (address) {
+        return _pendingOwner;
+    }
+
     /// @notice Returns the staking token address.
     ///
     /// @return The ERC20 token used for staking.
@@ -164,12 +180,22 @@ contract PolicyEngineStaking is ISemver {
         return STAKING_TOKEN;
     }
 
-    /// @notice Transfers ownership of the contract to a new account.
-    /// @param _newOwner The address of the new owner.
+    /// @notice Nominates a new owner. The nominated address must call `acceptOwnership`
+    ///         to finalize the transfer (two-step pattern).
+    ///
+    /// @param _newOwner The address of the nominated owner.
     function transferOwnership(address _newOwner) external onlyOwner {
         if (_newOwner == address(0)) revert PolicyEngineStaking_ZeroAddress();
-        emit OwnershipTransferred(_owner, _newOwner);
-        _owner = _newOwner;
+        _pendingOwner = _newOwner;
+        emit OwnershipTransferStarted(_owner, _newOwner);
+    }
+
+    /// @notice Accepts ownership after being nominated via `transferOwnership`.
+    function acceptOwnership() external {
+        if (msg.sender != _pendingOwner) revert PolicyEngineStaking_NotPendingOwner();
+        emit OwnershipTransferred(_owner, msg.sender);
+        _owner = msg.sender;
+        _pendingOwner = address(0);
     }
 
     /// @notice Pauses the contract. Stake is disabled while paused.

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -193,9 +193,11 @@ contract PolicyEngineStaking is ISemver {
     /// @notice Accepts ownership after being nominated via `transferOwnership`.
     function acceptOwnership() external {
         if (msg.sender != _pendingOwner) revert PolicyEngineStaking_NotPendingOwner();
-        _owner = msg.sender;
         _pendingOwner = address(0);
+
+        // Emit event before owner change
         emit OwnershipTransferred(_owner, msg.sender);
+        _owner = msg.sender;
     }
 
     /// @notice Pauses the contract. Stake is disabled while paused.

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -32,8 +32,8 @@ contract PolicyEngineStaking is ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.0
-    string public constant version = "1.1.0";
+    /// @custom:semver 1.0.0
+    string public constant version = "1.0.0";
 
     /// @notice Base storage slot for PE stakingData mapping. Policy Engine reads from
     ///         keccak256(abi.encode(account, PE_DATA_SLOT)).

--- a/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/src/periphery/staking/PolicyEngineStaking.sol
@@ -306,6 +306,10 @@ contract PolicyEngineStaking is ISemver {
     ///         stakers at any time. Note that disallowing a staker who is currently
     ///         delegated to the caller will move effective stake attribution back to the
     ///         staker, changing ordering-power state even while the contract is paused.
+    ///         Trust assumption: stakers who delegate to a beneficiary implicitly trust
+    ///         that the beneficiary will not remove them from the allowlist at a
+    ///         disadvantageous time. Removal triggers `_increasePeData` on the staker,
+    ///         which resets their `lastUpdate` and thus their accumulated staking weight.
     ///
     /// @param _staker The staker to allow or deny.
     /// @param _allowed The allowed state.

--- a/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
+++ b/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
@@ -135,11 +135,17 @@ contract PolicyEngineStaking_TransferOwnership_Test is PolicyEngineStaking_TestI
         staking.transferOwnership(alice);
     }
 
-    /// @notice Tests that transferring to zero address reverts.
-    function test_transferOwnership_zeroAddress_reverts() external {
+    /// @notice Tests that transferring to zero address cancels pending transfer.
+    function test_transferOwnership_zeroAddressCancels_succeeds() external {
+        address newOwner = makeAddr("newOwner");
+
         vm.prank(owner);
-        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_ZeroAddress.selector);
+        staking.transferOwnership(newOwner);
+        assertEq(staking.pendingOwner(), newOwner);
+
+        vm.prank(owner);
         staking.transferOwnership(address(0));
+        assertEq(staking.pendingOwner(), address(0));
     }
 
     /// @notice Tests that non-pending-owner cannot accept ownership.

--- a/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
+++ b/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
@@ -1009,3 +1009,47 @@ contract PolicyEngineStaking_Integration_Test is PolicyEngineStaking_TestInit {
         return a;
     }
 }
+
+/// @title PolicyEngineStaking_DecreasePeData_Test
+/// @notice Tests `_decreasePeData` behavior via unstake (partial vs full).
+contract PolicyEngineStaking_DecreasePeData_Test is PolicyEngineStaking_TestInit {
+    /// @notice Tests that partial unstake preserves lastUpdate (does not reset it).
+    function test_decreasePeData_partialUnstake_preservesLastUpdate_succeeds() external {
+        uint128 stakeAmount = uint128(100 ether);
+        uint128 unstakeAmount = uint128(40 ether);
+
+        vm.prank(alice);
+        staking.stake(stakeAmount, alice);
+        (, uint128 lastUpdateAfterStake) = staking.peData(alice);
+
+        // Warp time forward
+        vm.warp(block.timestamp + 1000);
+
+        // Partial unstake — lastUpdate should NOT change
+        vm.prank(alice);
+        staking.unstake(unstakeAmount);
+
+        (uint128 effectiveStake, uint128 lastUpdateAfterUnstake) = staking.peData(alice);
+        assertEq(effectiveStake, stakeAmount - unstakeAmount);
+        assertEq(lastUpdateAfterUnstake, lastUpdateAfterStake, "lastUpdate should be preserved on partial unstake");
+    }
+
+    /// @notice Tests that full unstake resets lastUpdate to block.timestamp.
+    function test_decreasePeData_fullUnstake_resetsLastUpdate_succeeds() external {
+        uint128 stakeAmount = uint128(100 ether);
+
+        vm.prank(alice);
+        staking.stake(stakeAmount, alice);
+
+        // Warp time forward
+        uint256 newTimestamp = block.timestamp + 1000;
+        vm.warp(newTimestamp);
+
+        // Full unstake — lastUpdate should reset to block.timestamp
+        vm.prank(alice);
+        staking.unstake(stakeAmount);
+
+        (, uint128 lastUpdateAfterUnstake) = staking.peData(alice);
+        assertEq(lastUpdateAfterUnstake, newTimestamp, "lastUpdate should reset on full unstake");
+    }
+}

--- a/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
+++ b/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
@@ -1059,11 +1059,11 @@ contract PolicyEngineStaking_Integration_Test is PolicyEngineStaking_TestInit {
     }
 }
 
-/// @title PolicyEngineStaking_DecreasePeData_Test
-/// @notice Tests `_decreasePeData` behavior via unstake (partial vs full).
-contract PolicyEngineStaking_DecreasePeData_Test is PolicyEngineStaking_TestInit {
+/// @title PolicyEngineStaking_Unstake_LastUpdate_Test
+/// @notice Tests lastUpdate behavior on partial vs full unstake.
+contract PolicyEngineStaking_Unstake_LastUpdate_Test is PolicyEngineStaking_TestInit {
     /// @notice Tests that partial unstake preserves lastUpdate (does not reset it).
-    function test_decreasePeData_partialUnstake_preservesLastUpdate_succeeds() external {
+    function test_unstake_partialPreservesLastUpdate_succeeds() external {
         uint128 stakeAmount = uint128(100 ether);
         uint128 unstakeAmount = uint128(40 ether);
 
@@ -1084,7 +1084,7 @@ contract PolicyEngineStaking_DecreasePeData_Test is PolicyEngineStaking_TestInit
     }
 
     /// @notice Tests that full unstake resets lastUpdate to block.timestamp.
-    function test_decreasePeData_fullUnstake_resetsLastUpdate_succeeds() external {
+    function test_unstake_fullResetsLastUpdate_succeeds() external {
         uint128 stakeAmount = uint128(100 ether);
 
         vm.prank(alice);

--- a/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
+++ b/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
@@ -28,6 +28,7 @@ abstract contract PolicyEngineStaking_TestInit is CommonTest {
     event BeneficiaryAllowlistUpdated(address indexed beneficiary, address indexed staker, bool allowed);
     event Paused();
     event Unpaused();
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
 
     function setUp() public virtual override {
         super.setUp();
@@ -61,22 +62,41 @@ abstract contract PolicyEngineStaking_TestInit is CommonTest {
 }
 
 /// @title PolicyEngineStaking_TransferOwnership_Test
-/// @notice Tests the `transferOwnership` function.
+/// @notice Tests the two-step `transferOwnership` / `acceptOwnership` pattern.
 contract PolicyEngineStaking_TransferOwnership_Test is PolicyEngineStaking_TestInit {
-    /// @notice Tests that owner can transfer ownership.
+    /// @notice Tests that transferOwnership nominates a pending owner without changing owner.
     function testFuzz_transferOwnership_succeeds(address _newOwner) external {
         vm.assume(_newOwner != address(0));
 
         vm.expectEmit(address(staking));
-        emit OwnershipTransferred(owner, _newOwner);
+        emit OwnershipTransferStarted(owner, _newOwner);
 
         vm.prank(owner);
         staking.transferOwnership(_newOwner);
 
-        assertEq(staking.owner(), _newOwner);
+        // Owner should NOT change yet
+        assertEq(staking.owner(), owner);
+        assertEq(staking.pendingOwner(), _newOwner);
     }
 
-    /// @notice Tests that new owner can exercise ownership after transfer.
+    /// @notice Tests that pendingOwner can accept ownership.
+    function test_acceptOwnership_succeeds() external {
+        address newOwner = makeAddr("newOwner");
+
+        vm.prank(owner);
+        staking.transferOwnership(newOwner);
+
+        vm.expectEmit(address(staking));
+        emit OwnershipTransferred(owner, newOwner);
+
+        vm.prank(newOwner);
+        staking.acceptOwnership();
+
+        assertEq(staking.owner(), newOwner);
+        assertEq(staking.pendingOwner(), address(0));
+    }
+
+    /// @notice Tests that new owner can exercise ownership after accepting.
     function test_transferOwnership_newOwnerCanPause_succeeds() external {
         address newOwner = makeAddr("newOwner");
 
@@ -84,23 +104,29 @@ contract PolicyEngineStaking_TransferOwnership_Test is PolicyEngineStaking_TestI
         staking.transferOwnership(newOwner);
 
         vm.prank(newOwner);
+        staking.acceptOwnership();
+
+        vm.prank(newOwner);
         staking.pause();
         assertTrue(staking.paused());
     }
 
-    /// @notice Tests that old owner loses ownership after transfer.
+    /// @notice Tests that old owner loses ownership after transfer is accepted.
     function test_transferOwnership_oldOwnerReverts_reverts() external {
         address newOwner = makeAddr("newOwner");
 
         vm.prank(owner);
         staking.transferOwnership(newOwner);
 
+        vm.prank(newOwner);
+        staking.acceptOwnership();
+
         vm.prank(owner);
         vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_OnlyOwner.selector);
         staking.pause();
     }
 
-    /// @notice Tests that non-owner cannot transfer ownership.
+    /// @notice Tests that non-owner cannot call transferOwnership.
     function testFuzz_transferOwnership_notOwner_reverts(address _caller) external {
         vm.assume(_caller != owner && _caller != address(0));
 
@@ -114,6 +140,29 @@ contract PolicyEngineStaking_TransferOwnership_Test is PolicyEngineStaking_TestI
         vm.prank(owner);
         vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_ZeroAddress.selector);
         staking.transferOwnership(address(0));
+    }
+
+    /// @notice Tests that non-pending-owner cannot accept ownership.
+    function test_acceptOwnership_notPendingOwner_reverts() external {
+        address newOwner = makeAddr("newOwner");
+
+        vm.prank(owner);
+        staking.transferOwnership(newOwner);
+
+        vm.prank(alice);
+        vm.expectRevert(IPolicyEngineStaking.PolicyEngineStaking_NotPendingOwner.selector);
+        staking.acceptOwnership();
+    }
+
+    /// @notice Tests that pendingOwner view returns the correct value.
+    function test_pendingOwner_succeeds() external {
+        assertEq(staking.pendingOwner(), address(0));
+
+        address newOwner = makeAddr("newOwner");
+        vm.prank(owner);
+        staking.transferOwnership(newOwner);
+
+        assertEq(staking.pendingOwner(), newOwner);
     }
 }
 


### PR DESCRIPTION
Fixes some findings from the Cantina's audit

1. Finding 1 - `setAllowedStaker` callable during pause (documented as intentional)                                                                                                                                          
2. Finding 7 - `lastUpdate` unnecessarily reset on partial unstake (now only resets on full `unstake`)                                                                                                                         
3. Finding 8 - One-step `transferOwnership` risks permanent loss (now two-step with `acceptOwnership`)                                                                                                                         
4. Finding 10 - Beneficiary can reset staker's `lastUpdate` via allowlist removal (documented trust assumption)