### PR TITLE
feat: Script to Migrate single super games to ZK

### DIFF
--- a/op-deployer/pkg/deployer/manage/flags.go
+++ b/op-deployer/pkg/deployer/manage/flags.go
@@ -170,6 +170,27 @@ var Commands = cli.Commands{
 		Action: MigrateCLI,
 	},
 	&cli.Command{
+		Name:  "migrate-to-zk-single",
+		Usage: "migrates an isolated chain from its super game (SFDG/SPDG) to the ZK dispute game via OPCMv2.upgrade().",
+		Flags: append([]cli.Flag{
+			deployer.CacheDirFlag,
+			deployer.L1RPCURLFlag,
+			deployer.PrivateKeyFlag,
+			deployer.ArtifactsLocatorFlag,
+			L1ProxyAdminOwnerFlag,
+			OPCMImplFlag,
+			SystemConfigProxyFlag,
+			StartingAnchorRootFlag,
+			StartingAnchorL2SequenceNumberFlag,
+			InitialBondFlag,
+			DisputeAbsolutePrestateFlag,
+			ZKVerifierFlag,
+			ZKMaxChallengeDurationFlag,
+			ZKMaxProveDurationFlag,
+		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
+		Action: MigrateToZKSingleCLI,
+	},
+	&cli.Command{
 		Name:  "set-interop-dispute-games",
 		Usage: "swaps the shared dispute games of an already-interop set to the ZK dispute game.",
 		Flags: append([]cli.Flag{

--- a/op-deployer/pkg/deployer/manage/migrate_to_zk_single.go
+++ b/op-deployer/pkg/deployer/manage/migrate_to_zk_single.go
@@ -1,0 +1,307 @@
+package manage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/embedded"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
+	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
+	"github.com/ethereum-optimism/optimism/op-service/ioutil"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/urfave/cli/v2"
+)
+
+// migrateToZKSingleParams holds the parsed inputs required to build a single-chain migration to the
+// ZK dispute game. It is kept separate from the cli.Context so the input-building logic can be
+// exercised in unit tests without a live chain.
+type migrateToZKSingleParams struct {
+	Prank                common.Address
+	Opcm                 common.Address
+	SystemConfig         common.Address
+	AbsolutePrestate     common.Hash
+	Verifier             common.Address
+	MaxChallengeDuration uint64
+	MaxProveDuration     uint64
+	InitBond             *big.Int
+	StartingAnchorRoot   common.Hash
+	StartingAnchorL2Seq  uint64
+}
+
+// buildMigrateToZKSingleInput assembles the OPCMv2.upgrade() input that migrates an isolated chain
+// from its current super game (SuperFaultDisputeGame or SuperPermissionedDisputeGame) to the ZK
+// dispute game. Every existing game type is disabled and only ZK_DISPUTE_GAME is enabled, and the
+// respected game type is flipped to ZK. The starting anchor root is always overridden so the
+// re-initialized AnchorStateRegistry seeds the ZK game from the supplied honest anchor.
+//
+// Detailed ZK-config validation (non-zero verifier/prestate, positive durations/bond) is delegated
+// to embedded.EncodedUpgradeInputV2 at run time; this function only validates the top-level inputs
+// it owns.
+func buildMigrateToZKSingleInput(p migrateToZKSingleParams) (embedded.UpgradeOPChainInput, error) {
+	var zero embedded.UpgradeOPChainInput
+
+	if p.Prank == (common.Address{}) {
+		return zero, fmt.Errorf("l1 proxy admin owner must not be the zero address")
+	}
+	if p.Opcm == (common.Address{}) {
+		return zero, fmt.Errorf("opcm must not be the zero address")
+	}
+	if p.SystemConfig == (common.Address{}) {
+		return zero, fmt.Errorf("system config proxy must not be the zero address")
+	}
+	if p.InitBond == nil || p.InitBond.Sign() <= 0 {
+		// The ZK game is enabled, so _assertValidFullConfig requires a non-zero init bond.
+		return zero, fmt.Errorf("initial bond must be a positive value")
+	}
+
+	// Build the full, ordered game-config array. The order MUST match the validGameTypes array in
+	// OPContractsManagerV2._assertValidFullConfig: CANNON, PERMISSIONED_CANNON, CANNON_KONA,
+	// SUPER_PERMISSIONED_CANNON, SUPER_CANNON_KONA, ZK_DISPUTE_GAME. All are disabled except ZK.
+	disputeGameConfigs := buildZKSingleDisputeGameConfigs(&embedded.ZKDisputeGameConfig{
+		AbsolutePrestate:     p.AbsolutePrestate,
+		Verifier:             p.Verifier,
+		MaxChallengeDuration: p.MaxChallengeDuration,
+		MaxProveDuration:     p.MaxProveDuration,
+		ChallengerBond:       p.InitBond,
+	}, p.InitBond)
+
+	// Flip the respected game type to ZK. Required because the previously-respected super game is
+	// being disabled by this upgrade; without the override, _loadFullConfig would load the old
+	// respected type and _assertValidFullConfig would revert.
+	respectedData, err := encodeStartingRespectedGameType(gameTypeZKDisputeGame)
+	if err != nil {
+		return zero, fmt.Errorf("failed to encode startingRespectedGameType override: %w", err)
+	}
+
+	// Seed the re-initialized AnchorStateRegistry from the supplied honest anchor. Gated on the
+	// SUPER_ROOT_GAMES_MIGRATION dev feature in OPContractsManagerV2._isPermittedInstruction.
+	anchorData, err := encodeStartingAnchorRoot(p.StartingAnchorRoot, p.StartingAnchorL2Seq)
+	if err != nil {
+		return zero, fmt.Errorf("failed to encode startingAnchorRoot override: %w", err)
+	}
+
+	return embedded.UpgradeOPChainInput{
+		Prank: p.Prank,
+		Opcm:  p.Opcm,
+		UpgradeInputV2: &embedded.UpgradeInputV2{
+			SystemConfig:       p.SystemConfig,
+			DisputeGameConfigs: disputeGameConfigs,
+			ExtraInstructions: []embedded.ExtraInstruction{
+				{Key: "overrides.cfg.startingRespectedGameType", Data: respectedData},
+				{Key: "overrides.cfg.startingAnchorRoot", Data: anchorData},
+			},
+		},
+	}, nil
+}
+
+// buildZKSingleDisputeGameConfigs returns the full game-config array with every game type disabled
+// except the ZK dispute game. The slice order is significant and must match the validGameTypes
+// array in OPContractsManagerV2._assertValidFullConfig.
+func buildZKSingleDisputeGameConfigs(
+	zkCfg *embedded.ZKDisputeGameConfig,
+	initBond *big.Int,
+) []embedded.DisputeGameConfig {
+	return []embedded.DisputeGameConfig{
+		{Enabled: false, InitBond: new(big.Int), GameType: embedded.GameTypeCannon},
+		{Enabled: false, InitBond: new(big.Int), GameType: embedded.GameTypePermissionedCannon},
+		{Enabled: false, InitBond: new(big.Int), GameType: embedded.GameTypeCannonKona},
+		{Enabled: false, InitBond: new(big.Int), GameType: embedded.GameTypeSuperPermCannon},
+		{Enabled: false, InitBond: new(big.Int), GameType: embedded.GameTypeSuperCannonKona},
+		{
+			Enabled:             true,
+			InitBond:            initBond,
+			GameType:            embedded.GameTypeZKDisputeGame,
+			ZKDisputeGameConfig: zkCfg,
+		},
+	}
+}
+
+// encodeStartingRespectedGameType ABI-encodes a GameType (uint32) for the
+// "overrides.cfg.startingRespectedGameType" upgrade instruction. OPCM decodes this via
+// abi.decode(data, (GameType)).
+func encodeStartingRespectedGameType(gameType uint32) ([]byte, error) {
+	uint32Ty, err := abi.NewType("uint32", "", nil)
+	if err != nil {
+		return nil, err
+	}
+	return abi.Arguments{{Type: uint32Ty}}.Pack(gameType)
+}
+
+// encodeStartingAnchorRoot ABI-encodes a Proposal{bytes32 root, uint256 l2SequenceNumber} for the
+// "overrides.cfg.startingAnchorRoot" upgrade instruction. OPCM decodes this via
+// abi.decode(data, (Proposal)).
+func encodeStartingAnchorRoot(root common.Hash, l2SequenceNumber uint64) ([]byte, error) {
+	proposalTy, err := abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "root", Type: "bytes32"},
+		{Name: "l2SequenceNumber", Type: "uint256"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return abi.Arguments{{Type: proposalTy}}.Pack(struct {
+		Root             common.Hash
+		L2SequenceNumber *big.Int
+	}{
+		Root:             root,
+		L2SequenceNumber: new(big.Int).SetUint64(l2SequenceNumber),
+	})
+}
+
+// MigrateToZKSingle runs the UpgradeOPChain forge script (OPCMv2.upgrade) for an isolated chain,
+// swapping its super game for the ZK dispute game. It reuses the embedded upgrade primitives, which
+// validate and encode the ZK config and run the script against the supplied forked host.
+func MigrateToZKSingle(host *script.Host, input embedded.UpgradeOPChainInput) error {
+	return embedded.Upgrade(host, input)
+}
+
+// migrateToZKSingleOutput is a small JSON summary emitted after a successful migration.
+type migrateToZKSingleOutput struct {
+	SystemConfig      common.Address `json:"systemConfig"`
+	RespectedGameType uint32         `json:"respectedGameType"`
+}
+
+// MigrateToZKSingleCLI is the entry point for the `manage migrate-to-zk-single` command. It builds
+// the OPCMv2.upgrade input that migrates an isolated chain from its current super game (SFDG/SPDG)
+// to the ZK dispute game and runs the upgrade against a forked L1.
+func MigrateToZKSingleCLI(cliCtx *cli.Context) error {
+	logCfg := oplog.ReadCLIConfig(cliCtx)
+	lgr := oplog.NewLogger(oplog.AppOut(cliCtx), logCfg)
+	oplog.SetGlobalLogHandler(lgr.Handler())
+
+	ctx, cancel := context.WithCancel(cliCtx.Context)
+	defer cancel()
+
+	l1RPCUrl := cliCtx.String(deployer.L1RPCURLFlag.Name)
+	if l1RPCUrl == "" {
+		return fmt.Errorf("missing required flag: %s", deployer.L1RPCURLFlag.Name)
+	}
+
+	privateKey := cliCtx.String(deployer.PrivateKeyFlag.Name)
+	if privateKey == "" {
+		return fmt.Errorf("missing required flag: %s", deployer.PrivateKeyFlag.Name)
+	}
+	privateKeyECDSA, err := crypto.HexToECDSA(strings.TrimPrefix(privateKey, "0x"))
+	if err != nil {
+		return fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	opcmFlag := cliCtx.String(OPCMImplFlag.Name)
+	if opcmFlag == "" {
+		return fmt.Errorf("missing required flag: %s", OPCMImplFlag.Name)
+	}
+
+	l1ProxyAdminOwnerFlag := cliCtx.String(L1ProxyAdminOwnerFlag.Name)
+	if l1ProxyAdminOwnerFlag == "" {
+		return fmt.Errorf("missing required flag: %s", L1ProxyAdminOwnerFlag.Name)
+	}
+
+	systemConfigFlag := cliCtx.String(SystemConfigProxyFlag.Name)
+	if systemConfigFlag == "" {
+		return fmt.Errorf("missing required flag: %s", SystemConfigProxyFlag.Name)
+	}
+
+	startingAnchorRootFlag := cliCtx.String(StartingAnchorRootFlag.Name)
+	if startingAnchorRootFlag == "" {
+		return fmt.Errorf("missing required flag: %s", StartingAnchorRootFlag.Name)
+	}
+
+	verifierFlag := cliCtx.String(ZKVerifierFlag.Name)
+	if verifierFlag == "" {
+		return fmt.Errorf("missing required flag: %s", ZKVerifierFlag.Name)
+	}
+
+	initBondStr := cliCtx.String(InitialBondFlag.Name)
+	if initBondStr == "" {
+		return fmt.Errorf("missing required flag: %s", InitialBondFlag.Name)
+	}
+	initBond, ok := new(big.Int).SetString(initBondStr, 10)
+	if !ok {
+		return fmt.Errorf("failed to parse initial bond: %s", initBondStr)
+	}
+
+	input, err := buildMigrateToZKSingleInput(migrateToZKSingleParams{
+		Prank:                common.HexToAddress(l1ProxyAdminOwnerFlag),
+		Opcm:                 common.HexToAddress(opcmFlag),
+		SystemConfig:         common.HexToAddress(systemConfigFlag),
+		AbsolutePrestate:     common.HexToHash(cliCtx.String(DisputeAbsolutePrestateFlag.Name)),
+		Verifier:             common.HexToAddress(verifierFlag),
+		MaxChallengeDuration: cliCtx.Uint64(ZKMaxChallengeDurationFlag.Name),
+		MaxProveDuration:     cliCtx.Uint64(ZKMaxProveDurationFlag.Name),
+		InitBond:             initBond,
+		StartingAnchorRoot:   common.HexToHash(startingAnchorRootFlag),
+		StartingAnchorL2Seq:  cliCtx.Uint64(StartingAnchorL2SequenceNumberFlag.Name),
+	})
+	if err != nil {
+		return err
+	}
+
+	artifactsLocatorStr := cliCtx.String(deployer.ArtifactsLocatorFlag.Name)
+	artifactsLocator := new(artifacts.Locator)
+	if err := artifactsLocator.UnmarshalText([]byte(artifactsLocatorStr)); err != nil {
+		return fmt.Errorf("failed to parse artifacts locator: %w", err)
+	}
+
+	l1RPC, err := rpc.Dial(l1RPCUrl)
+	if err != nil {
+		return fmt.Errorf("failed to dial RPC %s: %w", l1RPCUrl, err)
+	}
+
+	cacheDir := cliCtx.String(deployer.CacheDirFlag.Name)
+	artifactsFS, err := artifacts.Download(ctx, artifactsLocator, ioutil.BarProgressor(), cacheDir)
+	if err != nil {
+		return fmt.Errorf("failed to download artifacts: %w", err)
+	}
+
+	l1Client := ethclient.NewClient(l1RPC)
+	defer l1Client.Close()
+
+	l1ChainID, err := l1Client.ChainID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get chain ID: %w", err)
+	}
+
+	signer := opcrypto.SignerFnFromBind(opcrypto.PrivateKeySignerFn(privateKeyECDSA, l1ChainID))
+	deployerAddr := crypto.PubkeyToAddress(privateKeyECDSA.PublicKey)
+	bcaster, err := broadcaster.NewKeyedBroadcaster(broadcaster.KeyedBroadcasterOpts{
+		Logger:  lgr,
+		ChainID: l1ChainID,
+		Client:  l1Client,
+		Signer:  signer,
+		From:    deployerAddr,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create broadcaster: %w", err)
+	}
+
+	l1Host, err := env.DefaultForkedScriptHost(ctx, bcaster, lgr, deployerAddr, artifactsFS, l1RPC)
+	if err != nil {
+		return fmt.Errorf("failed to create script host: %w", err)
+	}
+
+	if err := MigrateToZKSingle(l1Host, input); err != nil {
+		return fmt.Errorf("failed to run ZK single-chain migration: %w", err)
+	}
+
+	enc := json.NewEncoder(cliCtx.App.Writer)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(migrateToZKSingleOutput{
+		SystemConfig:      input.UpgradeInputV2.SystemConfig,
+		RespectedGameType: gameTypeZKDisputeGame,
+	}); err != nil {
+		return fmt.Errorf("failed to encode migration output: %w", err)
+	}
+
+	return nil
+}

--- a/op-deployer/pkg/deployer/manage/migrate_to_zk_single_test.go
+++ b/op-deployer/pkg/deployer/manage/migrate_to_zk_single_test.go
@@ -1,0 +1,264 @@
+package manage
+
+import (
+	"context"
+	"log/slog"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/integration_test/shared"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/embedded"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func validZKSingleParams() migrateToZKSingleParams {
+	return migrateToZKSingleParams{
+		Prank:                common.HexToAddress("0x000000000000000000000000000000000000aaaa"),
+		Opcm:                 common.HexToAddress("0x000000000000000000000000000000000000bbbb"),
+		SystemConfig:         common.HexToAddress("0x000000000000000000000000000000000000cccc"),
+		AbsolutePrestate:     common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000abc"),
+		Verifier:             common.HexToAddress("0x000000000000000000000000000000000000bEEF"),
+		MaxChallengeDuration: 7 * 24 * 60 * 60,
+		MaxProveDuration:     3 * 24 * 60 * 60,
+		InitBond:             big.NewInt(1e18),
+		StartingAnchorRoot:   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000def"),
+		StartingAnchorL2Seq:  42,
+	}
+}
+
+func TestBuildMigrateToZKSingleInput(t *testing.T) {
+	t.Run("builds the full game config array with only ZK enabled", func(t *testing.T) {
+		p := validZKSingleParams()
+		in, err := buildMigrateToZKSingleInput(p)
+		require.NoError(t, err)
+
+		require.Equal(t, p.Prank, in.Prank)
+		require.Equal(t, p.Opcm, in.Opcm)
+		require.NotNil(t, in.UpgradeInputV2)
+		require.Equal(t, p.SystemConfig, in.UpgradeInputV2.SystemConfig)
+
+		cfgs := in.UpgradeInputV2.DisputeGameConfigs
+		// The order must match validGameTypes in OPContractsManagerV2._assertValidFullConfig.
+		expectedOrder := []embedded.GameType{
+			embedded.GameTypeCannon,
+			embedded.GameTypePermissionedCannon,
+			embedded.GameTypeCannonKona,
+			embedded.GameTypeSuperPermCannon,
+			embedded.GameTypeSuperCannonKona,
+			embedded.GameTypeZKDisputeGame,
+		}
+		require.Len(t, cfgs, len(expectedOrder))
+		for i, want := range expectedOrder {
+			require.Equal(t, want, cfgs[i].GameType, "game type at index %d", i)
+		}
+
+		// Only the ZK game (last entry) is enabled; all others are disabled with zero bond and no
+		// sub-config.
+		for i := 0; i < len(cfgs)-1; i++ {
+			require.False(t, cfgs[i].Enabled, "config %d should be disabled", i)
+			require.Equal(t, 0, cfgs[i].InitBond.Sign(), "disabled config %d should have zero bond", i)
+			require.Nil(t, cfgs[i].ZKDisputeGameConfig)
+			require.Nil(t, cfgs[i].FaultDisputeGameConfig)
+			require.Nil(t, cfgs[i].PermissionedDisputeGameConfig)
+			require.Nil(t, cfgs[i].SuperPermissionedDisputeGameConfig)
+		}
+
+		zk := cfgs[len(cfgs)-1]
+		require.True(t, zk.Enabled)
+		require.Equal(t, embedded.GameTypeZKDisputeGame, zk.GameType)
+		require.Equal(t, p.InitBond, zk.InitBond)
+		require.NotNil(t, zk.ZKDisputeGameConfig)
+		require.Equal(t, p.AbsolutePrestate, zk.ZKDisputeGameConfig.AbsolutePrestate)
+		require.Equal(t, p.Verifier, zk.ZKDisputeGameConfig.Verifier)
+		require.Equal(t, p.MaxChallengeDuration, zk.ZKDisputeGameConfig.MaxChallengeDuration)
+		require.Equal(t, p.MaxProveDuration, zk.ZKDisputeGameConfig.MaxProveDuration)
+		require.Equal(t, p.InitBond, zk.ZKDisputeGameConfig.ChallengerBond)
+	})
+
+	t.Run("emits both override instructions with correctly encoded data", func(t *testing.T) {
+		p := validZKSingleParams()
+		in, err := buildMigrateToZKSingleInput(p)
+		require.NoError(t, err)
+
+		instrs := in.UpgradeInputV2.ExtraInstructions
+		require.Len(t, instrs, 2)
+
+		require.Equal(t, "overrides.cfg.startingRespectedGameType", instrs[0].Key)
+		// abi.encode(uint32) is a single left-padded 32-byte word.
+		require.Len(t, instrs[0].Data, 32)
+		require.Equal(t, uint64(gameTypeZKDisputeGame), new(big.Int).SetBytes(instrs[0].Data).Uint64())
+
+		require.Equal(t, "overrides.cfg.startingAnchorRoot", instrs[1].Key)
+		// abi.encode(Proposal{bytes32,uint256}) is a static 64-byte tuple: root || l2SequenceNumber.
+		require.Len(t, instrs[1].Data, 64)
+		require.Equal(t, p.StartingAnchorRoot, common.BytesToHash(instrs[1].Data[0:32]))
+		require.Equal(t, p.StartingAnchorL2Seq, new(big.Int).SetBytes(instrs[1].Data[32:64]).Uint64())
+	})
+
+	t.Run("rejects missing required inputs", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			mutate func(*migrateToZKSingleParams)
+			errSub string
+		}{
+			{"zero prank", func(p *migrateToZKSingleParams) { p.Prank = common.Address{} }, "proxy admin owner"},
+			{"zero opcm", func(p *migrateToZKSingleParams) { p.Opcm = common.Address{} }, "opcm"},
+			{"zero system config", func(p *migrateToZKSingleParams) { p.SystemConfig = common.Address{} }, "system config"},
+			{"nil bond", func(p *migrateToZKSingleParams) { p.InitBond = nil }, "initial bond"},
+			{"zero bond", func(p *migrateToZKSingleParams) { p.InitBond = big.NewInt(0) }, "initial bond"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				p := validZKSingleParams()
+				tc.mutate(&p)
+				_, err := buildMigrateToZKSingleInput(p)
+				require.ErrorContains(t, err, tc.errSub)
+			})
+		}
+	})
+}
+
+// TestMigrateToZKSingleInputEncodes exercises the real encode path the command runs
+// (buildMigrateToZKSingleInput -> embedded.UpgradeOPChainInput.EncodedUpgradeInputV2), which mirrors
+// the on-chain ABI shape and the ZK-config validation that OPContractsManagerUtils enforces. This is
+// the analog of set_interop_dispute_games_test.go's TestEncodeZKGameArgs, adapted to the
+// upgrade()-based path.
+func TestMigrateToZKSingleInputEncodes(t *testing.T) {
+	t.Run("valid input encodes", func(t *testing.T) {
+		in, err := buildMigrateToZKSingleInput(validZKSingleParams())
+		require.NoError(t, err)
+
+		encoded, err := in.EncodedUpgradeInputV2()
+		require.NoError(t, err)
+		require.NotEmpty(t, encoded)
+	})
+
+	// ZK-field validation is delegated to embedded.EncodedUpgradeInputV2 rather than duplicated in
+	// the builder, so these zero-value cases build fine but must fail at encode time.
+	t.Run("encode rejects invalid ZK config", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			mutate func(*migrateToZKSingleParams)
+			errSub string
+		}{
+			{"zero verifier", func(p *migrateToZKSingleParams) { p.Verifier = common.Address{} }, "Verifier"},
+			{"zero prestate", func(p *migrateToZKSingleParams) { p.AbsolutePrestate = common.Hash{} }, "AbsolutePrestate"},
+			{"zero max challenge duration", func(p *migrateToZKSingleParams) { p.MaxChallengeDuration = 0 }, "MaxChallengeDuration"},
+			{"zero max prove duration", func(p *migrateToZKSingleParams) { p.MaxProveDuration = 0 }, "MaxProveDuration"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				p := validZKSingleParams()
+				tc.mutate(&p)
+				in, err := buildMigrateToZKSingleInput(p)
+				require.NoError(t, err, "builder delegates ZK validation to the encoder")
+				_, err = in.EncodedUpgradeInputV2()
+				require.ErrorContains(t, err, tc.errSub)
+			})
+		}
+	})
+}
+
+// TestMigrateToZKSingle is a forked-Sepolia end-to-end test of the full
+// Go -> forge script -> OPCMv2.upgrade() path. It deploys an isolated chain with the ZK and
+// super-root-migration dev features enabled (so the OPCM ships a ZKDisputeGame impl and permits the
+// startingAnchorRoot override), then migrates it to the ZK dispute game. UpgradeOPChain is a void
+// script (no on-chain checkOutput), so a non-erroring run plus a single broadcast to the prank
+// address proves the upgrade executed.
+func TestMigrateToZKSingle(t *testing.T) {
+	lgr := testlog.Logger(t, slog.LevelDebug)
+
+	forkedL1, stopL1, err := devnet.NewForkedSepolia(lgr)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, stopL1())
+	})
+	l1RPC := forkedL1.RPCUrl()
+
+	loc, afactsFS := testutil.LocalArtifacts(t)
+	testCacheDir := testutils.IsolatedTestDirWithAutoCleanup(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	_, pk, dk := shared.DefaultPrivkey(t)
+
+	l1ChainID := big.NewInt(11155111) // Sepolia
+	l2ChainID := uint256.NewInt(12345)
+
+	intent, st := shared.NewIntent(t, l1ChainID, dk, l2ChainID, loc, loc, 30_000_000)
+
+	// Enable ZK (so DeployImplementations ships the ZKDisputeGame impl into the OPCM container) and
+	// SuperRootGamesMigration (so OPCMv2._isPermittedInstruction permits the startingAnchorRoot
+	// override). Interop is enabled to match the super-capable chain configuration.
+	devBitmap := devfeatures.EnableDevFeature(common.Hash{}, devfeatures.OptimismPortalInteropFlag)
+	devBitmap = devfeatures.EnableDevFeature(devBitmap, devfeatures.ZKDisputeGameFlag)
+	devBitmap = devfeatures.EnableDevFeature(devBitmap, devfeatures.SuperRootGamesMigrationFlag)
+	intent.GlobalDeployOverrides = map[string]any{
+		"devFeatureBitmap": devBitmap,
+	}
+	intent.UseInterop = true
+
+	err = deployer.ApplyPipeline(ctx, deployer.ApplyPipelineOpts{
+		DeploymentTarget:   deployer.DeploymentTargetLive,
+		L1RPCUrl:           l1RPC,
+		DeployerPrivateKey: pk,
+		Intent:             intent,
+		State:              st,
+		Logger:             lgr,
+		StateWriter:        pipeline.NoopStateWriter(),
+		CacheDir:           testCacheDir,
+	})
+	require.NoError(t, err, "Failed to deploy chain")
+
+	require.Len(t, st.Chains, 1, "Expected one chain to be deployed")
+	systemConfigProxy := st.Chains[0].SystemConfigProxy
+	l1ProxyAdminOwner := intent.Chains[0].Roles.L1ProxyAdminOwner
+
+	require.NotEqual(t, common.Address{}, st.ImplementationsDeployment.OpcmV2Impl, "OPCM V2 address should be set")
+	opcmAddr := st.ImplementationsDeployment.OpcmV2Impl
+
+	rpcClient, err := rpc.Dial(l1RPC)
+	require.NoError(t, err)
+
+	shared.DeployDummyCaller(t, rpcClient, afactsFS, l1ProxyAdminOwner, opcmAddr)
+
+	bcast := new(broadcaster.CalldataBroadcaster)
+	host, err := env.DefaultForkedScriptHost(ctx, bcast, lgr, l1ProxyAdminOwner, afactsFS, rpcClient)
+	require.NoError(t, err)
+
+	// Build the single-chain ZK migration input and run OPCMv2.upgrade().
+	input, err := buildMigrateToZKSingleInput(migrateToZKSingleParams{
+		Prank:                l1ProxyAdminOwner,
+		Opcm:                 opcmAddr,
+		SystemConfig:         systemConfigProxy,
+		AbsolutePrestate:     common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000abc"),
+		Verifier:             common.HexToAddress("0x000000000000000000000000000000000000bEEF"),
+		MaxChallengeDuration: 7 * 24 * 60 * 60,
+		MaxProveDuration:     3 * 24 * 60 * 60,
+		InitBond:             big.NewInt(1000000000000000000),
+		StartingAnchorRoot:   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000def"),
+		StartingAnchorL2Seq:  1,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, MigrateToZKSingle(host, input), "ZK single-chain migration failed")
+
+	dump, err := bcast.Dump()
+	require.NoError(t, err)
+	require.Len(t, dump, 1, "should have one transaction (the upgrade)")
+	require.Equal(t, l1ProxyAdminOwner, *dump[0].To, "upgrade tx should be sent to the prank address")
+}


### PR DESCRIPTION
Adds the `migrate-to-zk-single` (Paths A & B) command that migrates an **isolated chain** from its current super game (`SuperFaultDisputeGame`/`SuperPermissionedDisputeGame`) to the `ZKDisputeGame` via a standard `OPCMv2.upgrade()`. Builds the full dispute-game config (all types disabled, only `ZK_DISPUTE_GAME` enabled), flips the respected game type to ZK, and runs `UpgradeOPChain.s.sol` against a forked L1.

**Files:** `op-deployer/pkg/deployer/manage/migrate_to_zk_single.go` (+ test), `flags.go` (command registration).

### Deliberate design choices
- **Reused the FDG→SFDG-via-upgrade template** (`superroot_via_upgrade.go`) and the `embedded.*` upgrade types/encoder + `embedded.Upgrade` rather than introducing new input plumbing.
- **Always override `startingRespectedGameType → ZK`** — the previously-respected game is disabled, so without the override `_assertValidFullConfig` would reject the config.
- **Always override `startingAnchorRoot`** (required flags) to seed the ZK game from the operator-supplied honest anchor; depends on the `SUPER_ROOT_GAMES_MIGRATION` dev feature.
- **No new flags** — reused existing single-chain flags (`--system-config-proxy-address`, ZK/anchor/bond flags).
- **Delegated ZK-config validation** to `embedded.EncodedUpgradeInputV2` instead of duplicating the checks.
- **Tests:** network-free coverage of input building + the real encode path; plus a forked-Sepolia e2e mirroring `TestSetInteropDisputeGames`.

### Questions

- Should we disable all games and leave just zk or just disable a single game that we provide as input ? 
- Should we expllicitly set the new anchor root each time? 
- Any more assertions we could add to the go tests? 