### PR TITLE
ZKGame Quality Review Fixes

### DIFF
--- a/packages/contracts-bedrock/src/dispute/lib/LibGameArgs.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/LibGameArgs.sol
@@ -8,6 +8,7 @@ import { InvalidGameArgsLength } from "src/dispute/lib/Errors.sol";
 library LibGameArgs {
     uint256 public constant PERMISSIONLESS_ARGS_LENGTH = 124;
     uint256 public constant PERMISSIONED_ARGS_LENGTH = 164;
+    uint256 public constant ZK_ARGS_LENGTH = 172;
 
     /// @notice Struct representing the game arguments.
     struct GameArgs {
@@ -93,8 +94,6 @@ library LibGameArgs {
     function isValidPermissionedArgs(bytes memory _args) internal pure returns (bool) {
         return _args.length == PERMISSIONED_ARGS_LENGTH;
     }
-
-    uint256 public constant ZK_ARGS_LENGTH = 172;
 
     /// @notice Checks if the provided game arguments are valid for a ZK dispute game.
     function isValidZKArgs(bytes memory _args) internal pure returns (bool) {

--- a/packages/contracts-bedrock/src/dispute/zk/ZKDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/zk/ZKDisputeGame.sol
@@ -461,6 +461,9 @@ contract ZKDisputeGame is Clone, ISemver, IDisputeGame {
         if (status != GameStatus.IN_PROGRESS) revert ClaimAlreadyResolved();
 
         // INVARIANT: Cannot resolve a game if the parent game has not been resolved.
+        // Note: Parent blacklisting or retirement is NOT propagated automatically to descendants.
+        // resolve() only checks the parent's GameStatus. If a parent is blacklisted after a child is created,
+        // the child must be manually blacklisted by the guardian to enter REFUND mode.
         GameStatus parentGameStatus = getParentGameStatus();
         if (parentGameStatus == GameStatus.IN_PROGRESS) revert ParentGameNotResolved();
 

--- a/packages/contracts-bedrock/src/dispute/zk/ZKDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/zk/ZKDisputeGame.sol
@@ -304,21 +304,21 @@ contract ZKDisputeGame is Clone, ISemver, IDisputeGame {
         // The first game is initialized with a parent index of uint32.max
         if (parentIndex() != type(uint32).max) {
             // For subsequent games, get the parent game's information
-            (,, IDisputeGame proxy) = disputeGameFactory.gameAtIndex(parentIndex());
+            (,, IDisputeGame parent) = disputeGameFactory.gameAtIndex(parentIndex());
 
             // Verify parent game is not blacklisted or retired.
-            if (anchorStateRegistry().isGameBlacklisted(proxy) || anchorStateRegistry().isGameRetired(proxy)) {
+            if (anchorStateRegistry().isGameBlacklisted(parent) || anchorStateRegistry().isGameRetired(parent)) {
                 revert InvalidParentGame();
             }
 
             // INVARIANT: The parent game must be of the same game type.
-            if (IDisputeGame(payable(address(proxy))).gameType().raw() != gameType().raw()) {
+            if (IDisputeGame(payable(address(parent))).gameType().raw() != gameType().raw()) {
                 revert UnexpectedGameType();
             }
 
             startingProposal = Proposal({
-                l2SequenceNumber: IDisputeGame(payable(address(proxy))).l2SequenceNumber(),
-                root: Hash.wrap(IDisputeGame(payable(address(proxy))).rootClaim().raw())
+                l2SequenceNumber: IDisputeGame(payable(address(parent))).l2SequenceNumber(),
+                root: Hash.wrap(IDisputeGame(payable(address(parent))).rootClaim().raw())
             });
 
             // INVARIANT: The parent game's sequence number must be strictly above the anchor state.
@@ -326,7 +326,7 @@ contract ZKDisputeGame is Clone, ISemver, IDisputeGame {
             if (startingProposal.l2SequenceNumber <= anchorL2SeqNum) revert InvalidParentGame();
 
             // INVARIANT: The parent game must be a valid game.
-            if (proxy.status() == GameStatus.CHALLENGER_WINS) revert InvalidParentGame();
+            if (parent.status() == GameStatus.CHALLENGER_WINS) revert InvalidParentGame();
         } else {
             // When there is no parent game, the starting output root is the anchor state for the game type.
             (startingProposal.root, startingProposal.l2SequenceNumber) = anchorStateRegistry().getAnchorRoot();

--- a/packages/contracts-bedrock/src/dispute/zk/ZKDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/zk/ZKDisputeGame.sol
@@ -467,7 +467,9 @@ contract ZKDisputeGame is Clone, ISemver, IDisputeGame {
         // INVARIANT: If the parent game's claim is invalid, then the current game's claim is invalid.
         if (parentGameStatus == GameStatus.CHALLENGER_WINS) {
             // Parent game is invalid so this game is invalid too. Therefore the challenger wins and gets all bonds.
-            // If the game has not been challenged then there will not be any challenger address and the bond is burned.
+            // Note: If unchallenged, the bond is credited to address(0) and burned. Proposers who build
+            // on a parent later invalidated by governance lose their bond with no on-chain remedy and should wait
+            // for sufficient finality confidence in the parent before extending it.
             status = GameStatus.CHALLENGER_WINS;
             normalModeCredit[claimData.challenger] = totalBonds;
         } else {

--- a/packages/contracts-bedrock/src/dispute/zk/ZKDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/zk/ZKDisputeGame.sol
@@ -436,6 +436,10 @@ contract ZKDisputeGame is Clone, ISemver, IDisputeGame {
     }
 
     /// @notice Returns the status of the parent game.
+    /// @dev A parentIndex of uint32.max is the sentinel value representing the absence of a parent game
+    ///      Treating the anchor as DEFENDER_WINS is safe because the anchor
+    ///      state is only ever updated from a previously resolved DEFENDER_WINS game, so its root
+    ///      is already trusted. Any other parentIndex fetches the actual parent from the factory.
     function getParentGameStatus() private view returns (GameStatus) {
         if (parentIndex() != type(uint32).max) {
             (,, IDisputeGame parentGame) = disputeGameFactory.gameAtIndex(parentIndex());

--- a/packages/contracts-bedrock/src/dispute/zk/ZKDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/zk/ZKDisputeGame.sol
@@ -597,8 +597,10 @@ contract ZKDisputeGame is Clone, ISemver, IDisputeGame {
             revert GameNotResolved();
         }
 
+        IDisputeGame self = IDisputeGame(address(this));
+
         // Game must be finalized according to the AnchorStateRegistry.
-        bool finalized = anchorStateRegistry().isGameFinalized(IDisputeGame(address(this)));
+        bool finalized = anchorStateRegistry().isGameFinalized(self);
         if (!finalized) {
             revert GameNotFinalized();
         }
@@ -606,10 +608,10 @@ contract ZKDisputeGame is Clone, ISemver, IDisputeGame {
         // Try to update the anchor game first. Won't always succeed because delays can lead
         // to situations in which this game might not be eligible to be a new anchor game.
         // nosemgrep: sol-safety-trycatch-eip150
-        try anchorStateRegistry().setAnchorState(IDisputeGame(address(this))) { } catch { }
+        try anchorStateRegistry().setAnchorState(self) { } catch { }
 
         // Check if the game is a proper game, which will determine the bond distribution mode.
-        bool properGame = anchorStateRegistry().isGameProper(IDisputeGame(address(this)));
+        bool properGame = anchorStateRegistry().isGameProper(self);
 
         // If the game is a proper game, the bonds should be distributed normally. Otherwise, go
         // into refund mode and distribute bonds back to their original depositors.

--- a/packages/contracts-bedrock/src/dispute/zk/ZKDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/zk/ZKDisputeGame.sol
@@ -453,7 +453,7 @@ contract ZKDisputeGame is Clone, ISemver, IDisputeGame {
     ///         `CHALLENGER_WINS` when the proposer's claim has been challenged, but the proposer has not proven
     ///         its claim within the `MAX_PROVE_DURATION`.
     function resolve() external returns (GameStatus) {
-        // INVARIANT: Resolution cannot occur unless the game has already been resolved.
+        // INVARIANT: Resolution cannot occur if the game has already been resolved.
         if (status != GameStatus.IN_PROGRESS) revert ClaimAlreadyResolved();
 
         // INVARIANT: Cannot resolve a game if the parent game has not been resolved.


### PR DESCRIPTION
  ## Summary                                                                                                                                                                               
                                                                                                                                                                                        
  - Address code quality review findings in `ZKDisputeGame.sol`:                                                                                                                          
    - Fix inverted comment in `resolve()` invariant check
    - Cache `IDisputeGame(address(this))` into a local self variable in `closeGame()` to avoid repeating the cast
    - Add `@dev` NatSpec to `getParentGameStatus()` explaining why `uint32.max` maps to `DEFENDER_WINS`                                                                                         
    - Rename proxy to parent in `initialize()` to reduce cognitive load during validation review
    - Document as a known invariant that an unchallenged child game built on an invalidated parent loses its bond with no on-chain remedy                                               
    - Document that parent blacklisting is not automatically propagated to descendants as manual guardian intervention is required