### PR TITLE
[INTERNAL] feat: pcd predict l1

### DIFF
--- a/op-deployer/pkg/cli/app.go
+++ b/op-deployer/pkg/cli/app.go
@@ -36,6 +36,12 @@ func NewApp(versionWithMeta string) *cli.App {
 			Action: deployer.InitCLI(),
 		},
 		{
+			Name:   "prepare",
+			Usage:  "prepares a chain deployment by generating the genesis artifacts",
+			Flags:  cliapp.ProtectFlags(deployer.PrepareFlags),
+			Action: deployer.PrepareCLI(),
+		},
+		{
 			Name:   "apply",
 			Usage:  "applies a chain intent to the chain",
 			Flags:  cliapp.ProtectFlags(deployer.ApplyFlags),

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -22,7 +22,6 @@ const (
 	WorkdirFlagName          = flags.WorkdirFlagName
 	OutdirFlagName           = flags.OutdirFlagName
 	PrivateKeyFlagName       = flags.PrivateKeyFlagName
-	DeployerAddressFlagName  = flags.DeployerAddressFlagName
 	IntentTypeFlagName       = flags.IntentTypeFlagName
 	VerifierAPIKeyFlagName   = flags.VerifierAPIKeyFlagName
 	EtherscanAPIKeyFlagName  = flags.EtherscanAPIKeyFlagName // Deprecated: use VerifierAPIKeyFlagName
@@ -79,11 +78,6 @@ var (
 		Name:    PrivateKeyFlagName,
 		Usage:   "Private key of the deployer account.",
 		EnvVars: PrefixEnvVar("PRIVATE_KEY"),
-	}
-	DeployerAddressFlag = &cli.StringFlag{
-		Name:    DeployerAddressFlagName,
-		Usage:   "Address of the deployer account used to execute the deployment dry-run. This address does not need to be funded or signed for.",
-		EnvVars: PrefixEnvVar("SENDER_ADDRESS"),
 	}
 	DeploymentTargetFlag = &cli.StringFlag{
 		Name:    "deployment-target",
@@ -155,7 +149,7 @@ var InitFlags = []cli.Flag{
 
 var PrepareFlags = []cli.Flag{
 	WorkdirFlag,
-	DeployerAddressFlag,
+	PrivateKeyFlag,
 	L1RPCURLFlag,
 }
 

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -22,6 +22,7 @@ const (
 	WorkdirFlagName          = flags.WorkdirFlagName
 	OutdirFlagName           = flags.OutdirFlagName
 	PrivateKeyFlagName       = flags.PrivateKeyFlagName
+	DeployerAddressFlagName  = flags.DeployerAddressFlagName
 	IntentTypeFlagName       = flags.IntentTypeFlagName
 	VerifierAPIKeyFlagName   = flags.VerifierAPIKeyFlagName
 	EtherscanAPIKeyFlagName  = flags.EtherscanAPIKeyFlagName // Deprecated: use VerifierAPIKeyFlagName
@@ -78,6 +79,11 @@ var (
 		Name:    PrivateKeyFlagName,
 		Usage:   "Private key of the deployer account.",
 		EnvVars: PrefixEnvVar("PRIVATE_KEY"),
+	}
+	DeployerAddressFlag = &cli.StringFlag{
+		Name:    DeployerAddressFlagName,
+		Usage:   "Address of the deployer account used to execute the deployment dry-run. This address does not need to be funded or signed for.",
+		EnvVars: PrefixEnvVar("SENDER_ADDRESS"),
 	}
 	DeploymentTargetFlag = &cli.StringFlag{
 		Name:    "deployment-target",
@@ -145,6 +151,11 @@ var InitFlags = []cli.Flag{
 	L2ChainIDsFlag,
 	WorkdirFlag,
 	IntentTypeFlag,
+}
+
+var PrepareFlags = []cli.Flag{
+	WorkdirFlag,
+	DeployerAddressFlag,
 }
 
 var ApplyFlags = []cli.Flag{

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -156,6 +156,7 @@ var InitFlags = []cli.Flag{
 var PrepareFlags = []cli.Flag{
 	WorkdirFlag,
 	DeployerAddressFlag,
+	L1RPCURLFlag,
 }
 
 var ApplyFlags = []cli.Flag{

--- a/op-deployer/pkg/deployer/flags/names.go
+++ b/op-deployer/pkg/deployer/flags/names.go
@@ -16,7 +16,6 @@ const (
 	WorkdirFlagName          = "workdir"
 	OutdirFlagName           = "outdir"
 	PrivateKeyFlagName       = "private-key"
-	DeployerAddressFlagName  = "deployer-address"
 	IntentTypeFlagName       = "intent-type"
 	VerifierAPIKeyFlagName   = "verifier-api-key"
 	EtherscanAPIKeyFlagName  = "etherscan-api-key" // Deprecated: use VerifierAPIKeyFlagName

--- a/op-deployer/pkg/deployer/flags/names.go
+++ b/op-deployer/pkg/deployer/flags/names.go
@@ -16,6 +16,7 @@ const (
 	WorkdirFlagName          = "workdir"
 	OutdirFlagName           = "outdir"
 	PrivateKeyFlagName       = "private-key"
+	DeployerAddressFlagName  = "deployer-address"
 	IntentTypeFlagName       = "intent-type"
 	VerifierAPIKeyFlagName   = "verifier-api-key"
 	EtherscanAPIKeyFlagName  = "etherscan-api-key" // Deprecated: use VerifierAPIKeyFlagName

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -112,8 +112,10 @@ func DeployOPChain(env *Env, intent *state.Intent, st *state.State, chainID comm
 	return nil
 }
 
-func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common.Hash, st *state.State) (opcm.DeployOPChainInput, error) {
-	proofParams, err := jsonutil.MergeJSON(
+// ResolveChainProofParams merges the standard dispute-game defaults with the
+// intent's global and per-chain deploy overrides.
+func ResolveChainProofParams(intent *state.Intent, chain *state.ChainIntent) (state.ChainProofParams, error) {
+	return jsonutil.MergeJSON(
 		state.ChainProofParams{
 			DisputeGameType:         standard.DisputeGameType,
 			DisputeAbsolutePrestate: standard.DisputeAbsolutePrestate,
@@ -123,8 +125,12 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 			DisputeMaxClockDuration: standard.DisputeMaxClockDuration,
 		},
 		intent.GlobalDeployOverrides,
-		thisIntent.DeployOverrides,
+		chain.DeployOverrides,
 	)
+}
+
+func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common.Hash, st *state.State) (opcm.DeployOPChainInput, error) {
+	proofParams, err := ResolveChainProofParams(intent, thisIntent)
 	if err != nil {
 		return opcm.DeployOPChainInput{}, fmt.Errorf("error merging proof params from overrides: %w", err)
 	}

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -88,7 +88,7 @@ func DeployOPChain(env *Env, intent *state.Intent, st *state.State, chainID comm
 		}
 	}
 
-	st.Chains = append(st.Chains, makeChainState(chainID, impls, dco))
+	st.SetChainContracts(chainID, chainContractsForDeploy(impls, dco), true)
 
 	st.ImplementationsDeployment.DelayedWethImpl = impls.DelayedWETH
 	st.ImplementationsDeployment.OptimismPortalImpl = impls.OptimismPortal
@@ -161,8 +161,9 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 	}, nil
 }
 
-func makeChainState(chainID common.Hash, impls opcm.ReadImplementationAddressesOutput, dco opcm.DeployOPChainOutput) *state.ChainState {
-	opChainContracts := addresses.OpChainContracts{}
+// OpChainContractsFromDeployOutput maps a DeployOPChain output to OpChainContracts
+func OpChainContractsFromDeployOutput(dco opcm.DeployOPChainOutput) addresses.OpChainContracts {
+	var opChainContracts addresses.OpChainContracts
 	opChainContracts.OpChainProxyAdminImpl = dco.OpChainProxyAdmin
 	opChainContracts.AddressManagerImpl = dco.AddressManager
 	opChainContracts.L1Erc721BridgeProxy = dco.L1ERC721BridgeProxy
@@ -178,6 +179,13 @@ func makeChainState(chainID common.Hash, impls opcm.ReadImplementationAddressesO
 	opChainContracts.PermissionedDisputeGameImpl = dco.PermissionedDisputeGame
 	opChainContracts.DelayedWethPermissionedGameProxy = dco.DelayedWETHPermissionedGameProxy
 	opChainContracts.DelayedWethPermissionlessGameProxy = dco.DelayedWETHPermissionlessGameProxy
+	return opChainContracts
+}
+
+// chainContractsForDeploy builds the OpChainContracts for a deployed chain,
+// overriding the dispute game impls with the values read back from the proxies.
+func chainContractsForDeploy(impls opcm.ReadImplementationAddressesOutput, dco opcm.DeployOPChainOutput) addresses.OpChainContracts {
+	opChainContracts := OpChainContractsFromDeployOutput(dco)
 
 	if (impls.PermissionedDisputeGame != common.Address{}) {
 		opChainContracts.PermissionedDisputeGameImpl = impls.PermissionedDisputeGame
@@ -186,16 +194,14 @@ func makeChainState(chainID common.Hash, impls opcm.ReadImplementationAddressesO
 		opChainContracts.FaultDisputeGameImpl = impls.FaultDisputeGame
 	}
 
-	return &state.ChainState{
-		ID:               chainID,
-		OpChainContracts: opChainContracts,
-	}
+	return opChainContracts
 }
 
+// shouldDeployOPChain checks if the given chainID is already deployed in the state.
 func shouldDeployOPChain(st *state.State, chainID common.Hash) bool {
 	for _, chain := range st.Chains {
 		if chain.ID == chainID {
-			return false
+			return !chain.Deployed
 		}
 	}
 

--- a/op-deployer/pkg/deployer/pipeline/opchain_test.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain_test.go
@@ -118,6 +118,32 @@ func Test_makeDCI_OpcmAddress(t *testing.T) {
 	}
 }
 
+func TestShouldDeployOPChain(t *testing.T) {
+	chainID := common.HexToHash("0x0a")
+	other := common.HexToHash("0x0b")
+
+	t.Run("absent chain is deployed", func(t *testing.T) {
+		require.True(t, shouldDeployOPChain(&state.State{}, chainID))
+	})
+
+	t.Run("deployed chain is skipped", func(t *testing.T) {
+		st := &state.State{Chains: []*state.ChainState{{ID: chainID, Deployed: true}}}
+		require.False(t, shouldDeployOPChain(st, chainID))
+	})
+
+	t.Run("predicted-only chain is still deployed", func(t *testing.T) {
+		// prepare writes the chain with Deployed=false; apply/continue must still
+		// broadcast it.
+		st := &state.State{Chains: []*state.ChainState{{ID: chainID, Deployed: false}}}
+		require.True(t, shouldDeployOPChain(st, chainID))
+	})
+
+	t.Run("only matches the requested chain id", func(t *testing.T) {
+		st := &state.State{Chains: []*state.ChainState{{ID: other, Deployed: true}}}
+		require.True(t, shouldDeployOPChain(st, chainID))
+	})
+}
+
 func TestDeployOPChain_WithForge(t *testing.T) {
 	ctx := context.Background()
 	tmpDir := t.TempDir()

--- a/op-deployer/pkg/deployer/prepare.go
+++ b/op-deployer/pkg/deployer/prepare.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/common"
@@ -17,6 +18,9 @@ type PrepareConfig struct {
 	// DeployerAddress is the account used to predict deployment addresses. It
 	// does not need to be funded or signed for, since prepare does not broadcast.
 	DeployerAddress common.Address
+	// L1RPCUrl is the L1 endpoint that prepare forks to dry-run OPCM.deploy
+	// against the current L1 state.
+	L1RPCUrl string
 }
 
 func (c *PrepareConfig) Check() error {
@@ -30,6 +34,10 @@ func (c *PrepareConfig) Check() error {
 
 	if c.DeployerAddress == (common.Address{}) {
 		return fmt.Errorf("deployer address must be specified")
+	}
+
+	if c.L1RPCUrl == "" {
+		return fmt.Errorf("l1 RPC URL must be specified")
 	}
 
 	return nil
@@ -65,6 +73,7 @@ func newPrepareConfig(cliCtx *cli.Context, l log.Logger) (PrepareConfig, error) 
 		Workdir:         cliCtx.String(WorkdirFlagName),
 		Logger:          l,
 		DeployerAddress: common.HexToAddress(deployerAddressRaw),
+		L1RPCUrl:        cliCtx.String(L1RPCURLFlagName),
 	}, nil
 }
 
@@ -72,5 +81,27 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 	if err := cfg.Check(); err != nil {
 		return fmt.Errorf("invalid config for prepare: %w", err)
 	}
+
+	// prepare predicts the L1 addresses by dry-running OPCM.deploy against a fork
+	// of the live L1. The chain config (OPCM address, superchain config, chain ID,
+	// artifacts locator) comes from intent.toml, and the CREATE2 salt mixer from
+	// state.json. The salt MUST match the eventual broadcast (PCD aPCD-002), so it
+	// is read from the persisted state rather than regenerated here.
+	intent, err := pipeline.ReadIntent(cfg.Workdir)
+	if err != nil {
+		return fmt.Errorf("failed to read intent: %w", err)
+	}
+
+	st, err := pipeline.ReadState(cfg.Workdir)
+	if err != nil {
+		return fmt.Errorf("failed to read state: %w", err)
+	}
+
+	cfg.Logger.Info(
+		"loaded prepare inputs",
+		"chains", len(intent.Chains),
+		"create2Salt", st.Create2Salt,
+	)
+
 	return nil
 }

--- a/op-deployer/pkg/deployer/prepare.go
+++ b/op-deployer/pkg/deployer/prepare.go
@@ -1,0 +1,76 @@
+package deployer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli/v2"
+)
+
+type PrepareConfig struct {
+	Workdir string
+	Logger  log.Logger
+	// DeployerAddress is the account used to predict deployment addresses. It
+	// does not need to be funded or signed for, since prepare does not broadcast.
+	DeployerAddress common.Address
+}
+
+func (c *PrepareConfig) Check() error {
+	if c.Workdir == "" {
+		return fmt.Errorf("workdir must be specified")
+	}
+
+	if c.Logger == nil {
+		return fmt.Errorf("logger must be specified")
+	}
+
+	if c.DeployerAddress == (common.Address{}) {
+		return fmt.Errorf("deployer address must be specified")
+	}
+
+	return nil
+}
+
+func PrepareCLI() func(cliCtx *cli.Context) error {
+	return func(cliCtx *cli.Context) error {
+		logCfg := oplog.ReadCLIConfig(cliCtx)
+		l := oplog.NewLogger(oplog.AppOut(cliCtx), logCfg)
+		oplog.SetGlobalLogHandler(l.Handler())
+
+		cfg, err := newPrepareConfig(cliCtx, l)
+		if err != nil {
+			return err
+		}
+
+		ctx := ctxinterrupt.WithCancelOnInterrupt(cliCtx.Context)
+
+		return Prepare(ctx, cfg)
+	}
+}
+
+// newPrepareConfig builds a PrepareConfig from the CLI flags. It parses and
+// validates the deployer address here so a malformed value is rejected before
+// it silently decodes to the zero address.
+func newPrepareConfig(cliCtx *cli.Context, l log.Logger) (PrepareConfig, error) {
+	deployerAddressRaw := cliCtx.String(DeployerAddressFlagName)
+	if !common.IsHexAddress(deployerAddressRaw) {
+		return PrepareConfig{}, fmt.Errorf("invalid deployer address: %q", deployerAddressRaw)
+	}
+
+	return PrepareConfig{
+		Workdir:         cliCtx.String(WorkdirFlagName),
+		Logger:          l,
+		DeployerAddress: common.HexToAddress(deployerAddressRaw),
+	}, nil
+}
+
+func Prepare(ctx context.Context, cfg PrepareConfig) error {
+	if err := cfg.Check(); err != nil {
+		return fmt.Errorf("invalid config for prepare: %w", err)
+	}
+	return nil
+}

--- a/op-deployer/pkg/deployer/prepare.go
+++ b/op-deployer/pkg/deployer/prepare.go
@@ -195,6 +195,11 @@ func makePredictionInput(intent *state.Intent, st *state.State, chain *state.Cha
 		gasLimit = standard.GasLimit
 	}
 
+	proofParams, err := pipeline.ResolveChainProofParams(intent, chain)
+	if err != nil {
+		return opcm.DeployOPChainInput{}, fmt.Errorf("failed to resolve dispute params: %w", err)
+	}
+
 	return opcm.DeployOPChainInput{
 		OpChainProxyAdminOwner: placeholderRole,
 		SystemConfigOwner:      placeholderRole,
@@ -210,14 +215,17 @@ func makePredictionInput(intent *state.Intent, st *state.State, chain *state.Cha
 		SaltMixer:         st.Create2Salt.String(),
 		GasLimit:          gasLimit,
 
-		// Default dispute params
-		DisputeGameType:         standard.DisputeGameType,
-		DisputeAbsolutePrestate: standard.DisputeAbsolutePrestate,
-		DisputeMaxGameDepth:     new(big.Int).SetUint64(standard.DisputeMaxGameDepth),
-		DisputeSplitDepth:       new(big.Int).SetUint64(standard.DisputeSplitDepth),
-		DisputeClockExtension:   standard.DisputeClockExtension,
-		DisputeMaxClockDuration: standard.DisputeMaxClockDuration,
+		DisputeGameType:              proofParams.DisputeGameType,
+		DisputeAbsolutePrestate:      proofParams.DisputeAbsolutePrestate,
+		DisputeMaxGameDepth:          new(big.Int).SetUint64(proofParams.DisputeMaxGameDepth),
+		DisputeSplitDepth:            new(big.Int).SetUint64(proofParams.DisputeSplitDepth),
+		DisputeClockExtension:        proofParams.DisputeClockExtension,
+		DisputeMaxClockDuration:      proofParams.DisputeMaxClockDuration,
+		AllowCustomDisputeParameters: proofParams.DangerouslyAllowCustomDisputeParameters,
 
-		SuperchainConfig: *intent.SuperchainConfigProxy,
+		SuperchainConfig:    *intent.SuperchainConfigProxy,
+		OperatorFeeScalar:   chain.OperatorFeeScalar,
+		OperatorFeeConstant: chain.OperatorFeeConstant,
+		UseCustomGasToken:   chain.IsCustomGasTokenEnabled(),
 	}, nil
 }

--- a/op-deployer/pkg/deployer/prepare.go
+++ b/op-deployer/pkg/deployer/prepare.go
@@ -2,25 +2,44 @@ package deployer
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"fmt"
+	"math/big"
+	"strings"
 
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
+	"github.com/ethereum-optimism/optimism/op-service/ioutil"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/urfave/cli/v2"
 )
+
+// placeholderRole is a non-zero sentinel used for the role addresses in the
+// prediction dry-run.
+var placeholderRole = common.Address{0x01}
 
 type PrepareConfig struct {
 	Workdir string
 	Logger  log.Logger
-	// DeployerAddress is the account used to predict deployment addresses. It
-	// does not need to be funded or signed for, since prepare does not broadcast.
-	DeployerAddress common.Address
-	// L1RPCUrl is the L1 endpoint that prepare forks to dry-run OPCM.deploy
-	// against the current L1 state.
+	// PrivateKey of the deployer account. Its address is used as the dry-run
+	// sender, operator MUST use the same key for the eventual broadcast.
+	PrivateKey string
+	// L1RPCUrl is the L1 endpoint that prepare forks to dry-run OPCM.deploy.
 	L1RPCUrl string
+	// CacheDir is where downloaded artifacts are cached.
+	CacheDir string
+
+	privateKeyECDSA *ecdsa.PrivateKey
 }
 
 func (c *PrepareConfig) Check() error {
@@ -32,9 +51,14 @@ func (c *PrepareConfig) Check() error {
 		return fmt.Errorf("logger must be specified")
 	}
 
-	if c.DeployerAddress == (common.Address{}) {
-		return fmt.Errorf("deployer address must be specified")
+	if c.PrivateKey == "" {
+		return fmt.Errorf("private key must be specified")
 	}
+	privECDSA, err := crypto.HexToECDSA(strings.TrimPrefix(c.PrivateKey, "0x"))
+	if err != nil {
+		return fmt.Errorf("failed to parse private key: %w", err)
+	}
+	c.privateKeyECDSA = privECDSA
 
 	if c.L1RPCUrl == "" {
 		return fmt.Errorf("l1 RPC URL must be specified")
@@ -49,32 +73,22 @@ func PrepareCLI() func(cliCtx *cli.Context) error {
 		l := oplog.NewLogger(oplog.AppOut(cliCtx), logCfg)
 		oplog.SetGlobalLogHandler(l.Handler())
 
-		cfg, err := newPrepareConfig(cliCtx, l)
-		if err != nil {
-			return err
-		}
-
 		ctx := ctxinterrupt.WithCancelOnInterrupt(cliCtx.Context)
 
-		return Prepare(ctx, cfg)
+		return Prepare(ctx, newPrepareConfig(cliCtx, l))
 	}
 }
 
-// newPrepareConfig builds a PrepareConfig from the CLI flags. It parses and
-// validates the deployer address here so a malformed value is rejected before
-// it silently decodes to the zero address.
-func newPrepareConfig(cliCtx *cli.Context, l log.Logger) (PrepareConfig, error) {
-	deployerAddressRaw := cliCtx.String(DeployerAddressFlagName)
-	if !common.IsHexAddress(deployerAddressRaw) {
-		return PrepareConfig{}, fmt.Errorf("invalid deployer address: %q", deployerAddressRaw)
-	}
-
+// newPrepareConfig maps the CLI flags onto a PrepareConfig. The private key is
+// parsed and validated later in Check, mirroring apply.
+func newPrepareConfig(cliCtx *cli.Context, l log.Logger) PrepareConfig {
 	return PrepareConfig{
-		Workdir:         cliCtx.String(WorkdirFlagName),
-		Logger:          l,
-		DeployerAddress: common.HexToAddress(deployerAddressRaw),
-		L1RPCUrl:        cliCtx.String(L1RPCURLFlagName),
-	}, nil
+		Workdir:    cliCtx.String(WorkdirFlagName),
+		Logger:     l,
+		PrivateKey: cliCtx.String(PrivateKeyFlagName),
+		L1RPCUrl:   cliCtx.String(L1RPCURLFlagName),
+		CacheDir:   cliCtx.String(CacheDirFlagName),
+	}
 }
 
 func Prepare(ctx context.Context, cfg PrepareConfig) error {
@@ -83,10 +97,7 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 	}
 
 	// prepare predicts the L1 addresses by dry-running OPCM.deploy against a fork
-	// of the live L1. The chain config (OPCM address, superchain config, chain ID,
-	// artifacts locator) comes from intent.toml, and the CREATE2 salt mixer from
-	// state.json. The salt MUST match the eventual broadcast (PCD aPCD-002), so it
-	// is read from the persisted state rather than regenerated here.
+	// of the live L1.
 	intent, err := pipeline.ReadIntent(cfg.Workdir)
 	if err != nil {
 		return fmt.Errorf("failed to read intent: %w", err)
@@ -97,11 +108,110 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 		return fmt.Errorf("failed to read state: %w", err)
 	}
 
-	cfg.Logger.Info(
-		"loaded prepare inputs",
-		"chains", len(intent.Chains),
-		"create2Salt", st.Create2Salt,
+	if len(intent.Chains) == 0 {
+		return fmt.Errorf("intent has no chains to prepare")
+	}
+
+	// Download the L1 artifacts referenced by the intent so the dry-run uses the
+	// same DeployOPChain script as the eventual broadcast.
+	l1ArtifactsFS, err := artifacts.Download(ctx, intent.L1ContractsLocator, ioutil.BarProgressor(), cfg.CacheDir)
+	if err != nil {
+		return fmt.Errorf("failed to download L1 artifacts: %w", err)
+	}
+
+	// The sender of the deploy transaction.
+	deployer := crypto.PubkeyToAddress(cfg.privateKeyECDSA.PublicKey)
+
+	l1RPC, err := rpc.Dial(cfg.L1RPCUrl)
+	if err != nil {
+		return fmt.Errorf("failed to connect to L1 RPC: %w", err)
+	}
+	defer l1RPC.Close()
+
+	l1Host, err := env.DefaultForkedScriptHost(
+		ctx,
+		broadcaster.NoopBroadcaster(),
+		cfg.Logger,
+		deployer,
+		l1ArtifactsFS,
+		l1RPC,
 	)
+	if err != nil {
+		return fmt.Errorf("failed to create forked L1 script host: %w", err)
+	}
+
+	deployScript, err := opcm.NewDeployOPChainScript(l1Host)
+	if err != nil {
+		return fmt.Errorf("failed to load DeployOPChain script: %w", err)
+	}
+
+	for _, chain := range intent.Chains {
+		dci, err := makePredictionInput(intent, st, chain)
+		if err != nil {
+			return fmt.Errorf("failed to build prediction input for chain %s: %w", chain.ID.Hex(), err)
+		}
+
+		out, err := deployScript.Run(dci)
+		if err != nil {
+			return fmt.Errorf("failed to predict L1 addresses for chain %s: %w", chain.ID.Hex(), err)
+		}
+
+		// For now we just log the addresses
+		cfg.Logger.Info(
+			"predicted L1 addresses",
+			"chain", chain.ID.Hex(),
+			"systemConfigProxy", out.SystemConfigProxy,
+			"optimismPortalProxy", out.OptimismPortalProxy,
+			"l1StandardBridgeProxy", out.L1StandardBridgeProxy,
+			"l1CrossDomainMessengerProxy", out.L1CrossDomainMessengerProxy,
+			"disputeGameFactoryProxy", out.DisputeGameFactoryProxy,
+			"anchorStateRegistryProxy", out.AnchorStateRegistryProxy,
+		)
+	}
 
 	return nil
+}
+
+// makePredictionInput builds the DeployOPChain input for the prediction dry-run.
+// The OPCM, superchain config and salt mixer are taken from the committed intent
+// and state so the prediction matches the eventual broadcast. Role addresses are set to
+// placeholders since they are not relevant for the prediction.
+func makePredictionInput(intent *state.Intent, st *state.State, chain *state.ChainIntent) (opcm.DeployOPChainInput, error) {
+	if intent.OPCMAddress == nil {
+		return opcm.DeployOPChainInput{}, fmt.Errorf("intent.opcmAddress must be set to predict against an existing OPCM")
+	}
+	if intent.SuperchainConfigProxy == nil {
+		return opcm.DeployOPChainInput{}, fmt.Errorf("intent.superchainConfigProxy must be set")
+	}
+
+	gasLimit := chain.GasLimit
+	if gasLimit == 0 {
+		gasLimit = standard.GasLimit
+	}
+
+	return opcm.DeployOPChainInput{
+		OpChainProxyAdminOwner: placeholderRole,
+		SystemConfigOwner:      placeholderRole,
+		Batcher:                placeholderRole,
+		UnsafeBlockSigner:      placeholderRole,
+		Proposer:               placeholderRole,
+		Challenger:             placeholderRole,
+
+		BasefeeScalar:     standard.BasefeeScalar,
+		BlobBaseFeeScalar: standard.BlobBaseFeeScalar,
+		L2ChainId:         chain.ID.Big(),
+		Opcm:              *intent.OPCMAddress,
+		SaltMixer:         st.Create2Salt.String(),
+		GasLimit:          gasLimit,
+
+		// Default dispute params
+		DisputeGameType:         standard.DisputeGameType,
+		DisputeAbsolutePrestate: standard.DisputeAbsolutePrestate,
+		DisputeMaxGameDepth:     new(big.Int).SetUint64(standard.DisputeMaxGameDepth),
+		DisputeSplitDepth:       new(big.Int).SetUint64(standard.DisputeSplitDepth),
+		DisputeClockExtension:   standard.DisputeClockExtension,
+		DisputeMaxClockDuration: standard.DisputeMaxClockDuration,
+
+		SuperchainConfig: *intent.SuperchainConfigProxy,
+	}, nil
 }

--- a/op-deployer/pkg/deployer/prepare.go
+++ b/op-deployer/pkg/deployer/prepare.go
@@ -156,7 +156,9 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 			return fmt.Errorf("failed to predict L1 addresses for chain %s: %w", chain.ID.Hex(), err)
 		}
 
-		// For now we just log the addresses
+		// Record the predicted addresses into the chain state marked as not deployed yet.
+		st.SetChainContracts(chain.ID, pipeline.OpChainContractsFromDeployOutput(out), false)
+
 		cfg.Logger.Info(
 			"predicted L1 addresses",
 			"chain", chain.ID.Hex(),
@@ -167,6 +169,10 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 			"disputeGameFactoryProxy", out.DisputeGameFactoryProxy,
 			"anchorStateRegistryProxy", out.AnchorStateRegistryProxy,
 		)
+	}
+
+	if err := pipeline.WriteState(cfg.Workdir, st); err != nil {
+		return fmt.Errorf("failed to write state: %w", err)
 	}
 
 	return nil

--- a/op-deployer/pkg/deployer/prepare_test.go
+++ b/op-deployer/pkg/deployer/prepare_test.go
@@ -1,0 +1,52 @@
+package deployer
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+// newPrepareCtx builds a CLI context with the prepare flags applied and the
+// deployer address set to addr.
+func newPrepareCtx(t *testing.T, addr string) *cli.Context {
+	t.Helper()
+
+	app := cli.NewApp()
+	flagSet := flag.NewFlagSet("test-prepare", flag.ContinueOnError)
+	for _, f := range PrepareFlags {
+		require.NoError(t, f.Apply(flagSet))
+	}
+	require.NoError(t, flagSet.Set(DeployerAddressFlagName, addr))
+
+	return cli.NewContext(app, flagSet, nil)
+}
+
+func TestNewPrepareConfig_DeployerAddressPassed(t *testing.T) {
+	const addr = "0x1234567890123456789012345678901234567890"
+
+	cfg, err := newPrepareConfig(newPrepareCtx(t, addr), log.NewLogger(log.DiscardHandler()))
+	require.NoError(t, err)
+	require.Equal(t, common.HexToAddress(addr), cfg.DeployerAddress)
+}
+
+func TestNewPrepareConfig_InvalidDeployerAddress(t *testing.T) {
+	for _, addr := range []string{"", "not-an-address", "0x123"} {
+		_, err := newPrepareConfig(newPrepareCtx(t, addr), log.NewLogger(log.DiscardHandler()))
+		require.ErrorContains(t, err, "invalid deployer address")
+	}
+}
+
+func TestPrepareConfigCheck_RequiresDeployerAddress(t *testing.T) {
+	cfg := PrepareConfig{
+		Workdir: "/tmp",
+		Logger:  log.NewLogger(log.DiscardHandler()),
+	}
+	require.ErrorContains(t, cfg.Check(), "deployer address must be specified")
+
+	cfg.DeployerAddress = common.HexToAddress("0x1234567890123456789012345678901234567890")
+	require.NoError(t, cfg.Check())
+}

--- a/op-deployer/pkg/deployer/prepare_test.go
+++ b/op-deployer/pkg/deployer/prepare_test.go
@@ -4,17 +4,22 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 )
 
-const testL1RPCUrl = "http://localhost:8545"
+const (
+	testL1RPCUrl = "http://localhost:8545"
+	testPrivKey  = "0000000000000000000000000000000000000000000000000000000000000001"
+)
 
 // newPrepareCtx builds a CLI context with the prepare flags applied and the
-// deployer address set to addr.
-func newPrepareCtx(t *testing.T, addr string) *cli.Context {
+// given private key + a test L1 RPC URL set.
+func newPrepareCtx(t *testing.T, privKey string) *cli.Context {
 	t.Helper()
 
 	app := cli.NewApp()
@@ -22,40 +27,82 @@ func newPrepareCtx(t *testing.T, addr string) *cli.Context {
 	for _, f := range PrepareFlags {
 		require.NoError(t, f.Apply(flagSet))
 	}
-	require.NoError(t, flagSet.Set(DeployerAddressFlagName, addr))
+	require.NoError(t, flagSet.Set(PrivateKeyFlagName, privKey))
 	require.NoError(t, flagSet.Set(L1RPCURLFlagName, testL1RPCUrl))
 
 	return cli.NewContext(app, flagSet, nil)
 }
 
 func TestNewPrepareConfig_FlagsPassed(t *testing.T) {
-	const addr = "0x1234567890123456789012345678901234567890"
-
-	cfg, err := newPrepareConfig(newPrepareCtx(t, addr), log.NewLogger(log.DiscardHandler()))
-	require.NoError(t, err)
-	require.Equal(t, common.HexToAddress(addr), cfg.DeployerAddress)
+	cfg := newPrepareConfig(newPrepareCtx(t, testPrivKey), log.NewLogger(log.DiscardHandler()))
+	require.Equal(t, testPrivKey, cfg.PrivateKey)
 	require.Equal(t, testL1RPCUrl, cfg.L1RPCUrl)
 }
 
-func TestNewPrepareConfig_InvalidDeployerAddress(t *testing.T) {
-	for _, addr := range []string{"", "not-an-address", "0x123"} {
-		_, err := newPrepareConfig(newPrepareCtx(t, addr), log.NewLogger(log.DiscardHandler()))
-		require.ErrorContains(t, err, "invalid deployer address")
+func TestMakePredictionInput(t *testing.T) {
+	opcmAddr := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+	superchainConfig := common.HexToAddress("0xbbbb000000000000000000000000000000000002")
+	salt := common.HexToHash("0xcccc000000000000000000000000000000000000000000000000000000000003")
+	chainID := common.HexToHash("0x000000000000000000000000000000000000000000000000000000000000000a")
+
+	intent := &state.Intent{
+		OPCMAddress:           &opcmAddr,
+		SuperchainConfigProxy: &superchainConfig,
 	}
+	st := &state.State{Create2Salt: salt}
+	chain := &state.ChainIntent{ID: chainID} // GasLimit unset -> defaulted
+
+	dci, err := makePredictionInput(intent, st, chain)
+	require.NoError(t, err)
+
+	// Committed values are passed through verbatim so the prediction matches the
+	// eventual broadcast.
+	require.Equal(t, opcmAddr, dci.Opcm)
+	require.Equal(t, superchainConfig, dci.SuperchainConfig)
+	require.Equal(t, salt.String(), dci.SaltMixer)
+	require.Equal(t, chainID.Big(), dci.L2ChainId)
+	require.Equal(t, standard.GasLimit, dci.GasLimit)
+
+	// Roles are non-zero placeholders (they don't affect the predicted addresses,
+	// but DeployOPChain.checkInput requires them set).
+	for _, role := range []common.Address{
+		dci.OpChainProxyAdminOwner, dci.SystemConfigOwner, dci.Batcher,
+		dci.UnsafeBlockSigner, dci.Proposer, dci.Challenger,
+	} {
+		require.Equal(t, placeholderRole, role)
+		require.NotEqual(t, common.Address{}, role)
+	}
+}
+
+func TestMakePredictionInput_MissingRequiredAddresses(t *testing.T) {
+	opcmAddr := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+	superchainConfig := common.HexToAddress("0xbbbb000000000000000000000000000000000002")
+	st := &state.State{Create2Salt: common.HexToHash("0x03")}
+	chain := &state.ChainIntent{ID: common.HexToHash("0x0a")}
+
+	_, err := makePredictionInput(&state.Intent{SuperchainConfigProxy: &superchainConfig}, st, chain)
+	require.ErrorContains(t, err, "opcmAddress must be set")
+
+	_, err = makePredictionInput(&state.Intent{OPCMAddress: &opcmAddr}, st, chain)
+	require.ErrorContains(t, err, "superchainConfigProxy must be set")
 }
 
 func TestPrepareConfigCheck(t *testing.T) {
 	valid := PrepareConfig{
-		Workdir:         "/tmp",
-		Logger:          log.NewLogger(log.DiscardHandler()),
-		DeployerAddress: common.HexToAddress("0x1234567890123456789012345678901234567890"),
-		L1RPCUrl:        testL1RPCUrl,
+		Workdir:    "/tmp",
+		Logger:     log.NewLogger(log.DiscardHandler()),
+		PrivateKey: testPrivKey,
+		L1RPCUrl:   testL1RPCUrl,
 	}
 	require.NoError(t, valid.Check())
 
-	missingDeployer := valid
-	missingDeployer.DeployerAddress = common.Address{}
-	require.ErrorContains(t, missingDeployer.Check(), "deployer address must be specified")
+	missingKey := valid
+	missingKey.PrivateKey = ""
+	require.ErrorContains(t, missingKey.Check(), "private key must be specified")
+
+	invalidKey := valid
+	invalidKey.PrivateKey = "not-a-valid-key"
+	require.ErrorContains(t, invalidKey.Check(), "failed to parse private key")
 
 	missingL1RPC := valid
 	missingL1RPC.L1RPCUrl = ""

--- a/op-deployer/pkg/deployer/prepare_test.go
+++ b/op-deployer/pkg/deployer/prepare_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const testL1RPCUrl = "http://localhost:8545"
+
 // newPrepareCtx builds a CLI context with the prepare flags applied and the
 // deployer address set to addr.
 func newPrepareCtx(t *testing.T, addr string) *cli.Context {
@@ -21,16 +23,18 @@ func newPrepareCtx(t *testing.T, addr string) *cli.Context {
 		require.NoError(t, f.Apply(flagSet))
 	}
 	require.NoError(t, flagSet.Set(DeployerAddressFlagName, addr))
+	require.NoError(t, flagSet.Set(L1RPCURLFlagName, testL1RPCUrl))
 
 	return cli.NewContext(app, flagSet, nil)
 }
 
-func TestNewPrepareConfig_DeployerAddressPassed(t *testing.T) {
+func TestNewPrepareConfig_FlagsPassed(t *testing.T) {
 	const addr = "0x1234567890123456789012345678901234567890"
 
 	cfg, err := newPrepareConfig(newPrepareCtx(t, addr), log.NewLogger(log.DiscardHandler()))
 	require.NoError(t, err)
 	require.Equal(t, common.HexToAddress(addr), cfg.DeployerAddress)
+	require.Equal(t, testL1RPCUrl, cfg.L1RPCUrl)
 }
 
 func TestNewPrepareConfig_InvalidDeployerAddress(t *testing.T) {
@@ -40,13 +44,20 @@ func TestNewPrepareConfig_InvalidDeployerAddress(t *testing.T) {
 	}
 }
 
-func TestPrepareConfigCheck_RequiresDeployerAddress(t *testing.T) {
-	cfg := PrepareConfig{
-		Workdir: "/tmp",
-		Logger:  log.NewLogger(log.DiscardHandler()),
+func TestPrepareConfigCheck(t *testing.T) {
+	valid := PrepareConfig{
+		Workdir:         "/tmp",
+		Logger:          log.NewLogger(log.DiscardHandler()),
+		DeployerAddress: common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		L1RPCUrl:        testL1RPCUrl,
 	}
-	require.ErrorContains(t, cfg.Check(), "deployer address must be specified")
+	require.NoError(t, valid.Check())
 
-	cfg.DeployerAddress = common.HexToAddress("0x1234567890123456789012345678901234567890")
-	require.NoError(t, cfg.Check())
+	missingDeployer := valid
+	missingDeployer.DeployerAddress = common.Address{}
+	require.ErrorContains(t, missingDeployer.Check(), "deployer address must be specified")
+
+	missingL1RPC := valid
+	missingL1RPC.L1RPCUrl = ""
+	require.ErrorContains(t, missingL1RPC.Check(), "l1 RPC URL must be specified")
 }

--- a/op-deployer/pkg/deployer/state/state.go
+++ b/op-deployer/pkg/deployer/state/state.go
@@ -94,11 +94,34 @@ type ChainState struct {
 
 	addresses.OpChainContracts
 
+	// Deployed indicates whether the addresses in this chain have been deployed or are just addresses produced
+	// by the prediction step of the prepare command.
+	Deployed bool `json:"deployed"`
+
 	AdditionalDisputeGames []AdditionalDisputeGameState `json:"additionalDisputeGames"`
 
 	Allocs *GzipData[foundry.ForgeAllocs] `json:"allocs"`
 
 	StartBlock *L1BlockRefJSON `json:"startBlock"`
+}
+
+// SetChainContracts records the L1 contract addresses for a chain. It creates
+// the chain entry if it does not exist and otherwise updates it in place,
+// preserving any other fields already set by other stages. deployed indicates whether the addresses
+// have been already broadcast or are just predicted addresses from the prepare stage.
+func (s *State) SetChainContracts(id common.Hash, contracts addresses.OpChainContracts, deployed bool) {
+	for _, chain := range s.Chains {
+		if chain.ID == id {
+			chain.OpChainContracts = contracts
+			chain.Deployed = deployed
+			return
+		}
+	}
+	s.Chains = append(s.Chains, &ChainState{
+		ID:               id,
+		OpChainContracts: contracts,
+		Deployed:         deployed,
+	})
 }
 
 type L1BlockRefJSON struct {

--- a/op-deployer/pkg/deployer/state/state_test.go
+++ b/op-deployer/pkg/deployer/state/state_test.go
@@ -4,9 +4,47 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
+
+func TestState_SetChainContracts(t *testing.T) {
+	chainA := common.HexToHash("0x0a")
+	chainB := common.HexToHash("0x0b")
+
+	contractsWith := func(systemConfig string) addresses.OpChainContracts {
+		var c addresses.OpChainContracts
+		c.SystemConfigProxy = common.HexToAddress(systemConfig)
+		return c
+	}
+
+	s := &State{}
+
+	// A new chain is appended, we mark a  predicted entry as not-deployed.
+	s.SetChainContracts(chainA, contractsWith("0xa1"), false)
+	require.Len(t, s.Chains, 1)
+	require.Equal(t, chainA, s.Chains[0].ID)
+	require.Equal(t, common.HexToAddress("0xa1"), s.Chains[0].SystemConfigProxy)
+	require.False(t, s.Chains[0].Deployed)
+
+	// A different chain is also appended.
+	s.SetChainContracts(chainB, contractsWith("0xb1"), false)
+	require.Len(t, s.Chains, 2)
+
+	// Updating an existing chain in the state replaces it in place, preserves other
+	// fields set by other stages, and can flip the deployed flag.
+	s.Chains[0].StartBlock = &L1BlockRefJSON{Hash: common.HexToHash("0xdead")}
+	s.SetChainContracts(chainA, contractsWith("0xa2"), true)
+	require.Len(t, s.Chains, 2)
+
+	got, err := s.Chain(chainA)
+	require.NoError(t, err)
+	require.Equal(t, common.HexToAddress("0xa2"), got.SystemConfigProxy)
+	require.True(t, got.Deployed)
+	require.NotNil(t, got.StartBlock, "other fields must be preserved on update")
+	require.Equal(t, common.HexToHash("0xdead"), got.StartBlock.Hash)
+}
 
 func TestBlockRef_Deserialize(t *testing.T) {
 	tests := []struct {

--- a/op-deployer/pkg/deployer/verify/state_bundle.go
+++ b/op-deployer/pkg/deployer/verify/state_bundle.go
@@ -38,6 +38,10 @@ func getContractBundleFromState(filepath string) (map[string]common.Address, err
 	}
 
 	for _, chain := range st.Chains {
+		// Skip chains whose addresses are only predicted and not yet broadcast.
+		if !chain.Deployed {
+			continue
+		}
 		chainPrefix := fmt.Sprintf("opchain_%s", chain.ID.Hex())
 		addContractsFromStruct(chainPrefix, &chain.OpChainContracts, bundle)
 	}


### PR DESCRIPTION
## Summary

Adds the `prepare` command to op-deployer. `prepare` predicts a chain's L1 contract addresses without broadcasting anything. 

## What it does

For each chain in the intent, `prepare`:

1. Reads `intent.toml` and `state.json` from the workdir.
2. Forks the live L1 (`--l1-rpc-url`) and dry-runs `OPCM.deploy()` through the `DeployOPChain` script, using a `NoopBroadcaster` so nothing is written to L1.
3. Records the predicted addresses into `state.json`.

The dry-run runs as the address derived from `--private-key`. Predicted addresses are deterministic in the sender and salt mixer, so the prediction matches the real deployment.

## State changes

`ChainState` gains a `Deployed` bool to distinguish predicted addresses (`prepare`) from broadcast addresses (`apply`/`continue`). `shouldDeployOPChain` and contract verification now skip predicted-only chains, so running `apply` over a prepared state deploys the chain rather than treating the prediction as finished.

## Test Plan
- Test the --private-key and --l1-rpc-url flags are parsed into the config.
- Test config validation rejects a missing private key, a malformed private key, and a missing L1 RPC URL.
- Test the prediction input holds the correct values derived from the state.
- Test `prepare` fails when the intent is missing the OPCM address or superchain config proxy.
- Test predicted addresses are updated in the state with the flag `Deployed=false`.