### PR TITLE
l2cm upgrade accaptance test

### DIFF
--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test_helper.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test_helper.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-func withdrawalOpts(gameType gameTypes.GameType) []presets.Option {
+func withdrawalOpts(gameType gameTypes.GameType, extra ...presets.Option) []presets.Option {
 	opts := []presets.Option{
 		presets.WithTimeTravelEnabled(),
 		presets.WithDeployerOptions(
@@ -27,16 +27,16 @@ func withdrawalOpts(gameType gameTypes.GameType) []presets.Option {
 			cfg.DisputeGameType = uint32(gameType)
 		}),
 	}
-	return opts
+	return append(opts, extra...)
 }
 
-func newSystem(t devtest.T, gameType gameTypes.GameType) *presets.Minimal {
-	return presets.NewMinimal(t, withdrawalOpts(gameType)...)
+func newSystem(t devtest.T, gameType gameTypes.GameType, extra ...presets.Option) *presets.Minimal {
+	return presets.NewMinimal(t, withdrawalOpts(gameType, extra...)...)
 }
 
-func TestWithdrawal(gt *testing.T, gameType gameTypes.GameType) {
+func TestWithdrawal(gt *testing.T, gameType gameTypes.GameType, extra ...presets.Option) {
 	t := devtest.ParallelT(gt)
-	sys := newSystem(t, gameType)
+	sys := newSystem(t, gameType, extra...)
 
 	bridge := sys.StandardBridge()
 	bridge.VerifyRespectedGameType(gameType)

--- a/op-acceptance-tests/tests/karst/upgrade_test.go
+++ b/op-acceptance-tests/tests/karst/upgrade_test.go
@@ -1,0 +1,197 @@
+package karst
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	ps "github.com/ethereum-optimism/optimism/op-proposer/proposer"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+var conditionalDeployerAddr = common.HexToAddress("0x420000000000000000000000000000000000002C")
+
+func loadSchemaRegistryInitcode(t devtest.T) []byte {
+	wd, err := os.Getwd()
+	t.Require().NoError(err)
+	root, err := opservice.FindMonorepoRoot(wd)
+	t.Require().NoError(err)
+
+	artifactPath := filepath.Join(root, "packages", "contracts-bedrock", "forge-artifacts", "SchemaRegistry.sol", "SchemaRegistry.json")
+	data, err := os.ReadFile(artifactPath)
+	t.Require().NoError(err, "failed to read SchemaRegistry artifact")
+
+	var artifact struct {
+		Bytecode struct {
+			Object string `json:"object"`
+		} `json:"bytecode"`
+	}
+	t.Require().NoError(json.Unmarshal(data, &artifact))
+	t.Require().NotEmpty(artifact.Bytecode.Object)
+	return common.FromHex(artifact.Bytecode.Object)
+}
+
+// callVersionString calls version() on a contract and returns the decoded string.
+func callVersionString(t devtest.T, client apis.EthClient, addr common.Address) string {
+	selector := crypto.Keccak256([]byte("version()"))[:4]
+	raw, err := client.Call(t.Ctx(), ethereum.CallMsg{To: &addr, Data: selector}, rpc.LatestBlockNumber)
+	t.Require().NoError(err, "version() call failed on %s", addr)
+	stringType, _ := abi.NewType("string", "", nil)
+	decoded, err := abi.Arguments{{Type: stringType}}.Unpack(raw)
+	t.Require().NoError(err)
+	return decoded[0].(string)
+}
+
+// patchVersionInInitcode patches the version string inside initcode.
+//
+// Solidity stores a string constant via two instructions:
+//   - PUSH1 <len>  — the string length, a few bytes before PUSH32
+//   - PUSH32 <str left-aligned in 32 bytes>  — the string data
+//
+// We locate both by searching for the PUSH32 pattern (0x7f + currentVersion
+// left-aligned in 32 zero-padded bytes) and scanning backwards for the
+// length PUSH1. This makes the patch independent of the current version value.
+func patchVersionInInitcode(t devtest.T, initcode []byte, currentVersion, newVersion string) []byte {
+	t.Require().LessOrEqual(len([]byte(newVersion)), 32, "new version must fit in a PUSH32 (max 32 bytes)")
+
+	currentVersionBytes := []byte(currentVersion)
+	newVersionBytes := []byte(newVersion)
+
+	// Build the expected 32-byte PUSH32 argument for the current version.
+	currentPush32Arg := make([]byte, 32)
+	copy(currentPush32Arg, currentVersionBytes)
+
+	push32Pattern := append([]byte{0x7f}, currentPush32Arg...)
+	idx := bytes.Index(initcode, push32Pattern)
+	t.Require().GreaterOrEqual(idx, 0, "PUSH32 version pattern not found in initcode (current version: %q)", currentVersion)
+
+	result := make([]byte, len(initcode))
+	copy(result, initcode)
+
+	// Overwrite the 32-byte PUSH32 argument with the new version (left-aligned, zero-padded).
+	newPush32Arg := make([]byte, 32)
+	copy(newPush32Arg, newVersionBytes)
+	copy(result[idx+1:idx+33], newPush32Arg)
+
+	// Scan backwards from the PUSH32 to find the PUSH1 <len(currentVersionBytes)> instruction.
+	searchStart := idx - 30
+	if searchStart < 0 {
+		searchStart = 0
+	}
+	found := false
+	for i := idx - 1; i >= searchStart; i-- {
+		if result[i] == 0x60 && int(result[i+1]) == len(currentVersionBytes) {
+			result[i+1] = byte(len(newVersionBytes))
+			found = true
+			break
+		}
+	}
+	t.Require().True(found, "PUSH1 length byte not found near version PUSH32 (current version: %q)", currentVersion)
+
+	return result
+}
+
+// TestL2CMUpgrade_Karst deploys a patched SchemaRegistry implementation via
+// ConditionalDeployer, upgrades the proxy via L2ProxyAdmin, and verifies the
+// change is observable both on L2 (version string, ERC-1967 slot) and on L1
+// (dispute game covering the post-upgrade block).
+func TestL2CMUpgrade_Karst(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewMinimal(t,
+		presets.WithDeployerOptions(sysgo.WithKarstAtGenesis),
+		presets.WithGameTypeAdded(gameTypes.CannonGameType),
+		presets.WithRespectedGameTypeOverride(gameTypes.CannonGameType),
+		presets.WithProposerOption(func(_ sysgo.ComponentTarget, cfg *ps.CLIConfig) {
+			cfg.DisputeGameType = uint32(gameTypes.CannonGameType)
+		}),
+	)
+
+	devKeys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	t.Require().NoError(err)
+	paOwnerKey := devkeys.L2ProxyAdminOwnerRole.Key(sys.L2Chain.ChainID().ToBig())
+	privKey, err := devKeys.Secret(paOwnerKey)
+	t.Require().NoError(err)
+	l2PAO := dsl.NewEOA(dsl.NewKey(t, privKey), sys.L2EL)
+	sys.FunderL2.Fund(l2PAO, eth.OneEther)
+
+	currentVersion := callVersionString(t, sys.L2EL.EthClient(), predeploys.SchemaRegistryAddr)
+	t.Logger().Info("Current SchemaRegistry version", "version", currentVersion)
+
+	const newVersion = "999.999.999"
+	initcode := loadSchemaRegistryInitcode(t)
+	initcode = patchVersionInInitcode(t, initcode, currentVersion, newVersion)
+
+	var salt [32]byte
+	copy(salt[:], []byte("karst-upgrade-test-v1"))
+
+	deterministicProxy := predeploys.DeterministicDeploymentProxyAddr
+	newImplAddr := crypto.CreateAddress2(deterministicProxy, salt, crypto.Keccak256(initcode))
+
+	cdABI, err := abi.JSON(bytes.NewReader([]byte(
+		`[{"inputs":[{"name":"_salt","type":"bytes32"},{"name":"_code","type":"bytes"}],"name":"deploy","outputs":[{"name":"implementation_","type":"address"}],"stateMutability":"nonpayable","type":"function"}]`,
+	)))
+	t.Require().NoError(err)
+	deployCalldata, err := cdABI.Pack("deploy", salt, initcode)
+	t.Require().NoError(err)
+
+	cdAddr := conditionalDeployerAddr
+	l2PAO.Transact(l2PAO.Plan(), txplan.WithTo(&cdAddr), txplan.WithData(deployCalldata))
+	t.Logger().Info("Deployed patched SchemaRegistry implementation", "impl", newImplAddr)
+
+	paABI, err := abi.JSON(bytes.NewReader([]byte(
+		`[{"inputs":[{"name":"_proxy","type":"address"},{"name":"_implementation","type":"address"}],"name":"upgrade","outputs":[],"stateMutability":"nonpayable","type":"function"}]`,
+	)))
+	t.Require().NoError(err)
+	upgradeCalldata, err := paABI.Pack("upgrade", predeploys.SchemaRegistryAddr, newImplAddr)
+	t.Require().NoError(err)
+
+	proxyAdminAddr := predeploys.ProxyAdminAddr
+	upgradeTx := l2PAO.Transact(l2PAO.Plan(), txplan.WithTo(&proxyAdminAddr), txplan.WithData(upgradeCalldata))
+	upgradeReceipt, err := upgradeTx.Included.Eval(t.Ctx())
+	t.Require().NoError(err)
+	upgradeBlockNumber := upgradeReceipt.BlockNumber.Uint64()
+	t.Logger().Info("Upgraded SchemaRegistry proxy", "block", upgradeBlockNumber, "newImpl", newImplAddr)
+
+	// Verify ERC-1967 slot and version() on L2.
+	implSlot, err := sys.L2EL.EthClient().GetStorageAt(
+		t.Ctx(), predeploys.SchemaRegistryAddr, genesis.ImplementationSlot, "latest",
+	)
+	t.Require().NoError(err)
+	t.Require().Equal(newImplAddr, common.BytesToAddress(implSlot[:]))
+	t.Require().Equal(newVersion, callVersionString(t, sys.L2EL.EthClient(), predeploys.SchemaRegistryAddr))
+	t.Logger().Info("Verified version() on L2", "version", newVersion)
+
+	// Wait for a dispute game on L1 that covers the post-upgrade block.
+	dgf := sys.DisputeGameFactory()
+	initialGameCount := dgf.GameCount()
+	t.Require().Eventually(func() bool {
+		count := dgf.GameCount()
+		for i := initialGameCount; i < count; i++ {
+			if dgf.GameAtIndex(i).L2SequenceNumber() >= upgradeBlockNumber {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Minute, 5*time.Second, fmt.Sprintf("L1 must have a dispute game covering upgrade block %d", upgradeBlockNumber))
+	t.Logger().Info("Verified L1 dispute game covers upgrade block", "block", upgradeBlockNumber)
+}

--- a/op-acceptance-tests/tests/karst/upgrade_test.go
+++ b/op-acceptance-tests/tests/karst/upgrade_test.go
@@ -4,52 +4,31 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
-	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	ps "github.com/ethereum-optimism/optimism/op-proposer/proposer"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
 )
-
-var conditionalDeployerAddr = common.HexToAddress("0x420000000000000000000000000000000000002C")
-
-func loadSchemaRegistryInitcode(t devtest.T) []byte {
-	wd, err := os.Getwd()
-	t.Require().NoError(err)
-	root, err := opservice.FindMonorepoRoot(wd)
-	t.Require().NoError(err)
-
-	artifactPath := filepath.Join(root, "packages", "contracts-bedrock", "forge-artifacts", "SchemaRegistry.sol", "SchemaRegistry.json")
-	data, err := os.ReadFile(artifactPath)
-	t.Require().NoError(err, "failed to read SchemaRegistry artifact")
-
-	var artifact struct {
-		Bytecode struct {
-			Object string `json:"object"`
-		} `json:"bytecode"`
-	}
-	t.Require().NoError(json.Unmarshal(data, &artifact))
-	t.Require().NotEmpty(artifact.Bytecode.Object)
-	return common.FromHex(artifact.Bytecode.Object)
-}
 
 // callVersionString calls version() on a contract and returns the decoded string.
 func callVersionString(t devtest.T, client apis.EthClient, addr common.Address) string {
@@ -60,6 +39,20 @@ func callVersionString(t devtest.T, client apis.EthClient, addr common.Address) 
 	decoded, err := abi.Arguments{{Type: stringType}}.Unpack(raw)
 	t.Require().NoError(err)
 	return decoded[0].(string)
+}
+
+// loadInitcodeFromArtifact loads deployment bytecode from a forge artifact JSON file.
+func loadInitcodeFromArtifact(t devtest.T, artifactPath string) []byte {
+	data, err := os.ReadFile(artifactPath)
+	t.Require().NoError(err, "failed to read artifact: %s", artifactPath)
+	var artifact struct {
+		Bytecode struct {
+			Object string `json:"object"`
+		} `json:"bytecode"`
+	}
+	t.Require().NoError(json.Unmarshal(data, &artifact))
+	t.Require().NotEmpty(artifact.Bytecode.Object)
+	return common.FromHex(artifact.Bytecode.Object)
 }
 
 // patchVersionInInitcode patches the version string inside initcode.
@@ -77,7 +70,6 @@ func patchVersionInInitcode(t devtest.T, initcode []byte, currentVersion, newVer
 	currentVersionBytes := []byte(currentVersion)
 	newVersionBytes := []byte(newVersion)
 
-	// Build the expected 32-byte PUSH32 argument for the current version.
 	currentPush32Arg := make([]byte, 32)
 	copy(currentPush32Arg, currentVersionBytes)
 
@@ -88,12 +80,10 @@ func patchVersionInInitcode(t devtest.T, initcode []byte, currentVersion, newVer
 	result := make([]byte, len(initcode))
 	copy(result, initcode)
 
-	// Overwrite the 32-byte PUSH32 argument with the new version (left-aligned, zero-padded).
 	newPush32Arg := make([]byte, 32)
 	copy(newPush32Arg, newVersionBytes)
 	copy(result[idx+1:idx+33], newPush32Arg)
 
-	// Scan backwards from the PUSH32 to find the PUSH1 <len(currentVersionBytes)> instruction.
 	searchStart := idx - 30
 	if searchStart < 0 {
 		searchStart = 0
@@ -111,12 +101,106 @@ func patchVersionInInitcode(t devtest.T, initcode []byte, currentVersion, newVer
 	return result
 }
 
-// TestL2CMUpgrade_Karst deploys a patched SchemaRegistry implementation via
-// ConditionalDeployer, upgrades the proxy via L2ProxyAdmin, and verifies the
-// change is observable both on L2 (version string, ERC-1967 slot) and on L1
-// (dispute game covering the post-upgrade block).
+// buildNUTDepositTx creates a serialized deposit transaction suitable for use as a custom NUT.
+func buildNUTDepositTx(t devtest.T, intent string, from common.Address, to *common.Address, data []byte, gasLimit uint64) hexutil.Bytes {
+	source := derive.UpgradeDepositSource{Intent: intent}
+	depTx := &types.DepositTx{
+		SourceHash:          source.SourceHash(),
+		From:                from,
+		To:                  to,
+		Mint:                big.NewInt(0),
+		Value:               big.NewInt(0),
+		Gas:                 gasLimit,
+		IsSystemTransaction: false,
+		Data:                data,
+	}
+	encoded, err := types.NewTx(depTx).MarshalBinary()
+	t.Require().NoError(err, "failed to marshal NUT deposit tx")
+	return encoded
+}
+
+// buildCustomNUTs constructs the three deposit transactions for the post-Karst upgrade:
+//  1. ConditionalDeployer.deploy(salt, patchedSchemaRegistryInitcode)
+//  2. ConditionalDeployer.deploy(salt2, minimalTestL2CMInitcode)
+//  3. L2ProxyAdmin.upgradePredeploys(testL2CMAddr)
+func buildCustomNUTs(
+	t devtest.T,
+	implSalt [32]byte, patchedInitcode []byte,
+	l2CMSalt [32]byte, l2CMInitcode []byte,
+	testL2CMAddr common.Address,
+) ([]hexutil.Bytes, uint64) {
+	depositor := common.HexToAddress("0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001")
+	cdAddr := predeploys.ConditionalDeployerAddr
+	paAddr := predeploys.ProxyAdminAddr
+
+	cdABI, err := abi.JSON(bytes.NewReader([]byte(
+		`[{"inputs":[{"name":"_salt","type":"bytes32"},{"name":"_code","type":"bytes"}],"name":"deploy","outputs":[{"name":"implementation_","type":"address"}],"stateMutability":"nonpayable","type":"function"}]`,
+	)))
+	t.Require().NoError(err)
+
+	paABI, err := abi.JSON(bytes.NewReader([]byte(
+		`[{"inputs":[{"name":"_l2ContractsManager","type":"address"}],"name":"upgradePredeploys","outputs":[],"stateMutability":"nonpayable","type":"function"}]`,
+	)))
+	t.Require().NoError(err)
+
+	deployImplData, err := cdABI.Pack("deploy", implSalt, patchedInitcode)
+	t.Require().NoError(err)
+
+	deployL2CMData, err := cdABI.Pack("deploy", l2CMSalt, l2CMInitcode)
+	t.Require().NoError(err)
+
+	upgradeData, err := paABI.Pack("upgradePredeploys", testL2CMAddr)
+	t.Require().NoError(err)
+
+	const implGas = uint64(3_000_000)
+	const l2CMGas = uint64(500_000)
+	const upgradeGas = uint64(300_000)
+
+	tx1 := buildNUTDepositTx(t, "Custom NUT 0: Deploy Patched SchemaRegistry", depositor, &cdAddr, deployImplData, implGas)
+	tx2 := buildNUTDepositTx(t, "Custom NUT 1: Deploy MinimalTestL2CM", depositor, &cdAddr, deployL2CMData, l2CMGas)
+	tx3 := buildNUTDepositTx(t, "Custom NUT 2: Upgrade Predeploys", depositor, &paAddr, upgradeData, upgradeGas)
+
+	return []hexutil.Bytes{tx1, tx2, tx3}, implGas + l2CMGas + upgradeGas
+}
+
+// TestL2CMUpgrade_Karst simulates a post-Karst upgrade on an already-Karst chain. It deploys a
+// patched SchemaRegistry implementation via ConditionalDeployer, deploys a MinimalTestL2CM, and
+// triggers L2ProxyAdmin.upgradePredeploys() via DEPOSITOR — exactly the production NUT flow —
+// then verifies the upgrade is observable on L2 and covered by an L1 dispute game.
 func TestL2CMUpgrade_Karst(gt *testing.T) {
 	t := devtest.ParallelT(gt)
+
+	wd, err := os.Getwd()
+	t.Require().NoError(err)
+	root, err := opservice.FindMonorepoRoot(wd)
+	t.Require().NoError(err)
+
+	// Load forge artifacts.
+	schemaRegistryInitcode := loadInitcodeFromArtifact(t,
+		filepath.Join(root, "packages", "contracts-bedrock", "forge-artifacts", "SchemaRegistry.sol", "SchemaRegistry.json"))
+	minimalTestL2CMInitcode := loadInitcodeFromArtifact(t,
+		filepath.Join(root, "packages", "contracts-bedrock", "forge-artifacts", "MinimalTestL2CM.sol", "MinimalTestL2CM.json"))
+
+	// Pre-compute the patched SchemaRegistry implementation address.
+	// The current version is patched to a recognisably high value so the upgrade is easily verified.
+	// (patchVersionInInitcode will fail loudly if the version string is not found in the bytecode.)
+	const newVersion = "999.999.999"
+
+	var implSalt [32]byte
+	copy(implSalt[:], []byte("karst-upgrade-test-impl-v1"))
+	deterministicProxy := predeploys.DeterministicDeploymentProxyAddr
+
+	var l2CMSalt [32]byte
+	copy(l2CMSalt[:], []byte("karst-upgrade-test-l2cm-v1"))
+
+	// Pre-compute L2CM address: it depends on the patched impl address (baked as an immutable),
+	// but we need the impl address first. We will fill in the initcode after reading version().
+	// Both addresses are deterministic from salts + initcodes, so they can be computed offline
+	// once the version is known. We defer that to after system startup (see below).
+
+	// Schedule the custom NUT activation 30 seconds after genesis.
+	activation, nutOpt := sysgo.WithCustomNUTAtOffset(30)
+
 	sys := presets.NewMinimal(t,
 		presets.WithDeployerOptions(sysgo.WithKarstAtGenesis),
 		presets.WithGameTypeAdded(gameTypes.CannonGameType),
@@ -124,64 +208,50 @@ func TestL2CMUpgrade_Karst(gt *testing.T) {
 		presets.WithProposerOption(func(_ sysgo.ComponentTarget, cfg *ps.CLIConfig) {
 			cfg.DisputeGameType = uint32(gameTypes.CannonGameType)
 		}),
+		presets.WithGlobalL2CLOption(nutOpt),
 	)
 
-	devKeys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
-	t.Require().NoError(err)
-	paOwnerKey := devkeys.L2ProxyAdminOwnerRole.Key(sys.L2Chain.ChainID().ToBig())
-	privKey, err := devKeys.Secret(paOwnerKey)
-	t.Require().NoError(err)
-	l2PAO := dsl.NewEOA(dsl.NewKey(t, privKey), sys.L2EL)
-	sys.FunderL2.Fund(l2PAO, eth.OneEther)
-
+	// Read the current SchemaRegistry version from the running chain and build NUT transactions.
 	currentVersion := callVersionString(t, sys.L2EL.EthClient(), predeploys.SchemaRegistryAddr)
 	t.Logger().Info("Current SchemaRegistry version", "version", currentVersion)
 
-	const newVersion = "999.999.999"
-	initcode := loadSchemaRegistryInitcode(t)
-	initcode = patchVersionInInitcode(t, initcode, currentVersion, newVersion)
+	patchedInitcode := patchVersionInInitcode(t, schemaRegistryInitcode, currentVersion, newVersion)
+	newImplAddr := crypto.CreateAddress2(deterministicProxy, implSalt, crypto.Keccak256(patchedInitcode))
+	t.Logger().Info("Pre-computed patched SchemaRegistry implementation", "addr", newImplAddr)
 
-	var salt [32]byte
-	copy(salt[:], []byte("karst-upgrade-test-v1"))
-
-	deterministicProxy := predeploys.DeterministicDeploymentProxyAddr
-	newImplAddr := crypto.CreateAddress2(deterministicProxy, salt, crypto.Keccak256(initcode))
-
-	cdABI, err := abi.JSON(bytes.NewReader([]byte(
-		`[{"inputs":[{"name":"_salt","type":"bytes32"},{"name":"_code","type":"bytes"}],"name":"deploy","outputs":[{"name":"implementation_","type":"address"}],"stateMutability":"nonpayable","type":"function"}]`,
-	)))
+	// Build MinimalTestL2CM initcode with constructor args (proxy, newImpl).
+	addressType, _ := abi.NewType("address", "", nil)
+	ctorArgs, err := abi.Arguments{{Type: addressType}, {Type: addressType}}.Pack(predeploys.SchemaRegistryAddr, newImplAddr)
 	t.Require().NoError(err)
-	deployCalldata, err := cdABI.Pack("deploy", salt, initcode)
-	t.Require().NoError(err)
+	l2CMInitcodeWithArgs := append(minimalTestL2CMInitcode, ctorArgs...)
+	testL2CMAddr := crypto.CreateAddress2(deterministicProxy, l2CMSalt, crypto.Keccak256(l2CMInitcodeWithArgs))
+	t.Logger().Info("Pre-computed MinimalTestL2CM", "addr", testL2CMAddr)
 
-	cdAddr := conditionalDeployerAddr
-	l2PAO.Transact(l2PAO.Plan(), txplan.WithTo(&cdAddr), txplan.WithData(deployCalldata))
-	t.Logger().Info("Deployed patched SchemaRegistry implementation", "impl", newImplAddr)
+	// Register the NUT transactions before the activation block is sequenced.
+	nutTxs, totalGas := buildCustomNUTs(t, implSalt, patchedInitcode, l2CMSalt, l2CMInitcodeWithArgs, testL2CMAddr)
+	activation.SetTransactions(nutTxs, totalGas)
+	t.Logger().Info("Registered custom NUT transactions", "activationTime", activation.Time, "txCount", len(nutTxs))
 
-	paABI, err := abi.JSON(bytes.NewReader([]byte(
-		`[{"inputs":[{"name":"_proxy","type":"address"},{"name":"_implementation","type":"address"}],"name":"upgrade","outputs":[],"stateMutability":"nonpayable","type":"function"}]`,
-	)))
-	t.Require().NoError(err)
-	upgradeCalldata, err := paABI.Pack("upgrade", predeploys.SchemaRegistryAddr, newImplAddr)
-	t.Require().NoError(err)
+	// Wait for the activation block (poll until version() returns the new version).
+	t.Require().Eventually(func() bool {
+		ver := callVersionString(t, sys.L2EL.EthClient(), predeploys.SchemaRegistryAddr)
+		return ver == newVersion
+	}, 2*time.Minute, 2*time.Second, fmt.Sprintf("SchemaRegistry version should update to %s after custom NUT activation", newVersion))
+	t.Logger().Info("Verified version() on L2", "version", newVersion)
 
-	proxyAdminAddr := predeploys.ProxyAdminAddr
-	upgradeTx := l2PAO.Transact(l2PAO.Plan(), txplan.WithTo(&proxyAdminAddr), txplan.WithData(upgradeCalldata))
-	upgradeReceipt, err := upgradeTx.Included.Eval(t.Ctx())
-	t.Require().NoError(err)
-	upgradeBlockNumber := upgradeReceipt.BlockNumber.Uint64()
-	t.Logger().Info("Upgraded SchemaRegistry proxy", "block", upgradeBlockNumber, "newImpl", newImplAddr)
-
-	// Verify ERC-1967 slot and version() on L2.
+	// Verify ERC-1967 implementation slot.
 	implSlot, err := sys.L2EL.EthClient().GetStorageAt(
 		t.Ctx(), predeploys.SchemaRegistryAddr, genesis.ImplementationSlot, "latest",
 	)
 	t.Require().NoError(err)
 	t.Require().Equal(newImplAddr, common.BytesToAddress(implSlot[:]))
-	t.Require().Equal(newVersion, callVersionString(t, sys.L2EL.EthClient(), predeploys.SchemaRegistryAddr))
-	t.Logger().Info("Verified version() on L2", "version", newVersion)
 
-	// Wait for a dispute game on L1 that covers the post-upgrade block.
+	// Retrieve the block number at which the upgrade landed.
+	latestBlock, err := sys.L2EL.EthClient().InfoByLabel(t.Ctx(), eth.Unsafe)
+	t.Require().NoError(err)
+	upgradeBlockNumber := latestBlock.NumberU64()
+
+	// Wait for an L1 dispute game covering the post-upgrade block.
 	dgf := sys.DisputeGameFactory()
 	initialGameCount := dgf.GameCount()
 	t.Require().Eventually(func() bool {

--- a/op-acceptance-tests/tests/karst/withdrawal_test.go
+++ b/op-acceptance-tests/tests/karst/withdrawal_test.go
@@ -1,0 +1,18 @@
+package karst
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/withdrawal"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+// TestWithdrawal_Karst creates a withdrawal from the L2StandardBridge and
+// observes the full withdrawal flow, including finalization on L1.
+func TestWithdrawal_Karst(gt *testing.T) {
+	withdrawal.TestWithdrawal(gt, gameTypes.CannonGameType,
+		presets.WithDeployerOptions(sysgo.WithKarstAtGenesis),
+	)
+}

--- a/op-core/predeploys/addresses.go
+++ b/op-core/predeploys/addresses.go
@@ -32,6 +32,7 @@ const (
 	ETHLiquidity                  = "0x4200000000000000000000000000000000000025"
 	NativeAssetLiquidity          = "0x4200000000000000000000000000000000000029"
 	LiquidityController           = "0x420000000000000000000000000000000000002a"
+	ConditionalDeployer           = "0x420000000000000000000000000000000000002C"
 	Create2Deployer               = "0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2"
 	MultiCall3                    = "0xcA11bde05977b3631167028862bE2a173976CA11"
 	Safe_v130                     = "0x69f4D1788e39c87893C980c06EdF4b7f686e2938"
@@ -74,6 +75,7 @@ var (
 	ETHLiquidityAddr                  = common.HexToAddress(ETHLiquidity)
 	NativeAssetLiquidityAddr          = common.HexToAddress(NativeAssetLiquidity)
 	LiquidityControllerAddr           = common.HexToAddress(LiquidityController)
+	ConditionalDeployerAddr           = common.HexToAddress(ConditionalDeployer)
 	Create2DeployerAddr               = common.HexToAddress(Create2Deployer)
 	MultiCall3Addr                    = common.HexToAddress(MultiCall3)
 	Safe_v130Addr                     = common.HexToAddress(Safe_v130)

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -80,6 +80,19 @@ func WithJovianAtGenesis(p devtest.T, _ devkeys.Keys, builder intentbuilder.Buil
 	}
 }
 
+// WithCustomNUTAtOffset returns a *rollup.CustomNUTActivation handle and an L2CLOption that
+// schedules custom NUT deposit transactions to be injected at genesis-time + offsetSeconds.
+// The caller must call SetTransactions on the returned handle before the activation block is
+// sequenced. Intended for tests only; never use in production.
+func WithCustomNUTAtOffset(offsetSeconds uint64) (*rollup.CustomNUTActivation, L2CLOption) {
+	activation := &rollup.CustomNUTActivation{}
+	opt := L2CLOptionFn(func(_ devtest.T, _ ComponentTarget, cfg *L2CLConfig) {
+		cfg.customNUTActivationOffset = offsetSeconds
+		cfg.customNUTActivation = activation
+	})
+	return activation, opt
+}
+
 func WithL2GasLimit(gasLimit uint64) DeployerOption {
 	return func(_ devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
 		for _, l2Cfg := range builder.L2s() {

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -40,6 +41,14 @@ type L2CLConfig struct {
 
 	// OffsetELSafe retracts safe and finalized from the EL-sync tip by floor(OffsetELSafe / L2BlockTime) blocks.
 	OffsetELSafe time.Duration
+
+	// customNUTActivationOffset, if non-zero, triggers injection of custom NUT transactions at
+	// genesis-time + customNUTActivationOffset seconds. The *rollup.CustomNUTActivation handle
+	// returned by WithCustomNUTAtOffset must have SetTransactions called before that block.
+	customNUTActivationOffset uint64
+	// customNUTActivation is the shared handle written by singlechain_build once the genesis time
+	// is known. The caller holds the same pointer to feed in transactions after startup.
+	customNUTActivation *rollup.CustomNUTActivation
 }
 
 func L2CLSequencer() L2CLOption {

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -430,6 +430,10 @@ func startL2CLNode(
 		IgnoreMissingPectraBlobSchedule: false,
 		ExperimentalOPStackAPI:          true,
 	}
+	if cfg.customNUTActivation != nil {
+		cfg.customNUTActivation.Time = l2Net.rollupCfg.Genesis.L2Time + cfg.customNUTActivationOffset
+		nodeCfg.Rollup.CustomNUTActivation = cfg.customNUTActivation
+	}
 	l2CL := &OpNode{
 		name:     startCfg.Key,
 		opNode:   nil,

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -167,6 +167,12 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 		upgradeGas += nutGas
 	}
 
+	if ba.rollupCfg.IsCustomNUTActivationBlock(nextL2Time) {
+		customTxs, customGas := ba.rollupCfg.CustomNUTActivation.Transactions()
+		upgradeTxs = append(upgradeTxs, customTxs...)
+		upgradeGas += customGas
+	}
+
 	// TODO(#19239): migrate Interop to NUT bundle and add its gas to upgradeGas.
 	if ba.rollupCfg.IsInteropActivationBlock(nextL2Time) {
 		interop, err := InteropNetworkUpgradeTransactions()

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -593,6 +593,11 @@ func (d *Sequencer) startBuildingBlock() {
 		d.log.Info("Sequencing Karst upgrade block")
 	}
 
+	if d.rollupCfg.IsCustomNUTActivationBlock(uint64(attrs.Timestamp)) {
+		attrs.NoTxPool = true
+		d.log.Info("Sequencing custom NUT upgrade block")
+	}
+
 	// For the Interop activation block we must not include any sequencer transactions.
 	if d.rollupCfg.IsInteropActivationBlock(uint64(attrs.Timestamp)) {
 		attrs.NoTxPool = true

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"sync"
 	"time"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
@@ -14,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -165,6 +167,39 @@ type Config struct {
 	// This feature (de)activates by L1 origin timestamp, to keep a consistent L1 block info per L2
 	// epoch.
 	PectraBlobScheduleTime *uint64 `json:"pectra_blob_schedule_time,omitempty"`
+
+	// CustomNUTActivation is a test-only hook for injecting custom NUT deposit transactions at a
+	// specific L2 timestamp, simulating a future post-Karst upgrade. Not serialized; must not be
+	// used in production.
+	CustomNUTActivation *CustomNUTActivation `json:"-"`
+}
+
+// CustomNUTActivation holds the activation timestamp and NUT deposit transactions for a test-only
+// post-Karst upgrade simulation. Transactions may be set after construction (before the activation
+// block is sequenced) via SetTransactions.
+type CustomNUTActivation struct {
+	// Time is the L2 block timestamp at which to inject the NUT transactions.
+	Time uint64
+
+	mu       sync.Mutex
+	txs      []hexutil.Bytes
+	totalGas uint64
+}
+
+// SetTransactions sets the serialized deposit transactions and their combined gas limit.
+// Must be called before the activation block is sequenced.
+func (a *CustomNUTActivation) SetTransactions(txs []hexutil.Bytes, totalGas uint64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.txs = txs
+	a.totalGas = totalGas
+}
+
+// Transactions returns the serialized deposit transactions and their combined gas limit.
+func (a *CustomNUTActivation) Transactions() ([]hexutil.Bytes, uint64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.txs, a.totalGas
 }
 
 // ValidateL1Config checks L1 config variables for errors.
@@ -568,6 +603,19 @@ func (c *Config) IsKarstActivationBlock(l2BlockTime uint64) bool {
 	return c.IsKarst(l2BlockTime) &&
 		l2BlockTime >= c.BlockTime &&
 		!c.IsKarst(l2BlockTime-c.BlockTime)
+}
+
+// IsCustomNUTActivationBlock returns true for the first L2 block at or after the custom NUT
+// activation timestamp. Used to inject test-only NUT transactions; never true in production
+// (CustomNUTActivation is nil when loaded from JSON).
+func (c *Config) IsCustomNUTActivationBlock(l2BlockTime uint64) bool {
+	if c.CustomNUTActivation == nil {
+		return false
+	}
+	t := c.CustomNUTActivation.Time
+	return l2BlockTime >= t &&
+		l2BlockTime >= c.BlockTime &&
+		l2BlockTime-c.BlockTime < t
 }
 
 func (c *Config) IsInteropActivationBlock(l2BlockTime uint64) bool {

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -227,6 +227,15 @@ test-l2-fork-upgrade *ARGS:
 test-l2-fork-upgrade-rerun *ARGS:
   just test-l2-fork-upgrade {{ARGS}} --rerun -vvvv
 
+# Runs L2 fork upgrade tests against a Karst betanet L2 fork.
+# Skips bundle execution and only runs verification steps.
+# Usage: KARST_BETANET_L2_FORK_RPC_URL=<url> just test-karst-betanet-l2-fork-upgrade [ARGS]
+test-karst-betanet-l2-fork-upgrade *ARGS:
+  KARST_BETANET_L2_FORK_TEST=true just prepare-l2-upgrade-env "just test {{ARGS}}"
+
+test-karst-betanet-l2-fork-upgrade-rerun *ARGS:
+  just test-karst-betanet-l2-fork-upgrade {{ARGS}} --rerun -vvvv
+
 ########################################################
 #                        DEPLOY                        #
 ########################################################

--- a/packages/contracts-bedrock/scripts/libraries/Config.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Config.sol
@@ -289,9 +289,19 @@ library Config {
         return vm.envOr("L2_FORK_TEST", false);
     }
 
+    /// @notice Returns true if this is a Karst betanet L2 fork test.
+    function karstBetanetL2ForkTest() internal view returns (bool) {
+        return vm.envOr("KARST_BETANET_L2_FORK_TEST", false);
+    }
+
     /// @notice Returns the L2 RPC URL for forking.
     function l2ForkRpcUrl() internal view returns (string memory) {
         return vm.envString("L2_FORK_RPC_URL");
+    }
+
+    /// @notice Returns the Karst betanet L2 RPC URL for forking.
+    function karstBetanetL2ForkRpcUrl() internal view returns (string memory) {
+        return vm.envString("KARST_BETANET_L2_FORK_RPC_URL");
     }
 
     /// @notice Returns the L2 block number to fork at. Defaults to 0 (latest).

--- a/packages/contracts-bedrock/test/L2/MinimalTestL2CM.sol
+++ b/packages/contracts-bedrock/test/L2/MinimalTestL2CM.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+interface IProxy {
+    function upgradeTo(address _implementation) external;
+}
+
+/// @title MinimalTestL2CM
+/// @notice Test-only minimal L2ContractsManager that upgrades a single predeploy proxy.
+///         Designed to be called via DELEGATECALL from L2ProxyAdmin.upgradePredeploys():
+///         in that context address(this) == L2ProxyAdmin, which is the proxy admin, so
+///         the upgradeTo call is authorized.
+contract MinimalTestL2CM {
+    address public immutable proxy;
+    address public immutable newImpl;
+
+    constructor(address _proxy, address _newImpl) {
+        proxy = _proxy;
+        newImpl = _newImpl;
+    }
+
+    function upgrade() external {
+        IProxy(proxy).upgradeTo(newImpl);
+    }
+}

--- a/packages/contracts-bedrock/test/L2/fork/L2ForkUpgrade.t.sol
+++ b/packages/contracts-bedrock/test/L2/fork/L2ForkUpgrade.t.sol
@@ -146,8 +146,10 @@ contract L2ForkUpgrade_Versions_Test is L2ForkUpgrade_TestInit {
         // Capture pre-upgrade version state
         PreUpgradeVersionState memory preState = _capturePreUpgradeVersionState();
 
-        // Execute bundle on forked L2
-        executeScript.execute();
+        // Execute upgrade (skipped when the network already has the upgrade applied)
+        if (!isKarstForkActivated()) {
+            executeScript.execute();
+        }
 
         // Verify all versions were updated
         _verifyAllVersionsUpdated(preState);
@@ -251,8 +253,10 @@ contract L2ForkUpgrade_Initialization_Test is L2ForkUpgrade_TestInit {
         // Capture pre-upgrade initialization state
         PreUpgradeInitializationState memory preState = _capturePreUpgradeInitializationState();
 
-        // Execute bundle on forked L2
-        executeScript.execute();
+        // Execute upgrade (skipped when the network already has the upgrade applied)
+        if (!isKarstForkActivated()) {
+            executeScript.execute();
+        }
 
         // Verify initialization state was preserved
         _verifyInitializationState(preState);
@@ -606,8 +610,10 @@ contract L2ForkUpgrade_Implementations_Test is L2ForkUpgrade_TestInit {
         // Skip if running with an unoptimized Foundry profile
         skipIfUnoptimized();
 
-        // Execute upgrade
-        executeScript.execute();
+        // Execute upgrade (skipped when the network already has the upgrade applied)
+        if (!isKarstForkActivated()) {
+            executeScript.execute();
+        }
 
         // Get all upgradeable predeploys
         address[] memory predeploys = Predeploys.getUpgradeablePredeploys();
@@ -657,6 +663,12 @@ contract L2ForkUpgrade_Events_Test is L2ForkUpgrade_TestInit {
     function test_l2ForkUpgrade_upgradeEventsEmitted_succeeds() public {
         // Skip if running with an unoptimized Foundry profile
         skipIfUnoptimized();
+
+        // Events were emitted in the past and cannot be replayed on an already-upgraded network
+        if (isKarstForkActivated()) {
+            vm.skip(true);
+            return;
+        }
 
         // Get StorageSetter implementation to filter out intermediate upgrade events
         (address storageSetterImpl,,,) = generateScript.implementationConfigs("StorageSetter");

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -173,6 +173,11 @@ abstract contract Setup is FeatureFlags {
         return Config.l2ForkTest();
     }
 
+    /// @notice Indicates whether a test is running against a Karst betanet L2 fork test.
+    function isKarstBetanetL2ForkTest() public view returns (bool) {
+        return Config.karstBetanetL2ForkTest();
+    }
+
     /// @dev Deploys either the Deploy.s.sol or Fork.s.sol contract, by fetching the bytecode dynamically using
     ///      `vm.getDeployedCode()` and etching it into the state.
     ///      This enables us to avoid including the bytecode of those contracts in the bytecode of this contract.
@@ -184,12 +189,20 @@ abstract contract Setup is FeatureFlags {
         console.log("Setup: L1 setup start!");
 
         // Handle L2 fork test (takes precedence over L1 fork)
-        if (isL2ForkTest()) {
+        if (isL2ForkTest() || isKarstBetanetL2ForkTest()) {
             uint256 l2ForkBlock = Config.l2ForkBlockNumber();
-            if (l2ForkBlock == 0) {
-                vm.createSelectFork(Config.l2ForkRpcUrl());
+            if (isKarstBetanetL2ForkTest()) {
+                if (l2ForkBlock == 0) {
+                    vm.createSelectFork(Config.karstBetanetL2ForkRpcUrl());
+                } else {
+                    vm.createSelectFork(Config.karstBetanetL2ForkRpcUrl(), l2ForkBlock);
+                }
             } else {
-                vm.createSelectFork(Config.l2ForkRpcUrl(), l2ForkBlock);
+                if (l2ForkBlock == 0) {
+                    vm.createSelectFork(Config.l2ForkRpcUrl());
+                } else {
+                    vm.createSelectFork(Config.l2ForkRpcUrl(), l2ForkBlock);
+                }
             }
             console.log("Setup: L2 fork selected!");
         } else if (isL1ForkTest()) {
@@ -351,6 +364,12 @@ abstract contract Setup is FeatureFlags {
             vm.skip(true);
             console.log(string.concat("Skipping non-L2 fork test: ", message));
         }
+    }
+
+    /// @dev Returns true if the forked L2 network has the Karst upgrade applied, by checking if the ConditionalDeployer predeploy exists.
+    ///      When true, fork upgrade tests skip bundle execution but still run verification.
+    function isKarstForkActivated() public view returns (bool) {
+        return Predeploys.CONDITIONAL_DEPLOYER.code.length > 0;
     }
 
     /// @dev Sets up the L1 contracts.


### PR DESCRIPTION
fixes #18870

- [x] option to run forktests against karst betanet
- [x] acceptance test for withdrawal
- [x] acceptance test for minimal upgrade with L2CM
- [ ] verify that the deterministic-deployment-proxy exists on all target L2 chains before the upgrade fork activates